### PR TITLE
Fix traefik configuration for metadata-validation service

### DIFF
--- a/scripts/govtool/config/templates/docker-compose.yml.tpl
+++ b/scripts/govtool/config/templates/docker-compose.yml.tpl
@@ -223,10 +223,12 @@ services:
       labels:
         - "traefik.enable=true"
         - "traefik.http.routers.metadata-validation.rule=Host(`<DOMAIN>`) && PathPrefix(`/metadata-validation`)"
+        - "traefik.http.middlewares.metadata-validation-stripprefix.stripprefix.prefixes=/metadata-validation"
+        - "traefik.http.routers.metadata-validation.middlewares=metadata-validation-stripprefix@docker"
         - "traefik.http.routers.metadata-validation.entrypoints=websecure"
         - "traefik.http.routers.metadata-validation.tls.certresolver=myresolver"
         - "traefik.http.services.metadata-validation.loadbalancer.server.port=3000"
-  
+
   frontend:
     image: <REPO_URL>/frontend:${FRONTEND_TAG}
     volumes:


### PR DESCRIPTION
The traefik configuration for the metadata-validation service was missing the stripprefix option to rewrite paths. This option is necessary to ensure proper handling of incoming requests and forwarding them to the correct destination.
