### PR TITLE
[#181] Implement hotfix for SanchoNet Cardano DB Sync configuration issue

### DIFF
--- a/scripts/govtool/docker-compose.sanchonet.yml
+++ b/scripts/govtool/docker-compose.sanchonet.yml
@@ -143,7 +143,7 @@ services:
     logging: *logging
 
   cardano-db-sync:
-    image: ghcr.io/intersectmbo/cardano-db-sync:sancho-4-0-0
+    image: ghcr.io/intersectmbo/cardano-db-sync:sancho-4-0-0-fix-config
     environment:
       - NETWORK=${CARDANO_NETWORK:-sanchonet}
       - POSTGRES_HOST=postgres


### PR DESCRIPTION
### Overview
This pull request addresses a critical configuration parsing issue identified in the SanchoNet Cardano DB Sync Docker environment, which prevented the correct operation of the DB Sync component due to a failure in parsing the conway-genesis.json file. The root cause was identified as a missing motionNoConfidence key within the configuration, arising from hardcoded paths and settings within the Docker image's entrypoint script.

### Changes Introduced
At first to rectify this, we introduced a series of modifications that enable dynamic configuration loading, ensuring the DB Sync operates correctly by utilizing external configuration files and scripts. The solution comprised creating and integrating custom scripts (govtool-dbsync, govtool-entrypoint, and govtool-sanchonet) that replaced the Docker image's original entrypoint and associated scripts. These custom scripts were designed to read configuration files from a specified volume, allowing for the necessary flexibility to accommodate the correct Sanchonet environment settings as outlined in the official documentation. This solution was applied to the `dev` environment, tested and confirmed to be working, as the DBSync was fully operational and synced well with the corresponding Cardano Node in the stack.

Meanwhine the related issue has been solved so we switched to the official new image release.

### Outcome
The actual change this PR introduces is a bump of the Cardano DBSync version to `ghcr.io/intersectmbo/cardano-db-sync:sancho-4-0-0-fix-config`.

Eventualy, to document our efforts and to have a better insight into a reported issue solving process we kept the previous solution in the git history in case such problem will rise again elsewhere, so at least we have schema of treatment.