### PR TITLE
[#720] fix drep/info null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ changes.
 
 ### Fixed
 
+- drep/info no longer returns null values [Issue 720](https://github.com/IntersectMBO/govtool/issues/720)
 - drep/getVotes no longer returns 500 [Issue 685](https://github.com/IntersectMBO/govtool/issues/685)
 - drep/info no longer returns 500 [Issue 676](https://github.com/IntersectMBO/govtool/issues/676)
 - proposal/list search is case insensitive now [Issue 582](https://github.com/IntersectMBO/govtool/issues/582)

--- a/govtool/backend/sql/get-drep-info.sql
+++ b/govtool/backend/sql/get-drep-info.sql
@@ -125,13 +125,13 @@ DRepRegister AS (
 DRepRetire AS (
     SELECT
         encode(AllRegistrationEntries.tx_hash, 'hex') as tx_hash,
-        AllRegistrationEntries.tx_id
+        AllRegistrationEntries.tx_id as tx_id
     FROM
         DRepRegister
     LEFT JOIN
-        AllRegistrationEntries ON AllRegistrationEntries.deposit < 0
-            OR AllRegistrationEntries.voting_anchor_id IS NULL
-    WHERE AllRegistrationEntries.tx_id > DRepRegister.tx_id
+        AllRegistrationEntries ON (AllRegistrationEntries.deposit < 0
+            OR AllRegistrationEntries.voting_anchor_id IS NULL)
+            and  AllRegistrationEntries.tx_id > DRepRegister.tx_id
     ORDER BY
         AllRegistrationEntries.tx_id asc
 
@@ -156,9 +156,9 @@ SoleVoterRetire AS (
     FROM
         SoleVoterRegister
     LEFT JOIN
-        AllRegistrationEntries ON AllRegistrationEntries.deposit < 0
-            OR AllRegistrationEntries.voting_anchor_id IS NOT NULL
-    WHERE AllRegistrationEntries.tx_id > SoleVoterRegister.tx_id
+        AllRegistrationEntries ON (AllRegistrationEntries.deposit < 0
+            OR AllRegistrationEntries.voting_anchor_id IS NOT NULL)
+            AND AllRegistrationEntries.tx_id > SoleVoterRegister.tx_id
     ORDER BY
         AllRegistrationEntries.tx_id asc
 


### PR DESCRIPTION
## List of changes

Fixed bug where drep/info returns null values for dreps that should have actual non-null values

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/720)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
