### PR TITLE
[64] feat: add alwaysAbstain and noConfidence voting powers to the ne…

### DIFF
--- a/src/vva-be/src/VVA/API/Types.hs
+++ b/src/vva-be/src/VVA/API/Types.hs
@@ -536,6 +536,8 @@ data GetNetworkMetricsResponse = GetNetworkMetricsResponse
   , getNetworkMetricsResponseTotalGovernanceActions :: Integer
   , getNetworkMetricsResponseTotalDRepVotes :: Integer
   , getNetworkMetricsResponseTotalRegisteredDReps :: Integer
+  , getNetworkMetricsResponseAlwaysAbstainVotingPower :: Integer
+  , getNetworkMetricsResponseAlwaysNoConfidenceVotingPower :: Integer
   }
 
 deriveJSON (jsonOptions "getNetworkMetricsResponse") ''GetNetworkMetricsResponse
@@ -549,7 +551,9 @@ exampleGetNetworkMetricsResponse =
  <> "\"totalDelegations\": 0,"
  <> "\"totalGovernanceActions\": 0,"
  <> "\"totalDRepVotes\": 0,"
- <> "\"totalRegisteredDReps\": 0}"
+ <> "\"totalRegisteredDReps\": 0,"
+ <> "\"alwaysAbstainVotingPower\": 0,"
+ <> "\"alwaysNoConfidenceVotingPower\": 0}"
 
 instance ToSchema GetNetworkMetricsResponse where
     declareNamedSchema _ = pure $ NamedSchema (Just "GetNetworkMetricsResponse") $ mempty

--- a/src/vva-be/src/VVA/Network.hs
+++ b/src/vva-be/src/VVA/Network.hs
@@ -37,16 +37,20 @@ networkMetrics = withPool $ \conn -> do
      , block_no
      , unique_delegators
      , total_delegations
-     , total_governance_actions
+     , total_gov_action_proposals
      , total_drep_votes
      , total_registered_dreps
+     , always_abstain_voting_power
+     , always_no_confidence_voting_power
      )] -> return $ NetworkMetrics
             current_time
             epoch_no
             block_no
             unique_delegators
             total_delegations
-            total_governance_actions
+            total_gov_action_proposals
             total_drep_votes
             total_registered_dreps
+            always_abstain_voting_power
+            always_no_confidence_voting_power
     _ -> throwError $ CriticalError "Could not query the network metrics. This should never happen."

--- a/src/vva-be/src/VVA/Types.hs
+++ b/src/vva-be/src/VVA/Types.hs
@@ -114,5 +114,7 @@ data NetworkMetrics = NetworkMetrics
   , networkMetricsTotalGovernanceActions :: Integer
   , networkMetricsTotalDRepVotes :: Integer
   , networkMetricsTotalRegisteredDReps :: Integer
+  , networkMetricsAlwaysAbstainVotingPower :: Integer
+  , networkMetricsAlwaysNoConfidenceVotingPower :: Integer
   }
 


### PR DESCRIPTION
…twork/metrics endpoint

Before there was no easy way to check current voting power of alwaysAbstain and noConfidence dreps. Now they are available in the network/metrics endpoint

## List of changes

- network/metrics endpoint returns 2 additional values - `alwaysAbstainVotingPower` and `alwaysNoConfidenceVotingPower`

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots of change (for FE)
