### PR TITLE
[#503] Update Cardano DB Sync version for Sanchonet

### DIFF
--- a/scripts/govtool/docker-compose.node+dbsync.yml
+++ b/scripts/govtool/docker-compose.node+dbsync.yml
@@ -65,7 +65,7 @@ services:
       retries: 10
 
   cardano-db-sync:
-    image: ghcr.io/intersectmbo/cardano-db-sync:sancho-4-0-0-fix-config
+    image: ghcr.io/intersectmbo/cardano-db-sync:sancho-4.1.0
     environment:
       - NETWORK=sanchonet
       - POSTGRES_HOST=postgres


### PR DESCRIPTION
Closes #503.

This pull request addresses the user story requesting an update of the Cardano DB Sync version to 4.1.0 in the context of Sanchonet development. By upgrading the Cardano DB Sync version to 4.1.0, developers can now proceed with verifications and adjustments necessary to ensure compatibility with the updated DB Sync version. The changes consist of updating the `docker-compose.node+dbsync.yml` file to use the Cardano DB Sync image version 4.1.0 (`ghcr.io/intersectmbo/cardano-db-sync:sancho-4.1.0`).

The outcome of these changes provides a streamlined process for developers to continue their work on latest features released on Sanchonet by aligning the Cardano DB Sync version with the latest release. This update allows for seamless verification and adjustments to ensure application compatibility with the new DB Sync version.
