### PR TITLE
[#466] Enhancing Docker Compose stack for proper frontend image tagging

### DIFF
--- a/govtool/frontend/Makefile
+++ b/govtool/frontend/Makefile
@@ -7,7 +7,7 @@ endif
 .DEFAULT_GOAL := push-frontend
 
 # image tags
-frontend_image_tag := $(shell git log -n 1 --format="%H" -- $(root_dir)/govtool/frontend)
+frontend_image_tag := $(shell git log -n 1 --format="%H" -- $(root_dir)/govtool/frontend)-$(env)
 
 .PHONY: build-frontend
 build-frontend: docker-login


### PR DESCRIPTION
Closes #466.

## Purpose of the Changes:

The purpose of these changes is to fix the Docker Compose stack in order to
properly tag frontend images with environment-specific flags. This improvement
aims to address the issue where frontend images generated based on the last
commit SHA were inadequate due to variations in build arguments and deployment
settings across different environments. By introducing an environment flag to
the image tag, the goal is to ensure that the correct frontend build is utilized
for each specific deployment environment.

## Outcome of the Changes:

The introduced modification includes updating the Makefile in the
govtool/frontend directory to incorporate an environment tag to the image tag
name used during frontend image builds. This new tag generation process merges
the environment variable with the commit hash retrieved from the git log
command, guaranteeing a unique identification for each build based on the
environment. Consequently, applications sharing the same version can now be
distinctly recognized across diverse deployment environments, improving
deployment accuracy and environment segregation.
