### PR TITLE
[#655] fix: fix DRep registration when the DRep name is longer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ changes.
 
 - Integrate frontend with metadata validation service [Issue 617](https://github.com/IntersectMBO/govtool/issues/617)
 - Implement a loading modal for the validation of the metadata [Issue 646](https://github.com/IntersectMBO/govtool/issues/646)
+- Change style of url button to trim the file name [Issue 655](https://github.com/IntersectMBO/govtool/issues/655)
+- Change regex for parsing urls to match urls without protocol [Issue 655](https://github.com/IntersectMBO/govtool/issues/655)
 
 ### Added
 

--- a/govtool/frontend/src/components/organisms/CreateGovernanceActionSteps/StorageInformation.tsx
+++ b/govtool/frontend/src/components/organisms/CreateGovernanceActionSteps/StorageInformation.tsx
@@ -35,9 +35,10 @@ export const StorageInformation = ({ setStep }: StorageInformationProps) => {
 
   const fileName = getValues("governance_action_type");
 
-  // TODO: Change link to correct
   const openGuideAboutStoringInformation = () =>
-    openInNewTab("https://sancho.network/");
+    openInNewTab(
+      "https://docs.sanchogov.tools/faqs/how-to-create-a-metadata-anchor",
+    );
 
   const isActionButtonDisabled = !watch("storingURL") || !!errors.storingURL;
 
@@ -120,25 +121,6 @@ export const StorageInformation = ({ setStep }: StorageInformationProps) => {
         />
         <Spacer y={6} />
         <Step
-          component={
-            <Button
-              endIcon={
-                <OpenInNewIcon
-                  sx={{
-                    color: "primary",
-                    height: 17,
-                    width: 17,
-                  }}
-                />
-              }
-              onClick={openGuideAboutStoringInformation}
-              size="extraLarge"
-              sx={{ width: "fit-content" }}
-              variant="text"
-            >
-              {t("createGovernanceAction.storingInformationStep2Link")}
-            </Button>
-          }
           label={t("createGovernanceAction.storingInformationStep2Label")}
           stepNumber={2}
         />

--- a/govtool/frontend/src/components/organisms/EditDRepInfoSteps/EditDRepStorageInformation.tsx
+++ b/govtool/frontend/src/components/organisms/EditDRepInfoSteps/EditDRepStorageInformation.tsx
@@ -35,9 +35,10 @@ export const EditDRepStorageInformation = ({
 
   const fileName = getValues("dRepName");
 
-  // TODO: Change link to correct
   const openGuideAboutStoringInformation = () =>
-    openInNewTab("https://sancho.network/");
+    openInNewTab(
+      "https://docs.sanchogov.tools/faqs/how-to-create-a-metadata-anchor",
+    );
 
   const isActionButtonDisabled = !watch("storingURL") || !!errors.storingURL;
 

--- a/govtool/frontend/src/components/organisms/RegisterAsDRepSteps/DRepStorageInformation.tsx
+++ b/govtool/frontend/src/components/organisms/RegisterAsDRepSteps/DRepStorageInformation.tsx
@@ -11,7 +11,7 @@ import {
 } from "@hooks";
 import { Step } from "@molecules";
 import { BgCard, ControlledField } from "@organisms";
-import { openInNewTab } from "@utils";
+import { openInNewTab, ellipsizeText } from "@utils";
 
 type StorageInformationProps = {
   setStep: Dispatch<SetStateAction<number>>;
@@ -35,9 +35,10 @@ export const DRepStorageInformation = ({
 
   const fileName = getValues("dRepName");
 
-  // TODO: Change link to correct
   const openGuideAboutStoringInformation = () =>
-    openInNewTab("https://sancho.network/");
+    openInNewTab(
+      "https://docs.sanchogov.tools/faqs/how-to-create-a-metadata-anchor",
+    );
 
   const isActionButtonDisabled = !watch("storingURL") || !!errors.storingURL;
 
@@ -93,7 +94,7 @@ export const DRepStorageInformation = ({
               }}
               variant="outlined"
             >
-              {`${fileName}.jsonld`}
+              {`${ellipsizeText(fileName, 8)}.jsonld`}
             </Button>
           }
           label={t("registration.storingInformationStep1Label")}

--- a/govtool/frontend/src/components/organisms/VoteContext/VoteContextStoringInformation.tsx
+++ b/govtool/frontend/src/components/organisms/VoteContext/VoteContextStoringInformation.tsx
@@ -34,9 +34,10 @@ export const VoteContextStoringInformation = ({
     onClickDownloadJson,
   } = useVoteContextForm(setSavedHash, setStep, setErrorMessage);
 
-  // TODO: Change link to correct
   const openGuideAboutStoringInformation = () =>
-    openInNewTab("https://sancho.network/");
+    openInNewTab(
+      "https://docs.sanchogov.tools/faqs/how-to-create-a-metadata-anchor",
+    );
 
   const isContinueDisabled = !watch("storingURL");
 

--- a/govtool/frontend/src/consts/governanceAction/fields.ts
+++ b/govtool/frontend/src/consts/governanceAction/fields.ts
@@ -19,6 +19,12 @@ export const sharedGovernanceActionFields: SharedGovernanceActionFieldSchema = {
     placeholderI18nKey:
       "createGovernanceAction.fields.declarations.title.placeholder",
     rules: {
+      maxLength: {
+        value: 80,
+        message: I18n.t("createGovernanceAction.fields.validations.maxLength", {
+          maxLength: 80,
+        }),
+      },
       required: {
         value: true,
         message: I18n.t("createGovernanceAction.fields.validations.required"),

--- a/govtool/frontend/src/hooks/forms/useRegisterAsdRepForm.tsx
+++ b/govtool/frontend/src/hooks/forms/useRegisterAsdRepForm.tsx
@@ -15,7 +15,12 @@ import {
 } from "@consts";
 import { useCardano, useModal } from "@context";
 import { MetadataValidationStatus } from "@models";
-import { canonizeJSON, downloadJson, generateJsonld } from "@utils";
+import {
+  canonizeJSON,
+  downloadJson,
+  ellipsizeText,
+  generateJsonld,
+} from "@utils";
 
 import { useGetVoterInfo } from "..";
 import { useValidateMutation } from "../mutations";
@@ -110,7 +115,7 @@ export const useRegisterAsdRepForm = (
   const onClickDownloadJson = async () => {
     if (!json) return;
 
-    downloadJson(json, dRepName);
+    downloadJson(json, ellipsizeText(dRepName, 16, ""));
   };
 
   const validateHash = useCallback(

--- a/govtool/frontend/src/utils/ellipsizeText.ts
+++ b/govtool/frontend/src/utils/ellipsizeText.ts
@@ -1,0 +1,12 @@
+export const ellipsizeText = (
+  text: string,
+  maxLength: number,
+  ellipsize = "...",
+) => {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  const slicedText = text.slice(0, maxLength);
+
+  return `${slicedText.trimEnd()}${ellipsize}`;
+};

--- a/govtool/frontend/src/utils/index.ts
+++ b/govtool/frontend/src/utils/index.ts
@@ -7,6 +7,7 @@ export * from "./canonizeJSON";
 export * from "./checkIsMaintenanceOn";
 export * from "./checkIsWalletConnected";
 export * from "./dRep";
+export * from "./ellipsizeText";
 export * from "./formatDate";
 export * from "./generateAnchor";
 export * from "./generateJsonld";

--- a/govtool/frontend/src/utils/isValidFormat.ts
+++ b/govtool/frontend/src/utils/isValidFormat.ts
@@ -1,15 +1,15 @@
 export const URL_REGEX =
-  /^(?!.*\s)(ipfs:\/\/[a-zA-Z0-9]+|https?:\/\/(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|[^/\s]+?\.[a-zA-Z]{2,})[^\s]*)/;
+  /^(?:(?:https?:\/\/)?(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,})(?:\/[^\s]*)?)|(?:ipfs:\/\/[a-f0-9]+(?:\/[a-zA-Z0-9_]+)*)$|^$/;
 export const HASH_REGEX = /^[0-9A-Fa-f]+$/;
 export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 export const NICKNAME_REGEX = /^\S+$/;
 
 export function isValidURLFormat(str: string) {
-  if (!str.length) return true;
+  if (!str.length) return false;
   return URL_REGEX.test(str);
 }
 
 export function isValidHashFormat(str: string) {
-  if (!str.length) return true;
+  if (!str.length) return false;
   return HASH_REGEX.test(str);
 }

--- a/govtool/frontend/src/utils/tests/ellipsizeText.test.ts
+++ b/govtool/frontend/src/utils/tests/ellipsizeText.test.ts
@@ -1,0 +1,22 @@
+import { ellipsizeText } from "../ellipsizeText";
+
+describe("ellipsizeText", () => {
+  it("should return the original text if it is shorter than or equal to maxLength", () => {
+    const text = "Hello, World!";
+    const maxLength = 20;
+
+    const result = ellipsizeText(text, maxLength);
+
+    expect(result).toEqual(text);
+  });
+
+  it("should return the ellipsized text if it is longer than maxLength", () => {
+    const text = "This is a long text that needs to be ellipsized.";
+    const maxLength = 8;
+    const expected = "This is...";
+
+    const result = ellipsizeText(text, maxLength);
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/govtool/frontend/src/utils/tests/isValidFormat.test.ts
+++ b/govtool/frontend/src/utils/tests/isValidFormat.test.ts
@@ -11,6 +11,11 @@ describe("isValidURLFormat", () => {
     expect(isValidURLFormat(validHttpsUrl)).toBe(true);
   });
 
+  it("returns true for valid URL without protocol", () => {
+    const validUrl = "example.com";
+    expect(isValidURLFormat(validUrl)).toBe(true);
+  });
+
   it("returns true for valid HTTPS URLs with IP", () => {
     const validHttpsUrl = "http://192.168.0.1/resoruce";
     expect(isValidURLFormat(validHttpsUrl)).toBe(true);
@@ -37,9 +42,9 @@ describe("isValidURLFormat", () => {
     expect(isValidURLFormat(notUrl)).toBe(false);
   });
 
-  it("returns true for empty string", () => {
+  it("returns false for empty string", () => {
     const empty = "";
-    expect(isValidURLFormat(empty)).toBe(true);
+    expect(isValidURLFormat(empty)).toBe(false);
   });
 });
 
@@ -59,8 +64,8 @@ describe("isValidHashFormat", () => {
     expect(isValidHashFormat(invalidHash)).toBe(false);
   });
 
-  it("returns true for empty string", () => {
+  it("returns false for empty string", () => {
     const empty = "";
-    expect(isValidHashFormat(empty)).toBe(true);
+    expect(isValidHashFormat(empty)).toBe(false);
   });
 });


### PR DESCRIPTION
## List of changes

- Change style of url button to trim the file name
- Change regex for parsing urls to match urls without protocol

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/655)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [x] I have added tests that prove my fix is effective or that my feature works
