### PR TITLE
[#689] add tx hash to the ada-holder/get-current-delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ changes.
 
 ### Added
 
+- added drepView and txHash to the `ada-holder/get-current-delegation` [Issue 689](https://github.com/IntersectMBO/govtool/issues/689)
 - addded latestTxHash to the `drep/info` and `drep/list` endpoints [Issue 627](https://github.com/IntersectMBO/govtool/issues/627)
 - added `txHash` to `drep/getVotes` [Issue 626](https://github.com/IntersectMBO/govtool/issues/626)
 - added `references` to all proposal related endpoints

--- a/govtool/backend/sql/get-current-delegation.sql
+++ b/govtool/backend/sql/get-current-delegation.sql
@@ -1,9 +1,12 @@
 select
   case
-    when drep_hash.raw is NULL then drep_hash.view
+    when drep_hash.raw is NULL then NULL
     else encode(drep_hash.raw,'hex')
-  end
+  end as drep_raw,
+  drep_hash.view as drep_view,
+  encode(tx.hash, 'hex')
 from delegation_vote
+join tx on tx.id = delegation_vote.tx_id
 join drep_hash
 on drep_hash.id = delegation_vote.drep_hash_id
 join stake_address

--- a/govtool/backend/src/VVA/API/Types.hs
+++ b/govtool/backend/src/VVA/API/Types.hs
@@ -692,8 +692,25 @@ instance ToSchema DRep where
             & example
               ?~ toJSON exampleDrep
 
+data DelegationResponse
+  = DelegationResponse
+      { delegationResponseDRepHash       :: Maybe HexText
+      , delegationResponseDRepView       :: Text
+      , delegationResponseTxHash         :: HexText
+      }
+deriveJSON (jsonOptions "delegationResponse") ''DelegationResponse
 
+exampleDelegationResponse :: Text
+exampleDelegationResponse = "{\"drepHash\": \"b4e4184bfedf920fec53cdc327de4da661ae427784c0ccca9e3c2f50\","
+                          <> "\"drepView\": \"drep1l8uyy66sm8u82h82gc8hkcy2xu24dl8ffsh58aa0v7d37yp48u8\","
+                          <> "\"txHash\": \"47c14a128cd024f1b990c839d67720825921ad87ed875def42641ddd2169b39c\"}"
 
+instance ToSchema DelegationResponse where
+    declareNamedSchema _ = pure $ NamedSchema (Just "DelegationResponse") $ mempty
+        & type_ ?~ OpenApiObject
+        & description ?~ "Delegation Response"
+        & example
+          ?~ toJSON exampleDelegationResponse
 
 data GetNetworkMetricsResponse
   = GetNetworkMetricsResponse

--- a/govtool/backend/src/VVA/Types.hs
+++ b/govtool/backend/src/VVA/Types.hs
@@ -128,7 +128,7 @@ data CacheEnv
       , getProposalCache                   :: Cache.Cache (Text, Integer) Proposal
       , currentEpochCache                  :: Cache.Cache () (Maybe Value)
       , adaHolderVotingPowerCache          :: Cache.Cache Text Integer
-      , adaHolderGetCurrentDelegationCache :: Cache.Cache Text (Maybe Text)
+      , adaHolderGetCurrentDelegationCache :: Cache.Cache Text (Maybe Delegation)
       , dRepGetVotesCache                  :: Cache.Cache Text ([Vote], [Proposal])
       , dRepInfoCache                      :: Cache.Cache Text DRepInfo
       , dRepVotingPowerCache               :: Cache.Cache Text Integer
@@ -148,4 +148,11 @@ data NetworkMetrics
       , networkMetricsTotalRegisteredDReps          :: Integer
       , networkMetricsAlwaysAbstainVotingPower      :: Integer
       , networkMetricsAlwaysNoConfidenceVotingPower :: Integer
+      }
+
+data Delegation
+  = Delegation
+      { delegationDRepHash :: Maybe Text
+      , delegationDRepView :: Text
+      , delegationTxHash   :: Text
       }


### PR DESCRIPTION
Extend the  endpoint by providing both drepHash and drepView, and tx hash of the delegation

- Add
ada-holder/get-current-delegation now returns json with drepHash, drepView and txHash

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/689)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
