### PR TITLE
fix/481-ga-details-long-external-url-is-show-outside-the-view

### DIFF
--- a/govtool/frontend/src/components/organisms/ExternalLinkModal.tsx
+++ b/govtool/frontend/src/components/organisms/ExternalLinkModal.tsx
@@ -42,6 +42,7 @@ export function ExternalLinkModal() {
             marginBottom: "38px",
             color: primaryBlue,
             textDecoration: "underline",
+            wordBreak: "break-word",
           }}
         >
           {state?.externalLink}


### PR DESCRIPTION
## List of changes

wrap too long string

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
