### PR TITLE
Update deployment Slack notifications

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -246,8 +246,6 @@ jobs:
           curl -X POST -u "admin:$GRAFANA_ADMIN_PASSWORD" https://$DOMAIN/grafana/api/admin/provisioning/dashboards/reload
           curl -X POST -u "admin:$GRAFANA_ADMIN_PASSWORD" https://$DOMAIN/grafana/api/admin/provisioning/notifications/reload
       - name: Notify on Slack
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.DEPLOY_NOTIFY_SLACK_WEBHOOK_URL }}
         run: |
           if [[ "${{ inputs.environment }}" == "staging" ]]; then export DOMAIN=staging.govtool.byron.network; fi;
           if [[ "${{ inputs.environment }}" == "beta" ]]; then export DOMAIN=sanchogov.tools; fi;

--- a/scripts/govtool/Makefile
+++ b/scripts/govtool/Makefile
@@ -155,7 +155,7 @@ info:
 notify:
 	@:$(call check_defined, cardano_network)
 	@:$(call check_defined, env)
-	curl -X POST -H 'Content-type: application/json' --data '{"host":"$(docker_host)","branch":"$(branch)","env":"$(env)","commit":"$(shell git rev-parse HEAD)"}' $$SLACK_WEBHOOK_URL
+	curl -X POST -H "Authorization: Bearer $$GRAFANA_SLACK_OAUTH_TOKEN" -d "channel=$$GRAFANA_SLACK_RECIPIENT" -d "text=The deploy to $(env) has been made from branch $(branch) ($(shell git-rev-parse HEAD))" https://slack.com/api/chat.postMessage
 
 .PHONY: ssh
 ssh:


### PR DESCRIPTION
## List of changes

- Change the deployment Slack notifications to use Grafana's Slack app configuration so that the notifications are sent to the new channel instead of the old one.

## Checklist

- no related issue
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
