### PR TITLE
[#566] add optional 'search' query param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ changes.
 
 ### Fixed
 
+- proposal/list now takes optional `search` query param [Issue 566](https://github.com/IntersectMBO/govtool/issues/566)
 - Fix possible sql error when there would be no predefined drep voting pwoer [Issue 501](https://github.com/IntersectMBO/govtool/issues/501)
 - Fix drep type detection when changing metadata [Issue 333](https://github.com/IntersectMBO/govtool/issues/333)
 - Fix make button disble when wallet tries connect [Issue 265](https://github.com/IntersectMBO/govtool/issues/265)

--- a/govtool/backend/sql/list-proposals.sql
+++ b/govtool/backend/sql/list-proposals.sql
@@ -59,6 +59,7 @@ SELECT
     off_chain_vote_data.abstract,
     off_chain_vote_data.motivation,
     off_chain_vote_data.rationale,
+    off_chain_vote_data.json,
     coalesce(Sum(ldd.amount) FILTER (WHERE voting_procedure.vote::text = 'Yes'), 0) +(
         CASE WHEN gov_action_proposal.type = 'NoConfidence' THEN
             always_no_confidence_voting_power.amount
@@ -109,6 +110,7 @@ GROUP BY
         off_chain_vote_data.abstract,
         off_chain_vote_data.motivation,
         off_chain_vote_data.rationale,
+        off_chain_vote_data.json,
         gov_action_proposal.index,
         creator_tx.hash,
         creator_block.time,

--- a/govtool/backend/src/VVA/API/Types.hs
+++ b/govtool/backend/src/VVA/API/Types.hs
@@ -233,6 +233,27 @@ instance ToSchema GovernanceActionDetails where
           ?~ toJSON
                 ("{\"some_key\": \"some value\", \"some_key2\": [1,2,3]}" :: Text)
 
+
+newtype GovernanceActionMetadata = GovernanceActionMetadata Value
+  deriving newtype (Show)
+
+instance FromJSON GovernanceActionMetadata where
+  parseJSON v@(Aeson.Object o) = pure (GovernanceActionMetadata v)
+  parseJSON _ = fail "GovernanceActionMetadata has to be an object"
+
+instance ToJSON GovernanceActionMetadata where
+  toJSON (GovernanceActionMetadata g) = g
+
+instance ToSchema GovernanceActionMetadata where
+    declareNamedSchema _ = pure $ NamedSchema (Just "GovernanceActionMetadata") $ mempty
+        & type_ ?~ OpenApiObject
+        & description ?~ "A Governance Action metadata"
+        & example
+          ?~ toJSON
+                ("{\"some_key\": \"some value\", \"some_key2\": [1,2,3]}" :: Text)
+
+
+
 data ProposalResponse = ProposalResponse
   { proposalResponseId :: Text,
     proposalResponseTxHash :: HexText,
@@ -249,6 +270,7 @@ data ProposalResponse = ProposalResponse
     proposalResponseAbout :: Maybe Text,
     proposalResponseMotivation :: Maybe Text,
     proposalResponseRationale :: Maybe Text,
+    proposalResponseMetadata :: Maybe GovernanceActionMetadata,
     proposalResponseYesVotes :: Integer,
     proposalResponseNoVotes :: Integer,
     proposalResponseAbstainVotes :: Integer
@@ -273,6 +295,7 @@ exampleProposalResponse = "{ \"id\": \"proposalId123\","
                   <> "\"about\": \"Proposal About\","
                   <> "\"motivation\": \"Proposal Motivation\","
                   <> "\"rationale\": \"Proposal Rationale\","
+                  <> "\"metadata\": {\"key\": \"value\"},"
                   <> "\"yesVotes\": 0,"
                   <> "\"noVotes\": 0,"
                   <> "\"abstainVotes\": 0}"

--- a/govtool/backend/src/VVA/Proposal.hs
+++ b/govtool/backend/src/VVA/Proposal.hs
@@ -85,6 +85,7 @@ getProposals mProposalIds = withPool $ \conn -> do
                , about'
                , motivation'
                , rationale'
+               , metadataJson'
                , yesVotes'
                , noVotes'
                , abstainVotes'
@@ -108,6 +109,7 @@ getProposals mProposalIds = withPool $ \conn -> do
                   about'
                   motivation'
                   rationale'
+                  metadataJson'
                   (floor @Scientific yesVotes')
                   (floor @Scientific noVotes')
                   (floor @Scientific abstainVotes')

--- a/govtool/backend/src/VVA/Types.hs
+++ b/govtool/backend/src/VVA/Types.hs
@@ -105,6 +105,7 @@ data Proposal = Proposal
     proposalAbout :: Maybe Text,
     proposalMotivaiton :: Maybe Text,
     proposalRationale :: Maybe Text,
+    proposalMetadata :: Maybe Value,
     proposalYesVotes :: Integer,
     proposalNoVotes :: Integer,
     proposalAbstainVotes :: Integer


### PR DESCRIPTION
Allow for searching for specific GA by title, motivation, about and rationale

## List of changes

- Add
optional `search` query param to proposal/list

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
