### PR TITLE
[#688] split latest txHash in drep/info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ changes.
 
 ### Changed
 
+- `drep/info` now returns 4 different tx hashes instead of one latest tx hash [Issue 688](https://github.com/IntersectMBO/govtool/issues/688)
 - `proposal/list` allows user to search by tx hash [Issue 603](https://github.com/IntersectMBO/govtool/issues/603)
 - `proposal/list` returns additional data such ass `expiryEpochNo`, `createdEpochNo`, `title`, `about`, `motivation`,
   `rationale`. `TreasuryWithdrawals` GAs also got nicely formated details. [Issue 372](https://github.com/IntersectMBO/govtool/issues/372)

--- a/govtool/backend/sql/get-drep-info.sql
+++ b/govtool/backend/sql/get-drep-info.sql
@@ -2,11 +2,27 @@ WITH DRepId AS (
     SELECT
         decode(?, 'hex') AS raw
 ),
+AllRegistrationEntries AS (
+    SELECT
+        drep_registration.voting_anchor_id AS voting_anchor_id,
+        drep_registration.deposit AS deposit,
+        tx.hash AS tx_hash,
+        tx.id as tx_id
+    FROM
+        drep_registration
+        CROSS JOIN DRepId
+        JOIN drep_hash ON drep_hash.id = drep_registration.drep_hash_id
+        JOIN tx ON tx.id = drep_registration.tx_id
+
+    WHERE
+        drep_hash.raw = DRepId.raw
+    ORDER BY drep_registration.tx_id asc
+),
 LatestRegistrationEntry AS (
     SELECT
         drep_registration.voting_anchor_id AS voting_anchor_id,
         drep_registration.deposit AS deposit,
-        tx.hash as tx_hash
+        tx.hash AS tx_hash
     FROM
         drep_registration
         CROSS JOIN DrepId
@@ -20,14 +36,16 @@ LatestRegistrationEntry AS (
 ),
 IsRegisteredAsDRep AS (
     SELECT
-        (LatestRegistrationEntry.deposit is null or LatestRegistrationEntry.deposit > 0)
+        (LatestRegistrationEntry.deposit IS NULL
+            OR LatestRegistrationEntry.deposit > 0)
         AND LatestRegistrationEntry.voting_anchor_id IS NOT NULL AS value
     FROM
         LatestRegistrationEntry
 ),
 IsRegisteredAsSoleVoter AS (
     SELECT
-        (LatestRegistrationEntry.deposit is null or LatestRegistrationEntry.deposit > 0)
+        (LatestRegistrationEntry.deposit IS NULL
+            OR LatestRegistrationEntry.deposit > 0)
         AND LatestRegistrationEntry.voting_anchor_id IS NULL AS value
     FROM
         LatestRegistrationEntry
@@ -37,13 +55,11 @@ CurrentDeposit AS (
         GREATEST(drep_registration.deposit, 0) AS value
 FROM
     drep_registration
-    join drep_hash
-    on drep_hash.id = drep_registration.drep_hash_id
-    cross join DRepId
-
+    JOIN drep_hash ON drep_hash.id = drep_registration.drep_hash_id
+        CROSS JOIN DRepId
     WHERE
         drep_registration.deposit IS NOT NULL
-        and drep_hash.raw = DRepId.raw
+        AND drep_hash.raw = DRepId.raw
     ORDER BY
         drep_registration.tx_id DESC
     LIMIT 1
@@ -73,20 +89,79 @@ WasRegisteredAsSoleVoter AS (
                 WHERE
                     drep_hash.raw = DRepId.raw
                     AND drep_registration.voting_anchor_id IS NULL)) AS value
-), CurrentMetadata AS (
-    SELECT voting_anchor.url as url, encode(voting_anchor.data_hash, 'hex') as data_hash
-    FROM LatestRegistrationEntry
-    LEFT JOIN voting_anchor
-    ON voting_anchor.id = LatestRegistrationEntry.voting_anchor_id
+),
+CurrentMetadata AS (
+    SELECT
+        voting_anchor.url AS url,
+        encode(voting_anchor.data_hash, 'hex') AS data_hash
+FROM
+    LatestRegistrationEntry
+    LEFT JOIN voting_anchor ON voting_anchor.id = LatestRegistrationEntry.voting_anchor_id
+LIMIT 1
+),
+CurrentVotingPower AS (
+    SELECT
+        amount AS amount
+    FROM
+        drep_hash
+        JOIN DRepId ON drep_hash.raw = DRepId.raw
+        LEFT JOIN drep_distr ON drep_distr.hash_id = drep_hash.id
+    ORDER BY
+        drep_distr.epoch_no DESC
     LIMIT 1
-), CurrentVotingPower AS (
-    SELECT amount as amount
-    FROM drep_hash
-    JOIN DRepId
-    ON drep_hash.raw = DRepId.raw
-    LEFT JOIN drep_distr
-    ON drep_distr.hash_id = drep_hash.id
-    ORDER BY drep_distr.epoch_no DESC
+),
+DRepRegister AS (
+    SELECT
+        encode(AllRegistrationEntries.tx_hash, 'hex') as tx_hash,
+        AllRegistrationEntries.tx_id
+    FROM
+        (SELECT 1) AS dummy
+    LEFT JOIN
+        AllRegistrationEntries ON AllRegistrationEntries.voting_anchor_id IS NOT NULL and not (coalesce(deposit,0) < 0)
+    ORDER BY
+        AllRegistrationEntries.tx_id DESC
+    LIMIT 1
+),
+DRepRetire AS (
+    SELECT
+        encode(AllRegistrationEntries.tx_hash, 'hex') as tx_hash,
+        AllRegistrationEntries.tx_id
+    FROM
+        DRepRegister
+    LEFT JOIN
+        AllRegistrationEntries ON AllRegistrationEntries.deposit < 0
+            OR AllRegistrationEntries.voting_anchor_id IS NULL
+    WHERE AllRegistrationEntries.tx_id > DRepRegister.tx_id
+    ORDER BY
+        AllRegistrationEntries.tx_id asc
+
+    LIMIT 1
+),
+
+SoleVoterRegister AS (
+    SELECT
+        encode(AllRegistrationEntries.tx_hash, 'hex') as tx_hash,
+        AllRegistrationEntries.tx_id
+    FROM
+        (SELECT 1) AS dummy
+    LEFT JOIN
+        AllRegistrationEntries ON AllRegistrationEntries.voting_anchor_id IS NULL and not (coalesce(deposit,0) < 0)
+    ORDER BY
+        AllRegistrationEntries.tx_id DESC
+    LIMIT 1
+),
+SoleVoterRetire AS (
+    SELECT
+        encode(AllRegistrationEntries.tx_hash, 'hex') as tx_hash
+    FROM
+        SoleVoterRegister
+    LEFT JOIN
+        AllRegistrationEntries ON AllRegistrationEntries.deposit < 0
+            OR AllRegistrationEntries.voting_anchor_id IS NOT NULL
+    WHERE AllRegistrationEntries.tx_id > SoleVoterRegister.tx_id
+    ORDER BY
+        AllRegistrationEntries.tx_id asc
+
     LIMIT 1
 )
 SELECT
@@ -98,7 +173,10 @@ SELECT
     CurrentMetadata.url,
     CurrentMetadata.data_hash,
     CurrentVotingPower.amount,
-    encode(LatestRegistrationEntry.tx_hash, 'hex') as tx_hash
+    DRepRegister.tx_hash,
+    DRepRetire.tx_hash,
+    SoleVoterRegister.tx_hash,
+    SoleVoterRetire.tx_hash
 FROM
     IsRegisteredAsDRep
     CROSS JOIN IsRegisteredAsSoleVoter
@@ -107,4 +185,7 @@ FROM
     CROSS JOIN CurrentDeposit
     CROSS JOIN CurrentMetadata
     CROSS JOIN CurrentVotingPower
-    CROSS JOIN LatestRegistrationEntry
+    CROSS JOIN DRepRegister
+    CROSS JOIN DRepRetire
+    CROSS JOIN SoleVoterRegister
+    CROSS JOIN SoleVoterRetire

--- a/govtool/backend/src/VVA/API.hs
+++ b/govtool/backend/src/VVA/API.hs
@@ -211,7 +211,10 @@ drepInfo (unHexText -> dRepId) = do
     , dRepInfoResponseUrl = dRepInfoUrl
     , dRepInfoResponseDataHash = HexText <$> dRepInfoDataHash
     , dRepInfoResponseVotingPower = dRepInfoVotingPower
-    , dRepInfoResponseLatestTxHash = HexText <$> dRepInfoLatestTxHash
+    , dRepInfoResponseDRepRegisterTxHash = HexText <$> dRepInfoDRepRegisterTx
+    , dRepInfoResponseDRepRetireTxHash = HexText <$> dRepInfoDRepRetireTx
+    , dRepInfoResponseSoleVoterRegisterTxHash = HexText <$> dRepInfoSoleVoterRegisterTx
+    , dRepInfoResponseSoleVoterRetireTxHash = HexText <$> dRepInfoSoleVoterRetireTx
     }
 
 getCurrentDelegation :: App m => HexText -> m (Maybe HexText)

--- a/govtool/backend/src/VVA/API/Types.hs
+++ b/govtool/backend/src/VVA/API/Types.hs
@@ -466,7 +466,10 @@ data DRepInfoResponse
       , dRepInfoResponseUrl                      :: Maybe Text
       , dRepInfoResponseDataHash                 :: Maybe HexText
       , dRepInfoResponseVotingPower              :: Maybe Integer
-      , dRepInfoResponseLatestTxHash             :: Maybe HexText
+      , dRepInfoResponseDRepRegisterTxHash       :: Maybe HexText
+      , dRepInfoResponseDRepRetireTxHash         :: Maybe HexText
+      , dRepInfoResponseSoleVoterRegisterTxHash  :: Maybe HexText
+      , dRepInfoResponseSoleVoterRetireTxHash    :: Maybe HexText
       }
   deriving (Generic, Show)
 
@@ -482,7 +485,10 @@ exampleDRepInfoResponse =
   <> "\"url\": \"https://drep.metadata.xyz\","
   <> "\"dataHash\": \"9af10e89979e51b8cdc827c963124a1ef4920d1253eef34a1d5cfe76438e3f11\","
   <> "\"votingPower\": 1000000,"
-  <> "\"latestTxHash\": \"47c14a128cd024f1b990c839d67720825921ad87ed875def42641ddd2169b39c\"}"
+  <> "\"dRepRegisterTxHash\": \"47c14a128cd024f1b990c839d67720825921ad87ed875def42641ddd2169b39c\","
+  <> "\"dRepRetireTxHash\": \"47c14a128cd024f1b990c839d67720825921ad87ed875def42641ddd2169b39c\","
+  <> "\"soleVoterRegisterTxHash\": \"47c14a128cd024f1b990c839d67720825921ad87ed875def42641ddd2169b39c\","
+  <> "\"soleVoterRetireTxHash\": \"47c14a128cd024f1b990c839d67720825921ad87ed875def42641ddd2169b39c\"}"
 
 instance ToSchema DRepInfoResponse where
   declareNamedSchema proxy = do

--- a/govtool/backend/src/VVA/DRep.hs
+++ b/govtool/backend/src/VVA/DRep.hs
@@ -117,7 +117,10 @@ getDRepInfo drepId = withPool $ \conn -> do
       , url
       , dataHash
       , votingPower
-      , txHash
+      , drepRegisterTx
+      , drepRetireTx
+      , soleVoterRegisterTx
+      , soleVoterRetireTx
       )] ->
       return $ DRepInfo
         { dRepInfoIsRegisteredAsDRep = fromMaybe False isRegisteredAsDRep
@@ -128,6 +131,9 @@ getDRepInfo drepId = withPool $ \conn -> do
         , dRepInfoUrl = url
         , dRepInfoDataHash = dataHash
         , dRepInfoVotingPower = votingPower
-        , dRepInfoLatestTxHash = Just txHash
+        , dRepInfoDRepRegisterTx = drepRegisterTx
+        , dRepInfoDRepRetireTx = drepRetireTx
+        , dRepInfoSoleVoterRegisterTx = soleVoterRegisterTx
+        , dRepInfoSoleVoterRetireTx = soleVoterRetireTx
         }
-    [] -> return $ DRepInfo False False False False Nothing Nothing Nothing Nothing Nothing
+    [] -> return $ DRepInfo False False False False Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing

--- a/govtool/backend/src/VVA/Types.hs
+++ b/govtool/backend/src/VVA/Types.hs
@@ -75,7 +75,10 @@ data DRepInfo
       , dRepInfoUrl                      :: Maybe Text
       , dRepInfoDataHash                 :: Maybe Text
       , dRepInfoVotingPower              :: Maybe Integer
-      , dRepInfoLatestTxHash             :: Maybe Text
+      , dRepInfoDRepRegisterTx           :: Maybe Text
+      , dRepInfoDRepRetireTx             :: Maybe Text
+      , dRepInfoSoleVoterRegisterTx      :: Maybe Text
+      , dRepInfoSoleVoterRetireTx        :: Maybe Text
       }
 
 data DRepStatus = Retired | Active | Inactive


### PR DESCRIPTION
## List of changes

- Change
`latestTxHash` from `drep/info` changed to 4 different tx hashes

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/688)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
