### PR TITLE
[#278] Update domain references for test environment in docker-compose

### DIFF
--- a/scripts/govtool/docker-compose.test.yml
+++ b/scripts/govtool/docker-compose.test.yml
@@ -55,13 +55,13 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_INSTALL_PLUGINS=grafana-piechart-panel
-      - GF_SERVER_ROOT_URL=https://test.govtool.byron.network/grafana
+      - GF_SERVER_ROOT_URL=https://test-sanchonet.govtool.byron.network/grafana
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
     restart: always
     logging: *logging
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.grafana.rule=Host(`test.govtool.byron.network`) && PathPrefix(`/grafana`)"
+      - "traefik.http.routers.grafana.rule=Host(`test-sanchonet.govtool.byron.network`) && PathPrefix(`/grafana`)"
       - "traefik.http.routers.grafana.entrypoints=websecure"
       - "traefik.http.routers.grafana.tls.certresolver=myresolver"
       - "traefik.http.services.grafana.loadbalancer.server.port=3000"
@@ -76,7 +76,7 @@ services:
     logging: *logging
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.status-service.rule=Host(`test.govtool.byron.network`) && PathPrefix(`/status`)"
+      - "traefik.http.routers.status-service.rule=Host(`test-sanchonet.govtool.byron.network`) && PathPrefix(`/status`)"
       - "traefik.http.routers.status-service.entrypoints=websecure"
       - "traefik.http.routers.status-service.tls.certresolver=myresolver"
       - "traefik.http.services.status-service.loadbalancer.server.port=8000"
@@ -180,11 +180,11 @@ services:
     logging: *logging
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.backend.rule=Host(`test.govtool.byron.network`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.backend.rule=Host(`test-sanchonet.govtool.byron.network`) && PathPrefix(`/api`)"
       - "traefik.http.middlewares.backend-stripprefix.stripprefix.prefixes=/api"
       - "traefik.http.middlewares.backend-cors.headers.accesscontrolallowmethods=GET,HEAD,OPTIONS"
       - "traefik.http.middlewares.backend-cors.headers.accesscontrolallowheaders=*"
-      - "traefik.http.middlewares.backend-cors.headers.accesscontrolalloworiginlist=https://test.govtool.byron.network"
+      - "traefik.http.middlewares.backend-cors.headers.accesscontrolalloworiginlist=https://test-sanchonet.govtool.byron.network"
       - "traefik.http.middlewares.backend-cors.headers.accesscontrolmaxage=100"
       - "traefik.http.middlewares.backend-cors.headers.addvaryheader=true"
       - "traefik.http.routers.backend.middlewares=backend-stripprefix@docker,backend-cors@docker"
@@ -206,7 +206,7 @@ services:
     logging: *logging
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.frontend.rule=Host(`test.govtool.byron.network`)"
+      - "traefik.http.routers.frontend.rule=Host(`test-sanchonet.govtool.byron.network`)"
       - "traefik.http.routers.frontend.entrypoints=websecure"
       - "traefik.http.routers.frontend.tls.certresolver=myresolver"
       - "traefik.http.middlewares.frontend-csp.headers.contentSecurityPolicy=default-src 'self'; img-src *.usersnap.com 'self' data:; script-src *.usersnap.com 'self' 'unsafe-inline' https://www.googletagmanager.com https://browser.sentry-cdn.com; style-src *.usersnap.com *.googleapis.com 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src *.usersnap.com https://s3.eu-central-1.amazonaws.com/upload.usersnap.com 'self' https://o4506155985141760.ingest.sentry.io/api/4506156032196608/envelope/ *.google-analytics.com; font-src *.usersnap.com *.gstatic.com 'self' 'unsafe-inline' https://fonts.gstatic.com; worker-src blob:"


### PR DESCRIPTION
This PR updates the domain references within the docker-compose.test.yml for the test environment. Changes include updating the GF_SERVER_ROOT_URL and the traefik routing rules to point to the new test domain test-sanchonet.govtool.byron.network from the previous test.govtool.byron.network. These modifications ensure that the services such as Grafana, status-service, backend, and frontend are correctly accessible through the updated domain, aligning with infrastructure changes or domain migration needs. This update is crucial for maintaining seamless access and functionality of the test environment's services.