### PR TITLE
[#498] Modify Github Workflow to trigger on new tags matching pattern

### DIFF
--- a/.github/workflows/deploy-dev-from-tag.yml
+++ b/.github/workflows/deploy-dev-from-tag.yml
@@ -1,0 +1,66 @@
+name: Build and deploy GovTool to DEV server
+run-name: Deploy by @${{ github.actor }}
+
+on:
+  create:
+
+env:
+  ENVIRONMENT: "dev"
+  CARDANO_NETWORK: "sanchonet"
+  DOMAIN: "dev-sanchonet.govtool.byron.network"
+
+jobs:
+  deploy:
+    name: Deploy app
+    if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/dev-')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./scripts/govtool
+    env:
+      DBSYNC_POSTGRES_DB: "cexplorer"
+      DBSYNC_POSTGRES_USER: "postgres"
+      DBSYNC_POSTGRES_PASSWORD: "pSa8JCpQOACMUdGb"
+      GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
+      GRAFANA_SLACK_RECIPIENT: ${{ secrets.GRAFANA_SLACK_RECIPIENT }}
+      GRAFANA_SLACK_OAUTH_TOKEN: ${{ secrets.GRAFANA_SLACK_OAUTH_TOKEN }}
+      NGINX_BASIC_AUTH: ${{ secrets.NGINX_BASIC_AUTH }}
+      SENTRY_DSN_BACKEND: ${{ secrets.SENTRY_DSN_BACKEND }}
+      TRAEFIK_LE_EMAIL: "admin+govtool@binarapps.com"
+      GTM_ID: ${{ secrets.GTM_ID }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN_FRONTEND }}
+      PIPELINE_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      IP_ADDRESS_BYPASSING_BASIC_AUTH1: ${{ secrets.IP_ADDRESS_BYPASSING_BASIC_AUTH1 }}
+      IP_ADDRESS_BYPASSING_BASIC_AUTH2: ${{ secrets.IP_ADDRESS_BYPASSING_BASIC_AUTH2 }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id: ${{ secrets.GHA_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.GHA_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Login to AWS ECR
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: eu-west-1
+
+      - name: Setup SSH agent
+        uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.GHA_SSH_PRIVATE_KEY }}
+
+      - name: Deploy app
+        run: |
+          make --debug=b all
+
+      - name: Reprovision Grafana
+        run: |
+          sleep 30 # give grafana time to start up
+          make --debug=b reload-grafana


### PR DESCRIPTION
Closes #498.

This pull request addresses Issue #498, focusing on enhancing the GitHub workflow to trigger deployment to the `dev` branch upon the creation of a new tag that matches the specified pattern `refs/tags/dev-`. The changes consist of creating a new workflow configuration file, `deploy-dev-from-tag.yml`, to automate the deployment process and distinguish between automatic triggering and manual activation. This modification aims to improve automation efficiency and streamline deployment procedures for the repository. 

The implemented changes introduce a new workflow configuration file, `deploy-dev-from-tag.yml,` enabling the automated triggering of deployments when a new tag following the pattern `refs/tags/dev-` is created. Additionally, the workflow has been updated to differentiate between automated and manual activation to provide flexibility in deployment initiation. This adjustment ensures that tag creation events satisfying the specified pattern trigger the workflow automatically, while still allowing manual activation when needed. The enhancements aim to accelerate deployment procedures and maintain control over the workflow activation process.
