### PR TITLE
Tool to recreate Cardano node/db/db-sync

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,6 +23,10 @@ on:
         required: true
         type: boolean
         default: false
+      resync_cardano_node_and_db:
+        required: true
+        type: boolean
+        default: false
 
 env:
   ENVIRONMENT: ${{ inputs.environment || 'dev' }}
@@ -144,6 +148,12 @@ jobs:
           if [[ "${{ inputs.environment }}" == "staging" ]]; then export DOMAIN=staging.govtool.byron.network; fi;
           if [[ "${{ inputs.environment }}" == "beta" ]]; then export DOMAIN=sanchogov.tools; fi;
           make upload-config
+      - name: Destroy Cardano Node, DB sync and Postgres if required
+        if: ${{ inputs.resync_cardano_node_and_db }}
+        run: |
+          if [[ "${{ inputs.environment }}" == "staging" ]]; then export DOMAIN=staging.govtool.byron.network; fi;
+          if [[ "${{ inputs.environment }}" == "beta" ]]; then export DOMAIN=sanchogov.tools; fi;
+          make destroy-cardano-node-and-dbsync;
       - name: Deploy app
         run: |
           make docker-login
@@ -210,6 +220,12 @@ jobs:
           if [[ "${{ inputs.environment }}" == "staging" ]]; then export DOMAIN=staging.govtool.byron.network; fi;
           if [[ "${{ inputs.environment }}" == "beta" ]]; then export DOMAIN=sanchogov.tools; fi;
           make upload-config
+      - name: Destroy Cardano Node, DB sync and Postgres if required
+        if: ${{ inputs.resync_cardano_node_and_db }}
+        run: |
+          if [[ "${{ inputs.environment }}" == "staging" ]]; then export DOMAIN=staging.govtool.byron.network; fi;
+          if [[ "${{ inputs.environment }}" == "beta" ]]; then export DOMAIN=sanchogov.tools; fi;
+          make destroy-cardano-node-and-dbsync;
       - name: Deploy app
         run: |
           make docker-login

--- a/src/Makefile
+++ b/src/Makefile
@@ -106,6 +106,21 @@ deploy-stack:
 	docker compose -f docker-compose.$(cardano_network).yml -p vva-$(env)-$(cardano_network) pull; \
 	docker compose -f docker-compose.$(cardano_network).yml -p vva-$(env)-$(cardano_network) up -d
 
+.PHONY: destroy-cardano-node-and-dbsync
+destroy-cardano-node-and-dbsync:
+	@:$(call check_defined, cardano_network)
+	@:$(call check_defined, env)
+	export CARDANO_NETWORK=$(cardano_network); \
+	export DOCKER_HOST=ssh://$(ssh_url); \
+	export ENVIRONMENT=$(env); \
+	export TAG=$(tag); \
+	ssh-keyscan $(docker_host) 2>/dev/null >> ~/.ssh/known_hosts; \
+	containers="$$(docker container ls --no-trunc --format '{{.Names}}' -f name=cardano-node -f name=cardano-db-sync -f name=postgres)"; \
+	volumes="$$(docker volume ls --format '{{.Name}}' -f name=db-sync-data -f name=node-db -f name=node-ipc -f name=postgres)"; \
+	docker container stop $${containers}; \
+	docker container rm $${containers}; \
+	docker volume rm $${volumes}
+
 .PHONY: toggle-maintenance
 toggle-maintenance:
 	@:$(call check_defined, cardano_network)


### PR DESCRIPTION
add optional CI step to destroy cardano node and db sync data before deploy to force resync

## List of changes

Added a new parameter to a "Build and deploy" CI/CD workflow, which will make it possible to destroy Cardano node and DB sync data during deployment in order to force full resync.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots of change (for FE)
