### PR TITLE
fix/364-information-storage-steps

### DIFF
--- a/govtool/frontend/public/icons/Download.svg
+++ b/govtool/frontend/public/icons/Download.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17.5 12.5V15.8333C17.5 16.2754 17.3244 16.6993 17.0118 17.0118C16.6993 17.3244 16.2754 17.5 15.8333 17.5H4.16667C3.72464 17.5 3.30072 17.3244 2.98816 17.0118C2.67559 16.6993 2.5 16.2754 2.5 15.8333V12.5" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5.83301 8.33594L9.99967 12.5026L14.1663 8.33594" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10 12.5V2.5" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/govtool/frontend/src/components/organisms/CreateGovernanceActionSteps/StorageInformation.tsx
+++ b/govtool/frontend/src/components/organisms/CreateGovernanceActionSteps/StorageInformation.tsx
@@ -3,6 +3,7 @@ import { Box } from "@mui/material";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 
 import { Button, Spacer, Typography } from "@atoms";
+import { ICONS } from "@consts";
 import { useCreateGovernanceActionForm, useTranslation } from "@hooks";
 import { Step } from "@molecules";
 import { BgCard, ControlledField } from "@organisms";
@@ -64,11 +65,11 @@ export const StorageInformation = ({ setStep }: StorageInformationProps) => {
       </Typography>
       <Box sx={{ my: 4 }}>
         <Step
-          // TODO: add onClick action when available
           component={
             <Button
               onClick={onClickDownloadJson}
               size="extraLarge"
+              startIcon={<img src={ICONS.download} />}
               sx={{ width: "fit-content" }}
             >
               {`${fileName}.jsonld`}

--- a/govtool/frontend/src/consts/icons.ts
+++ b/govtool/frontend/src/consts/icons.ts
@@ -12,6 +12,7 @@ export const ICONS = {
   copyWhiteIcon: "/icons/CopyWhite.svg",
   dashboardActiveIcon: "/icons/DashboardActive.svg",
   dashboardIcon: "/icons/Dashboard.svg",
+  download: "/icons/Download.svg",
   drawerIcon: "/icons/DrawerIcon.svg",
   externalLinkIcon: "/icons/ExternalLink.svg",
   faqsActiveIcon: "/icons/FaqsActive.svg",


### PR DESCRIPTION
## List of changes

add icon into download json button

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
