### PR TITLE
[#714] Update Cardano DB Sync with fixed configuration files

### DIFF
--- a/scripts/govtool/Makefile
+++ b/scripts/govtool/Makefile
@@ -8,7 +8,7 @@ include config.mk
 
 # image tags
 cardano_node_image_tag := 8.10.0-pre
-cardano_db_sync_image_tag := sancho-4-2-0
+cardano_db_sync_image_tag := sancho-4-2-1
 
 .PHONY: all
 all: deploy-stack notify


### PR DESCRIPTION
The PR updates the Cardano DB Sync component in the Makefile by changing the image tag from "sancho-4-2-0" to "sancho-4-2-1." This adjustment ensures that the DB Sync is now set to the correct version, addressing any previously encountered issues and guaranteeing the proper functioning of the network on SanchoNet.

This was necesary since there was an issue with the previous build with non parsing configuration.