### PR TITLE
[#651] fix: correct text of governance action type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ changes.
 - Change style of url button to trim the file name [Issue 655](https://github.com/IntersectMBO/govtool/issues/655)
 - Change regex for parsing urls to match urls without protocol [Issue 655](https://github.com/IntersectMBO/govtool/issues/655)
 - Integrate ga displaying metadata validation with the validation service [Issue 712](https://github.com/IntersectMBO/govtool/issues/712)
+- Correct text of the governance action type [Issue 651](https://github.com/IntersectMBO/govtool/issues/651)
 
 ### Added
 

--- a/govtool/frontend/src/components/organisms/DashboardGovernanceActions.tsx
+++ b/govtool/frontend/src/components/organisms/DashboardGovernanceActions.tsx
@@ -2,7 +2,10 @@ import { useState, useEffect } from "react";
 import { Box, CircularProgress, Tab, Tabs, styled } from "@mui/material";
 import { useLocation } from "react-router-dom";
 
-import { GOVERNANCE_ACTIONS_FILTERS, GOVERNANCE_ACTIONS_SORTING } from "@consts";
+import {
+  GOVERNANCE_ACTIONS_FILTERS,
+  GOVERNANCE_ACTIONS_SORTING,
+} from "@consts";
 import { useCardano } from "@context";
 import {
   useDataActionsBar,

--- a/govtool/frontend/src/components/organisms/GovernanceActionsToVote.tsx
+++ b/govtool/frontend/src/components/organisms/GovernanceActionsToVote.tsx
@@ -6,7 +6,7 @@ import { PATHS } from "@consts";
 import { useCardano } from "@context";
 import { useScreenDimension, useTranslation } from "@hooks";
 import { GovernanceActionCard } from "@molecules";
-import { getProposalTypeLabel, getFullGovActionId, openInNewTab } from "@utils";
+import { getProposalTypeTitle, getFullGovActionId, openInNewTab } from "@utils";
 import { Slider } from "@organisms";
 
 type GovernanceActionsToVoteProps = {
@@ -103,7 +103,7 @@ export const GovernanceActionsToVote = ({
                 onDashboard={onDashboard}
                 searchPhrase={searchPhrase}
                 sorting={sorting}
-                title={getProposalTypeLabel(item.title)}
+                title={getProposalTypeTitle(item.title)}
               />
               {index < proposals.length - 1 && (
                 <Box height={isMobile ? 40 : 52} />

--- a/govtool/frontend/src/consts/governanceAction/filters.ts
+++ b/govtool/frontend/src/consts/governanceAction/filters.ts
@@ -1,30 +1,39 @@
+import I18n from "@/i18n";
+
 export const GOVERNANCE_ACTIONS_FILTERS = [
   {
     key: "NoConfidence",
-    label: "No Confidence",
+    title: I18n.t("govActions.type.noConfidence.title"),
+    label: I18n.t("govActions.type.noConfidence.label"),
   },
   {
     key: "NewCommittee",
-    label: "New Constitutional Committee or Quorum Size",
+    title: I18n.t("govActions.type.newCommittee.title"),
+    label: I18n.t("govActions.type.newCommittee.label"),
   },
   {
     key: "NewConstitution",
-    label: "Update to the Constitution",
+    title: I18n.t("govActions.type.newConstitution.title"),
+    label: I18n.t("govActions.type.newConstitution.label"),
   },
   {
     key: "HardForkInitiation",
-    label: "Hard Fork",
+    title: I18n.t("govActions.type.hardFork.title"),
+    label: I18n.t("govActions.type.hardFork.label"),
   },
   {
     key: "ParameterChange",
-    label: "Protocol Parameter Changes",
+    title: I18n.t("govActions.type.parameterChange.title"),
+    label: I18n.t("govActions.type.parameterChange.label"),
   },
   {
     key: "TreasuryWithdrawals",
-    label: "Treasury Withdrawals",
+    title: I18n.t("govActions.type.treasuryWithdrawals.title"),
+    label: I18n.t("govActions.type.treasuryWithdrawals.label"),
   },
   {
     key: "InfoAction",
-    label: "Info Action",
+    title: I18n.t("govActions.type.infoAction.title"),
+    label: I18n.t("govActions.type.infoAction.label"),
   },
 ];

--- a/govtool/frontend/src/i18n/locales/en.ts
+++ b/govtool/frontend/src/i18n/locales/en.ts
@@ -424,6 +424,36 @@ export const en = {
         partOne: "Governance action with id",
         partTwo: "does not exist.",
       },
+      type: {
+        noConfidence: {
+          title: "No Confidence",
+          label: "No Confidence",
+        },
+        newCommittee: {
+          title: "New Committee",
+          label: "New Committee",
+        },
+        newConstitution: {
+          title: "Update to the Constitution",
+          label: "Update to the Constitution",
+        },
+        hardFork: {
+          title: "Hard Fork",
+          label: "Hard Fork",
+        },
+        parameterChange: {
+          title: "Protocol Parameter Changes",
+          label: "Protocol Parameter Change",
+        },
+        treasuryWithdrawals: {
+          title: "Treasury Withdrawals",
+          label: "Treasury Withdrawal",
+        },
+        infoAction: {
+          title: "Info Action",
+          label: "Info Action",
+        },
+      },
     },
     hero: {
       connectWallet: "Connect your wallet",

--- a/govtool/frontend/src/utils/getProposalTypeLabel.ts
+++ b/govtool/frontend/src/utils/getProposalTypeLabel.ts
@@ -1,5 +1,10 @@
 import { GOVERNANCE_ACTIONS_FILTERS } from "@consts";
 
+export const getProposalTypeTitle = (type: string) => {
+  const title = GOVERNANCE_ACTIONS_FILTERS.find((i) => i.key === type)?.title;
+  return title || type;
+};
+
 export const getProposalTypeLabel = (type: string) => {
   const label = GOVERNANCE_ACTIONS_FILTERS.find((i) => i.key === type)?.label;
   return label || type;

--- a/govtool/frontend/src/utils/tests/getProposalTypeLabel.test.ts
+++ b/govtool/frontend/src/utils/tests/getProposalTypeLabel.test.ts
@@ -9,7 +9,7 @@ describe("getProposalTypeLabel", () => {
 
   it("returns correct label for another known type", () => {
     const type = "ParameterChange";
-    const expectedLabel = "Protocol Parameter Changes";
+    const expectedLabel = "Protocol Parameter Change";
     expect(getProposalTypeLabel(type)).toBe(expectedLabel);
   });
 

--- a/govtool/frontend/src/utils/tests/getProposalTypeNoEmptySpaces.test.ts
+++ b/govtool/frontend/src/utils/tests/getProposalTypeNoEmptySpaces.test.ts
@@ -9,7 +9,7 @@ describe("getProposalTypeNoEmptySpaces", () => {
 
   it("returns correct label with no spaces for another known type", () => {
     const type = "ParameterChange";
-    const expectedLabel = "ProtocolParameterChanges";
+    const expectedLabel = "ProtocolParameterChange";
     expect(getProposalTypeNoEmptySpaces(type)).toBe(expectedLabel);
   });
 


### PR DESCRIPTION
## List of changes

- correct wrong plural forms of GAs types

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/651)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [x] I have added tests that prove my fix is effective or that my feature works
