### PR TITLE
[#693] Troubleshooting loading resources from Google Tag Manager due to CSP issue

### DIFF
--- a/scripts/govtool/config/templates/docker-compose.yml.tpl
+++ b/scripts/govtool/config/templates/docker-compose.yml.tpl
@@ -250,7 +250,7 @@ services:
       - "traefik.http.routers.frontend.rule=Host(`<DOMAIN>`)"
       - "traefik.http.routers.frontend.entrypoints=websecure"
       - "traefik.http.routers.frontend.tls.certresolver=myresolver"
-      - "traefik.http.middlewares.frontend-csp.headers.contentSecurityPolicy=default-src 'self'; img-src *.usersnap.com 'self' data:; script-src *.usersnap.com 'self' 'unsafe-inline' https://www.googletagmanager.com https://browser.sentry-cdn.com; style-src *.usersnap.com *.googleapis.com 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src *.usersnap.com https://s3.eu-central-1.amazonaws.com/upload.usersnap.com 'self' o4506155985141760.ingest.sentry.io *.google-analytics.com; font-src *.usersnap.com *.gstatic.com 'self' 'unsafe-inline' https://fonts.gstatic.com; worker-src blob:"
+      - "traefik.http.middlewares.frontend-csp.headers.contentSecurityPolicy=default-src 'self'; img-src *.usersnap.com *.googletagmanager.com *.gstatic.com 'self' data:; script-src *.usersnap.com 'self' 'unsafe-inline' *.googletagmanager.com *.gstatic.com https://browser.sentry-cdn.com; style-src *.usersnap.com *.googleapis.com *.gstatic.com 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src *.usersnap.com https://s3.eu-central-1.amazonaws.com/upload.usersnap.com 'self' o4506155985141760.ingest.sentry.io *.google-analytics.com; font-src *.usersnap.com *.gstatic.com 'self' 'unsafe-inline'; worker-src blob:"
       - "traefik.http.routers.frontend.middlewares=frontend-csp@docker"
       - "traefik.http.services.frontend.loadbalancer.server.port=80"
 


### PR DESCRIPTION
Closes #693.

To address the problem of loading resources from Google Tag Manager caused by Content Security Policy (CSP) restrictions in Traefik, this pull request aims to adjust the CSP settings. The issue originated from a misconception that Google Tag Manager did not serve images, resulting in missing configurations in Traefik. By explicitly permitting images from Google Tag Manager in the CSP settings, the loading problem will be resolved, enabling successful resource retrieval from Google Tag Manager.

The commit updates the Traefik version to v2.11 in the docker-compose.yml template to ensure compatibility with the necessary CSP changes. This modification facilitates a seamless integration of the adjusted CSP settings, allowing resources to be loaded from Google Tag Manager without any hindrances.
