### PR TITLE
Chore: bump DBSync version to use fixed image

### DIFF
--- a/scripts/govtool/docker-compose.sanchonet.yml
+++ b/scripts/govtool/docker-compose.sanchonet.yml
@@ -143,7 +143,7 @@ services:
     logging: *logging
 
   cardano-db-sync:
-    image: ghcr.io/intersectmbo/cardano-db-sync:sancho-4-0-0
+    image: ghcr.io/intersectmbo/cardano-db-sync:sancho-4-0-0-fix-config
     environment:
       - NETWORK=${CARDANO_NETWORK:-sanchonet}
       - POSTGRES_HOST=postgres


### PR DESCRIPTION
## List of changes

- bumped to use DBSync `sancho-4-0-0` docker image with fixed config files

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/127)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
