### PR TITLE
[#714] Updating and restarting Cardano infrastructure on SanchoNet

### DIFF
--- a/scripts/govtool/Makefile
+++ b/scripts/govtool/Makefile
@@ -8,7 +8,7 @@ include config.mk
 
 # image tags
 cardano_node_image_tag := 8.10.0-pre
-cardano_db_sync_image_tag := sancho-4.1.0
+cardano_db_sync_image_tag := sancho-4-2-0
 
 .PHONY: all
 all: deploy-stack notify


### PR DESCRIPTION
Closes #714.

This pull request aims to update the Cardano DB Sync component on SanchoNet from version "sancho-4.1.0" to "sancho-4.2.0" by modifying the image tag in the Makefile. By making this change, the DB Sync element will be effectively updated to the new version, ensuring that the network remains current and operates efficiently.