### PR TITLE
fix: fix dev build failing by missing indents

### DIFF
--- a/scripts/govtool/config/templates/docker-compose.yml.tpl
+++ b/scripts/govtool/config/templates/docker-compose.yml.tpl
@@ -213,8 +213,8 @@ services:
         context: ../../govtool/metadata-validation
       environment:
         - PORT=3000
-        logging: *logging
-        restart: always
+      logging: *logging
+      restart: always
       healthcheck:
         test: ["CMD-SHELL", "curl -f 127.0.0.1:3000/health || exit 1"]
         interval: 5s


### PR DESCRIPTION
## List of changes

- fix build on dev caused by missing indents in docker-compose template

## Checklist

### Trivial
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
