### PR TITLE
[#569] Deployment issue due to bug in Dockerfile

### DIFF
--- a/govtool/backend/Dockerfile
+++ b/govtool/backend/Dockerfile
@@ -3,4 +3,4 @@ FROM 733019650473.dkr.ecr.eu-west-1.amazonaws.com/backend-base:$BASE_IMAGE_TAG
 WORKDIR /src
 COPY . .
 RUN cabal build
-RUN cp dist-newstyle/build/x86_64-linux/ghc-9.2.8/vva-be-0.1.0.0/x/vva-be/build/vva-be/vva-be /usr/local/bin
+RUN cp dist-newstyle/build/x86_64-linux/ghc-9.2.7/vva-be-0.1.0.0/x/vva-be/build/vva-be/vva-be /usr/local/bin


### PR DESCRIPTION
Closes #569.

This pull request addresses the deployment issue encountered due to a bug in the Dockerfile affecting the backend module of the project. The failing build was a result of a change in the GHC version, leading to an incorrect executable path. By updating the Dockerfile for the backend module to specify the correct GHC version (9.2.7) and executable path, the build issue is resolved, ensuring successful deployment.

The changes in this commit consist of updating the Dockerfile for the backend module to reflect the appropriate GHC version (9.2.7) and the associated executable path required for successful building of the backend module.
