### PR TITLE
[#362] fix display data only for one type of GA

### DIFF
--- a/govtool/frontend/src/components/organisms/CreateGovernanceActionForm.tsx
+++ b/govtool/frontend/src/components/organisms/CreateGovernanceActionForm.tsx
@@ -21,7 +21,7 @@ export const CreateGovernanceActionForm = ({
   setStep,
 }: ChooseGovernanceActionTypeProps) => {
   const { t } = useTranslation();
-  const { control, errors, getValues, register, watch } =
+  const { control, errors, getValues, register, reset, watch } =
     useCreateGovernanceActionForm();
   const {
     append,
@@ -48,6 +48,7 @@ export const CreateGovernanceActionForm = ({
   };
 
   const onClickBack = () => {
+    reset();
     setStep(2);
   };
 

--- a/govtool/frontend/src/hooks/forms/useCreateGovernanceActionForm.ts
+++ b/govtool/frontend/src/hooks/forms/useCreateGovernanceActionForm.ts
@@ -23,6 +23,7 @@ export const useCreateGovernanceActionForm = () => {
     setValue,
     watch,
     register,
+    reset,
   } = useFormContext<createGovernanceActionValues>();
 
   const onSubmit = useCallback(async () => {
@@ -44,5 +45,6 @@ export const useCreateGovernanceActionForm = () => {
     submitForm: handleSubmit(onSubmit),
     watch,
     register,
+    reset,
   };
 };


### PR DESCRIPTION
## List of changes

- fix - reset form on click back 

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
