### PR TITLE
[#171] Remove Nginx config post-deployment to prevent configuration reuse across environments

### DIFF
--- a/docs/operations/DEPLOY.md
+++ b/docs/operations/DEPLOY.md
@@ -52,3 +52,19 @@ Alternatively you can type `make all instance=$INSTANCE cardano_network=$CARDANO
 
 View the app at `https://${ENVIRONMENT}-${INSTANCE}.govtool.byron.network`.
 Keep in mind that after initial deployment on a new environment, it will take some time for the Cardano node to get in sync.
+
+## Aftermatch
+
+After performing a deploy from a local machine, it is crucial to carefully track
+the application's accessibility and functionality to ensure no unintended
+changes, such as the accidental activation of BasicAuth[^1], have occurred.
+
+Additionally, verifying that all configuration files and environment variables,
+particularly those related to environment-specific settings like database
+connections or external service endpoints, are correctly generated and applied
+is essential for maintaining the intended behavior of the application across
+different environments. This includes a thorough check of environment variables
+to confirm they are correctly set and aligned with the specific needs of the
+deployed environment.
+
+[^1]: https://github.com/IntersectMBO/govtool/discussions/174

--- a/scripts/govtool/prepare-config.sh
+++ b/scripts/govtool/prepare-config.sh
@@ -79,6 +79,7 @@ sed -e "s/GRAFANA_SLACK_RECIPIENT/$GRAFANA_SLACK_RECIPIENT/" \
 
 # nginx config for frontend optional basic auth
 nginx_config_dir="$target_config_dir/nginx"
+rm -rf "$nginx_config_dir"
 mkdir -p "$nginx_config_dir"
 if [[ "$DOMAIN" == *"sanchonet.govtool.byron.network"* ]]; then
   cat >"$nginx_config_dir/auth.conf" <<_EOF_


### PR DESCRIPTION
There is a bug in the prepare-config.sh script (#171) that caused an incident (https://github.com/IntersectMBO/govtool/discussions/174).

The result of the incident was that the `beta` environment had the BasicAuth turned on, therefore preventing users from reaching application.

The reason behind that behaviour was the reusage of the configuration files responsible for setting up the BasicAuth. Those files were generated during a previous deployments on internal environments (i.e. `dev`, `test` and `staging`) and futher used because the script was unaware of pre-existance of those files during their generation.

List of changes:

1. The modification was made in the `scripts/govtool/prepare-config.sh` script, where a command to remove the Nginx configuration directory (`$nginx_config_dir`) has been added. This change ensures that the Nginx configuration is not shared between executions of the deployment scripts on different environments, which was a actual reason behind the incident.