### PR TITLE
feat/464-missing-info-icon-next-to-the-ga-type-already-assigned

### DIFF
--- a/govtool/frontend/src/components/organisms/CreateGovernanceActionSteps/ChooseGovernanceActionType.tsx
+++ b/govtool/frontend/src/components/organisms/CreateGovernanceActionSteps/ChooseGovernanceActionType.tsx
@@ -1,5 +1,6 @@
 import { Dispatch, SetStateAction } from "react";
 import { ActionRadio, Spacer, Typography } from "@atoms";
+import { GovernanceActionTootlip } from "@consts";
 import {
   useCreateGovernanceActionForm,
   useScreenDimension,
@@ -34,7 +35,6 @@ export const ChooseGovernanceActionType = ({
     setValue("governance_action_type", value as GovernanceActionType);
   };
 
-  // TODO: Add tooltips when they will be available
   const renderGovernanceActionTypes = () =>
     Object.keys(GovernanceActionType).map(
       (type, index, governanceActionTypes) => {
@@ -46,6 +46,10 @@ export const ChooseGovernanceActionType = ({
               onChange={onChangeType}
               title={type}
               value={type}
+              tooltipTitle={type}
+              tooltipText={
+                GovernanceActionTootlip[type as GovernanceActionType]
+              }
             />
             {index + 1 < governanceActionTypes.length ? <Spacer y={2} /> : null}
           </div>

--- a/govtool/frontend/src/consts/governanceAction/fields.ts
+++ b/govtool/frontend/src/consts/governanceAction/fields.ts
@@ -7,6 +7,11 @@ import {
   SharedGovernanceActionFieldSchema,
 } from "@/types/governanceAction";
 
+export const GovernanceActionTootlip = {
+  Info: I18n.t("govActions.tooltips.info"),
+  Treasury: I18n.t("govActions.tooltips.treasury"),
+};
+
 export const CIP_100 =
   "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#";
 export const CIP_108 =

--- a/govtool/frontend/src/i18n/locales/en.ts
+++ b/govtool/frontend/src/i18n/locales/en.ts
@@ -424,6 +424,10 @@ export const en = {
         partOne: "Governance action with id",
         partTwo: "does not exist.",
       },
+      tooltips: {
+        info: "An action that has no effect on-chain, other than an on-chain record",
+        treasury: "Withdrawals from the treasury",
+      },
       type: {
         noConfidence: {
           title: "No Confidence",


### PR DESCRIPTION
## List of changes

-  add tooltips for gov actions

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
