### PR TITLE
[#301] Add Michał Szałowski to SSH access list for environment management

### DIFF
--- a/infra/terraform/modules/govtool-ec2/main.tf
+++ b/infra/terraform/modules/govtool-ec2/main.tf
@@ -153,7 +153,7 @@ resource "aws_instance" "govtool" {
   }
 
   user_data = file("${path.module}/user_data.sh")
-  # user_data_replace_on_change = true
+  user_data_replace_on_change = false
 
   credit_specification {
     cpu_credits = "unlimited"

--- a/infra/terraform/modules/govtool-ec2/user_data.sh
+++ b/infra/terraform/modules/govtool-ec2/user_data.sh
@@ -2,7 +2,7 @@
 
 # setup ssh access
 mkdir -p /home/ubuntu/.ssh
-users="a.guderski,michal.jankun,p.placzynski"
+users="a.guderski,michal.jankun,p.placzynski,michal.szalowski"
 curl --retry 5 --retry-delay 5 -L keys.binarapps.com/ssh/{$users} | tee -a /home/ubuntu/.ssh/authorized_keys
 echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKeM0HOF9szWhOfbQM8XkIfznORTtTaCJJStALYjQuy6 (voltaire-era-github-actions)" | tee -a /home/ubuntu/.ssh/authorized_keys
 chmod 700 /home/ubuntu/.ssh


### PR DESCRIPTION
This PR adds Michał Szałowski (@MSzalowski) to the list of users authorized for SSH access to all the environments, thereby expanding the secure access management system to include a team leader.
