### PR TITLE
[59] Fixed vote counting problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
+## [Unreleased]
+
+### Fixed
+- Fixed vote calculation problems related to NoConfidence DRep [Issue 59](https://github.com/IntersectMBO/govtool/issues/59)
+
 ## [sancho-v1.0.1](https://github.com/IntersectMBO/govtool/releases/tag/sancho-v1.0.1) 2023-12-XX
 
 ### Added
-- 
+-
 
 ### Fixed
-- 
+-
 
 ### Changed
 - Changed Node version from 8.7.1-pre to 8.7.2 and Db-sync version from sancho-2-3-0 to sancho-3-0-0.
 - (`docs/update-working-conventions`) Addressing [Issue 25](https://github.com/IntersectMBO/govtool/issues/25) changed working conventions documentation to improve intended flows.
 
 ### Removed
-- 
+-
 
 ## [sancho-v1.0.0](https://github.com/IntersectMBO/govtool/releases/tag/sancho-v1.0.0) 2023-12-17
 

--- a/src/vva-be/sql/list-proposals.sql
+++ b/src/vva-be/sql/list-proposals.sql
@@ -9,6 +9,22 @@ WITH LatestDrepDistr AS (
         Max(no) as last_epoch_no,
         Max(end_time) as last_epoch_end_time
     FROM epoch
+), always_no_confidence_voting_power as (
+    select amount
+    from drep_distr
+    join drep_hash
+    on drep_hash.id = drep_distr.hash_id
+    where drep_hash.view = 'drep_always_no_confidence'
+    order by epoch_no desc
+    limit 1
+), always_abstain_voting_power as (
+    select amount
+    from drep_distr
+    join drep_hash
+    on drep_hash.id = drep_distr.hash_id
+    where drep_hash.view = 'drep_always_abstain'
+    order by epoch_no desc
+    limit 1
 )
 
 select
@@ -21,11 +37,22 @@ select
     creator_block.time, /* created date */
     voting_anchor.url,
     encode(voting_anchor.data_hash, 'hex'),
-    coalesce(Sum(ldd.amount) filter (where voting_procedure.vote::text = 'Yes'),0) "yes_votes",
-    coalesce((select no_confidence_drep_distr.amount from drep_distr as no_confidence_drep_distr join drep_hash on no_confidence_drep_distr.hash_id = drep_hash.id where drep_hash.view='drep_always_no_confidence' order by no_confidence_drep_distr.epoch_no desc limit 1) + Sum(ldd.amount) filter (where voting_procedure.vote::text = 'No'), 0) "no_votes",
-    coalesce((select abstain_drep_distr.amount from drep_distr as abstain_drep_distr join drep_hash on abstain_drep_distr.hash_id = drep_hash.id where drep_hash.view='drep_always_abstain' order by abstain_drep_distr.epoch_no desc limit 1), 0) "abstain_votes"
+
+    coalesce(Sum(ldd.amount) filter (where voting_procedure.vote::text = 'Yes'),0)
+        + (case
+                when gov_action_proposal.type = 'NoConfidence' then always_no_confidence_voting_power.amount
+                else 0
+            end) "yes_votes",
+    coalesce(Sum(ldd.amount) filter (where voting_procedure.vote::text = 'No'),0) +
+        (case
+                when gov_action_proposal.type = 'NoConfidence' then 0
+                else always_no_confidence_voting_power.amount
+            end) "no_votes",
+    coalesce(Sum(ldd.amount) filter (where voting_procedure.vote::text = 'Abstain'),0) + always_abstain_voting_power.amount "abstain_votes"
 from gov_action_proposal
 cross join EpochUtils as epoch_utils
+cross join always_no_confidence_voting_power
+cross join always_abstain_voting_power
 join tx as creator_tx
 on creator_tx.id = gov_action_proposal.tx_id
 join block as creator_block
@@ -44,4 +71,16 @@ and gov_action_proposal.enacted_epoch is null
 and gov_action_proposal.expired_epoch is null
 and gov_action_proposal.dropped_epoch is null
 
-group by (gov_action_proposal.id, gov_action_proposal.index, creator_tx.hash, creator_block.time, epoch_utils.epoch_duration, epoch_utils.last_epoch_no, epoch_utils.last_epoch_end_time, voting_anchor.url, voting_anchor.data_hash)
+group by (
+    gov_action_proposal.id,
+    gov_action_proposal.index,
+    creator_tx.hash,
+    creator_block.time,
+    epoch_utils.epoch_duration,
+    epoch_utils.last_epoch_no,
+    epoch_utils.last_epoch_end_time,
+    voting_anchor.url,
+    voting_anchor.data_hash,
+    always_no_confidence_voting_power.amount,
+    always_abstain_voting_power.amount
+    )


### PR DESCRIPTION
Votes were counted in a wrong way, especially when it came to NoConfidence GAs and AlwaysNoConfidence DRep. The SQL query was modified and the problem is fixed

## List of changes

- Fixed 
Fixed vote calculation problems regarding NoConfidence GAs and DRep

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/59)
- [] My changes generate no new warnings
- [] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [] I have added tests that prove my fix is effective or that my feature works
