### PR TITLE
[#317] do not list sole voters in drep/list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ changes.
 
 ### Changed
 - `drep/list` and `drep/info` endpoints now return additional data such as metadata url and hash, and voting power [Issue 223](https://github.com/IntersectMBO/govtool/issues/223)
+- `drep/info` now does not return sole voters (dreps without metadata) [Issue 317](https://github.com/IntersectMBO/govtool/issues/317)
 - `isRegistered` and `wasRegistered` fields in the drep/info endpoint changed to `isRegisteredAsDRep` and `wasRegisteredAsDRep` respectively [Issue 212](https://github.com/IntersectMBO/govtool/issues/212)
 - Update Cardano-Serialization-Lib to 12.0.0-alpha.16 [Issue 156](https://github.com/IntersectMBO/govtool/issues/156)
 - Changed and improved working conventions docs, PR template and codeowners file, addressing [Issue 88](https://github.com/IntersectMBO/govtool/issues/88).

--- a/govtool/backend/sql/list-dreps.sql
+++ b/govtool/backend/sql/list-dreps.sql
@@ -27,6 +27,7 @@ LEFT JOIN (
   FROM drep_registration dr
 ) as dr_voting_anchor
 on dr_voting_anchor.drep_hash_id = dh.id and dr_voting_anchor.rn = 1
-left JOIN voting_anchor va ON va.id = dr_voting_anchor.voting_anchor_id
 LEFT JOIN DRepDistr
 on DRepDistr.hash_id = dh.id and DRepDistr.rn = 1
+JOIN voting_anchor va ON va.id = dr_voting_anchor.voting_anchor_id
+


### PR DESCRIPTION
## List of changes

Change
- drep/list no longer returns sole voters

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
