### PR TITLE
Hotfix for 'why' debug option in make

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -84,13 +84,13 @@ jobs:
       - name: Destroy Cardano Node, DB sync and Postgres if required
         if: ${{ inputs.resync_cardano_node_and_db }}
         run: |
-          make --debug=w destroy-cardano-node-and-dbsync
+          make --debug=b destroy-cardano-node-and-dbsync
 
       - name: Deploy app
         run: |
-          make --debug=w all
+          make --debug=b all
 
       - name: Reprovision Grafana
         run: |
           sleep 30 # give grafana time to start up
-          make --debug=w reload-grafana
+          make --debug=b reload-grafana


### PR DESCRIPTION
This PR corrects the debug option in make commands in the CI/CD pipeline workflow, so that the deployment process in the CI can execute without issues related to unrecognized debug flags.

The existing 'make' commands were utilizing the debug flag '--debug=w' which was causing compatibility issues in the CI environment where 'why' debug option was not recognized. This commit addresses the problem by replacing the 'w' with 'b' in the relevant 'make' commands in the '.github/workflows/build-and-deploy.yml' file, ensuring smooth execution of the deployment tasks.