### PR TITLE
Slider styles tiny fix

### DIFF
--- a/govtool/frontend/src/components/organisms/Slider.tsx
+++ b/govtool/frontend/src/components/organisms/Slider.tsx
@@ -102,6 +102,7 @@ export const Slider = ({
           alignItems: "center",
           gap: "10px",
           mb: 3.5,
+          height: "46px",
         }}
       >
         <Box


### PR DESCRIPTION
## List of changes

- Slider styles tiny fix. Prevents slider title bar from a small "jump" after keen-slider is fully initialized.

## Checklist

- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
