### PR TITLE
[#436] Refactor deployment makefiles to use file targets instead of phony targets

### DIFF
--- a/scripts/govtool/config.mk
+++ b/scripts/govtool/config.mk
@@ -37,6 +37,11 @@ output_dirs := $(sort $(foreach file,$(output_files),$(dir $(file))))
 .PHONY: prepare-config
 prepare-config: clear $(output_files)
 
+.PHONY: upload-config
+upload-config: check-env-defined prepare-config
+	@:$(call check_defined, ssh_url)
+	$(rsync) -av -e 'ssh -o StrictHostKeyChecking=no' config/target/. $(ssh_url):config
+
 .PHONY: clear
 clear:
 	rm -rf $(target_config_dir)
@@ -108,8 +113,3 @@ $(target_config_dir)/nginx/govtool.htpasswd: $(target_config_dir)/nginx/
 	else \
 	  echo > $@; \
 	fi
-
-.PHONY: upload-config
-upload-config: check-env-defined prepare-config
-	@:$(call check_defined, ssh_url)
-	$(rsync) -av -e 'ssh -o StrictHostKeyChecking=no' config/target/. $(ssh_url):config


### PR DESCRIPTION
Closes #436.

This pull request aims to refactor deployment makefiles by transitioning from using phony targets to utilizing actual file targets, as part of the goal to enhance declarative control over the configuration generation process. The commit focuses on updating specific targets within the `config.mk` file in the `scripts/govtool` directory, ensuring that file-driven processes streamline the configuration setup.

The changes include replacing phony targets with actual file targets, such as moving specific targets to the top of the makefile, removing invalid phony statements, creating explicit file targets for previously phony actions, and reorganizing variables for improved structure and maintainability. The commits provide clear explanations of the modifications made and the rationale behind shifting towards a more file-centric approach in managing deployment configurations.

These updates enhance the predictability, maintainability, and overall control over the configuration generation process, improving the developer workflow and understanding of the deployment makefiles. Additionally, the shift to file targets ensures precise management of configuration outcomes, catering to a more structured deployment process while maintaining the necessary actions as phony targets where required.

