### PR TITLE
#27 add basic auth for dev/test environments

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -144,6 +144,9 @@ jobs:
           ssh-private-key: ${{ secrets.GHA_SSH_PRIVATE_KEY }}
       - name: Prepare and upload app config
         run: |
+          if [[ "${{ inputs.environment }}" == "staging" ]]; then export DOMAIN=staging.govtool.byron.network; fi;
+          if [[ "${{ inputs.environment }}" == "beta" ]]; then export DOMAIN=sanchogov.tools; fi;
+          DOMAIN=${DOMAIN:-$ENVIRONMENT-$CARDANO_NETWORK.govtool.byron.network}
           make prepare-config
           if [[ "${{ inputs.environment }}" == "staging" ]]; then export DOMAIN=staging.govtool.byron.network; fi;
           if [[ "${{ inputs.environment }}" == "beta" ]]; then export DOMAIN=sanchogov.tools; fi;

--- a/src/docker-compose.sanchonet.yml
+++ b/src/docker-compose.sanchonet.yml
@@ -192,6 +192,9 @@ services:
 
   vva-fe:
     image: ${VVA_FE_REPO:-733019650473.dkr.ecr.eu-west-1.amazonaws.com/frontend}:${TAG:-main-dev-sanchonet}
+    volumes:
+      - /home/ubuntu/config/nginx/auth.conf:/etc/nginx/conf.d/auth.conf
+      - /home/ubuntu/config/nginx/govtool.htpasswd:/etc/nginx/conf.d/govtool.htpasswd
     depends_on:
       cardano-node:
         condition: service_healthy

--- a/src/scripts/prepare-config.sh
+++ b/src/scripts/prepare-config.sh
@@ -75,3 +75,20 @@ cp -a "$repo_root_dir/src/config/grafana-provisioning/"* "$grafana_provisioning_
 sed -e "s/GRAFANA_SLACK_RECIPIENT/$GRAFANA_SLACK_RECIPIENT/" \
     -e "s|GRAFANA_SLACK_OAUTH_TOKEN|$GRAFANA_SLACK_OAUTH_TOKEN|" \
     -i "$grafana_provisioning_dir/alerting/alerting.yml"
+
+# nginx config for frontend optional basic auth
+nginx_config_dir="$target_config_dir/nginx"
+mkdir -p "$nginx_config_dir"
+if [[ "$DOMAIN" == *"govtool.byron.network"* ]]; then
+  cat >"$nginx_config_dir/auth.conf" <<_EOF_
+auth_basic "Restricted";
+auth_basic_user_file /etc/nginx/conf.d/govtool.htpasswd;
+_EOF_
+  cat >"$nginx_config_dir/govtool.htpasswd" <<_EOF_
+$NGINX_BASIC_AUTH
+_EOF_
+else
+  # create empty files if no basic auth is needed
+  touch "$nginx_config_dir/auth.conf"
+  touch "$nginx_config_dir/govtool.htpasswd"
+fi


### PR DESCRIPTION
## List of changes

This adds a basic auth prompt on dev and test environments.

The authorization user/password hash is stored in GH Actions secret called `$NGINX_BASIC_AUTH`.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots of change (for FE)
