### PR TITLE
[#742] Missing context for the status service fails deploy to dev

### DIFF
--- a/govtool/metadata-validation/Makefile
+++ b/govtool/metadata-validation/Makefile
@@ -1,0 +1,21 @@
+common_mk := ../../scripts/govtool/common.mk
+ifeq ($(origin $(common_mk)), undefined)
+  $(eval $(common_mk) := included)
+  include $(common_mk)
+endif
+
+.DEFAULT_GOAL := push-metadata-validation
+
+# image tags
+metadata_validation_image_tag := $(shell git log -n 1 --format="%H" -- $(root_dir)/govtool/metadata-validation)
+
+.PHONY: build-metadata-validation
+build-metadata-validation: docker-login
+	$(call check_image_on_ecr,metadata-validation,$(metadata_validation_image_tag)) || \
+	$(docker) build --tag "$(repo_url)/metadata-validation:$(metadata_validation_image_tag)" \
+		$(root_dir)/govtool/metadata-validation
+
+.PHONY: push-metadata-validation
+push-metadata-validation: build-metadata-validation
+	$(call check_image_on_ecr,metadata-validation,$(metadata_validation_image_tag)) || \
+	$(docker) push $(repo_url)/metadata-validation:$(metadata_validation_image_tag)

--- a/govtool/status-service/Makefile
+++ b/govtool/status-service/Makefile
@@ -1,0 +1,21 @@
+common_mk := ../../scripts/govtool/common.mk
+ifeq ($(origin $(common_mk)), undefined)
+  $(eval $(common_mk) := included)
+  include $(common_mk)
+endif
+
+.DEFAULT_GOAL := push-status-service
+
+# image tags
+status_service_image_tag := $(shell git log -n 1 --format="%H" -- $(root_dir)/govtool/status-service)
+
+.PHONY: build-status-service
+build-status-service: docker-login
+	$(call check_image_on_ecr,status-service,$(status_service_image_tag)) || \
+	$(docker) build --tag "$(repo_url)/status-service:$(status_service_image_tag)" \
+		$(root_dir)/govtool/status-service
+
+.PHONY: push-status-service
+push-status-service: build-status-service
+	$(call check_image_on_ecr,status-service,$(status_service_image_tag)) || \
+	$(docker) push $(repo_url)/status-service:$(status_service_image_tag)

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -31,6 +31,11 @@ module "govtool-ecr-status-service" {
   repo_name = "status-service"
 }
 
+module "govtool-ecr-metadata-validation" {
+  source    = "./modules/ecr"
+  repo_name = "metadata-validation"
+}
+
 resource "aws_iam_policy" "cicd_ecr" {
   name = "CICD_ECR"
   policy = jsonencode({
@@ -45,7 +50,8 @@ resource "aws_iam_policy" "cicd_ecr" {
           module.govtool-ecr-backend.repo_arn,
           module.govtool-ecr-backend-base.repo_arn,
           module.govtool-ecr-frontend.repo_arn,
-          module.govtool-ecr-status-service.repo_arn
+          module.govtool-ecr-status-service.repo_arn,
+          module.govtool-ecr-metadata-validation.repo_arn
         ]
       },
       {
@@ -113,6 +119,10 @@ output "govtool-ecr-frontend-url" {
 
 output "govtool-ecr-status-service-url" {
   value = module.govtool-ecr-status-service.repo_url
+}
+
+output "govtool-ecr-metadata-validation-url" {
+  value = module.govtool-ecr-metadata-validation.repo_url
 }
 
 output "govtool-dev-sanchonet-frontend-domain" {

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -26,6 +26,11 @@ module "govtool-ecr-frontend" {
   repo_name = "frontend"
 }
 
+module "govtool-ecr-status-service" {
+  source    = "./modules/ecr"
+  repo_name = "status-service"
+}
+
 resource "aws_iam_policy" "cicd_ecr" {
   name = "CICD_ECR"
   policy = jsonencode({
@@ -39,7 +44,8 @@ resource "aws_iam_policy" "cicd_ecr" {
         Resource = [
           module.govtool-ecr-backend.repo_arn,
           module.govtool-ecr-backend-base.repo_arn,
-          module.govtool-ecr-frontend.repo_arn
+          module.govtool-ecr-frontend.repo_arn,
+          module.govtool-ecr-status-service.repo_arn
         ]
       },
       {
@@ -103,6 +109,10 @@ output "govtool-ecr-backend-base-url" {
 
 output "govtool-ecr-frontend-url" {
   value = module.govtool-ecr-frontend.repo_url
+}
+
+output "govtool-ecr-status-service-url" {
+  value = module.govtool-ecr-status-service.repo_url
 }
 
 output "govtool-dev-sanchonet-frontend-domain" {

--- a/scripts/govtool/Makefile
+++ b/scripts/govtool/Makefile
@@ -1,5 +1,6 @@
 include ../../govtool/backend/Makefile
 include ../../govtool/frontend/Makefile
+include ../../govtool/status-service/Makefile
 include utils.mk
 include info.mk
 include config.mk
@@ -14,7 +15,7 @@ cardano_db_sync_image_tag := sancho-4-2-1
 all: deploy-stack notify
 
 .PHONY: deploy-stack
-deploy-stack: upload-config push-backend push-frontend
+deploy-stack: upload-config push-backend push-frontend push-status-service
 	@:$(call check_defined, cardano_network)
 	@:$(call check_defined, env)
 	export CARDANO_NETWORK=$(cardano_network); \
@@ -23,6 +24,7 @@ deploy-stack: upload-config push-backend push-frontend
 	export GRAFANA_ADMIN_PASSWORD=$${GRAFANA_ADMIN_PASSWORD}; \
 	export BACKEND_TAG=$(backend_image_tag); \
 	export FRONTEND_TAG=$(frontend_image_tag); \
+	export STATUS_SERVICE_TAG=$(status_service_image_tag); \
 	export CARDANO_NODE_TAG=$(cardano_node_image_tag); \
 	export CARDANO_DB_SYNC_TAG=$(cardano_db_sync_image_tag); \
 	$(ssh-keyscan) $(docker_host) 2>/dev/null >> ~/.ssh/known_hosts; \
@@ -37,6 +39,7 @@ destroy-cardano-node-and-dbsync: prepare-config
 	export ENVIRONMENT=$(env); \
 	export BACKEND_TAG=$(backend_image_tag); \
 	export FRONTEND_TAG=$(frontend_image_tag); \
+	export STATUS_SERVICE_TAG=$(status_service_image_tag); \
 	export CARDANO_NODE_TAG=$(cardano_node_image_tag); \
 	export CARDANO_DB_SYNC_TAG=$(cardano_db_sync_image_tag); \
 	$(ssh-keyscan) $(docker_host) 2>/dev/null >> ~/.ssh/known_hosts; \
@@ -56,6 +59,7 @@ toggle-maintenance: docker-login prepare-config
 	export DOCKER_HOST=ssh://$(ssh_url); \
 	export BACKEND_TAG=$(backend_image_tag); \
 	export FRONTEND_TAG=$(frontend_image_tag); \
+	export STATUS_SERVICE_TAG=$(status_service_image_tag); \
 	export CARDANO_NODE_TAG=$(cardano_node_image_tag); \
 	export CARDANO_DB_SYNC_TAG=$(cardano_db_sync_image_tag); \
 	$(ssh-keyscan) $(docker_host) 2>/dev/null >> ~/.ssh/known_hosts; \

--- a/scripts/govtool/Makefile
+++ b/scripts/govtool/Makefile
@@ -1,6 +1,7 @@
 include ../../govtool/backend/Makefile
 include ../../govtool/frontend/Makefile
 include ../../govtool/status-service/Makefile
+include ../../govtool/metadata-validation/Makefile
 include utils.mk
 include info.mk
 include config.mk
@@ -15,7 +16,7 @@ cardano_db_sync_image_tag := sancho-4-2-1
 all: deploy-stack notify
 
 .PHONY: deploy-stack
-deploy-stack: upload-config push-backend push-frontend push-status-service
+deploy-stack: upload-config push-backend push-frontend push-status-service push-metadata-validation
 	@:$(call check_defined, cardano_network)
 	@:$(call check_defined, env)
 	export CARDANO_NETWORK=$(cardano_network); \
@@ -25,6 +26,7 @@ deploy-stack: upload-config push-backend push-frontend push-status-service
 	export BACKEND_TAG=$(backend_image_tag); \
 	export FRONTEND_TAG=$(frontend_image_tag); \
 	export STATUS_SERVICE_TAG=$(status_service_image_tag); \
+	export METADATA_VALIDATION_TAG=$(metadata_validation_image_tag); \
 	export CARDANO_NODE_TAG=$(cardano_node_image_tag); \
 	export CARDANO_DB_SYNC_TAG=$(cardano_db_sync_image_tag); \
 	$(ssh-keyscan) $(docker_host) 2>/dev/null >> ~/.ssh/known_hosts; \
@@ -40,6 +42,7 @@ destroy-cardano-node-and-dbsync: prepare-config
 	export BACKEND_TAG=$(backend_image_tag); \
 	export FRONTEND_TAG=$(frontend_image_tag); \
 	export STATUS_SERVICE_TAG=$(status_service_image_tag); \
+	export METADATA_VALIDATION_TAG=$(metadata_validation_image_tag); \
 	export CARDANO_NODE_TAG=$(cardano_node_image_tag); \
 	export CARDANO_DB_SYNC_TAG=$(cardano_db_sync_image_tag); \
 	$(ssh-keyscan) $(docker_host) 2>/dev/null >> ~/.ssh/known_hosts; \
@@ -60,6 +63,7 @@ toggle-maintenance: docker-login prepare-config
 	export BACKEND_TAG=$(backend_image_tag); \
 	export FRONTEND_TAG=$(frontend_image_tag); \
 	export STATUS_SERVICE_TAG=$(status_service_image_tag); \
+	export METADATA_VALIDATION_TAG=$(metadata_validation_image_tag); \
 	export CARDANO_NODE_TAG=$(cardano_node_image_tag); \
 	export CARDANO_DB_SYNC_TAG=$(cardano_db_sync_image_tag); \
 	$(ssh-keyscan) $(docker_host) 2>/dev/null >> ~/.ssh/known_hosts; \

--- a/scripts/govtool/config/templates/docker-compose.yml.tpl
+++ b/scripts/govtool/config/templates/docker-compose.yml.tpl
@@ -168,8 +168,7 @@ services:
     logging: *logging
 
   status-service:
-    build:
-      context: ../../govtool/status-service
+    image: <REPO_URL>/status-service:${STATUS_SERVICE_TAG}
     environment:
       - GRAFANA_USERNAME=admin
       - GRAFANA_PASSWORD=${GRAFANA_ADMIN_PASSWORD}

--- a/scripts/govtool/config/templates/docker-compose.yml.tpl
+++ b/scripts/govtool/config/templates/docker-compose.yml.tpl
@@ -182,8 +182,7 @@ services:
       - "traefik.http.services.status-service.loadbalancer.server.port=8000"
 
   metadata-validation:
-    build:
-      context: ../../govtool/metadata-validation
+    image: <REPO_URL>/metadata-validation:${METADATA_VALIDATION_TAG}
     environment:
       - PORT=3000
     logging: *logging

--- a/scripts/govtool/info.mk
+++ b/scripts/govtool/info.mk
@@ -22,10 +22,11 @@ info:
 	@echo "|  TIME      $(shell date +'%Y-%m-%d %H:%M:%S%z')"
 	@echo "|  BRANCH    $(branch) [$(commit)]"
 	@echo "|  ENV       $(env)"
-	@echo "I  NETWORK   $(cardano_network)"
-	@echo "N  BACKEND   $(repo_url)/backend:$(backend_image_tag)"
-	@echo "F  FRONTEND  $(repo_url)/frontend:$(frontend_image_tag)"
-	@echo "O  NODE      ghcr.io/intersectmbo/cardano-node:$(cardano_node_image_tag)"
+	@echo "|  NETWORK   $(cardano_network)"
+	@echo "|  BACKEND   $(repo_url)/backend:$(backend_image_tag)"
+	@echo "|  FRONTEND  $(repo_url)/frontend:$(frontend_image_tag)"
+	@echo "|  STATUS    $(repo_url)/status-service:$(status_service_image_tag)"
+	@echo "|  NODE      ghcr.io/intersectmbo/cardano-node:$(cardano_node_image_tag)"
 	@echo "|  DBSYNC    ghcr.io/intersectmbo/cardano-db-sync:$(cardano_db_sync_image_tag)"
 	@echo "|  SSH       $(ssh_url)"
 	@echo "|  URL       https://$(docker_host)"
@@ -38,4 +39,4 @@ notify: info log-deployment
 	$(curl) -X POST https://slack.com/api/chat.postMessage\
 		-H "Authorization: Bearer $${GRAFANA_SLACK_OAUTH_TOKEN}" \
 		-H "Content-Type: application/json; charset=utf-8" \
-		--data "{ \"channel\":\"$${GRAFANA_SLACK_RECIPIENT}\", \"text\":\":rocket: *Deploy performed on \`$(env)\`*\n- from *branch* \`$(branch)\` (\`$(commit)\`),\n- using *Cardano Node* version \`$(cardano_node_image_tag)\`,\n- using *Cardano DB Sync* version \`$(cardano_db_sync_image_tag)\`,\n- using *GovTool backend* version \`$(backend_image_tag)\`,\n- using *Govtool frontend* version \`$(frontend_image_tag)\`.\n$(pipeline_info)\" }"
+		--data "{ \"channel\":\"$${GRAFANA_SLACK_RECIPIENT}\", \"text\":\":rocket: *Deploy performed on \`$(env)\`*\n- from *branch* \`$(branch)\` (\`$(commit)\`),\n- using *Cardano Node* version \`$(cardano_node_image_tag)\`,\n- using *Cardano DB Sync* version \`$(cardano_db_sync_image_tag)\`,\n- using *GovTool backend* version \`$(backend_image_tag)\`,\n- using *Govtool frontend* version \`$(frontend_image_tag)\`,\n- using *Govtool status-service* version \`$(status_service_image_tag)\`.\n$(pipeline_info)\" }"

--- a/scripts/govtool/info.mk
+++ b/scripts/govtool/info.mk
@@ -26,6 +26,7 @@ info:
 	@echo "|  BACKEND   $(repo_url)/backend:$(backend_image_tag)"
 	@echo "|  FRONTEND  $(repo_url)/frontend:$(frontend_image_tag)"
 	@echo "|  STATUS    $(repo_url)/status-service:$(status_service_image_tag)"
+	@echo "|  METADATA  $(repo_url)/metadata-validation:$(metadata_validation_image_tag)"
 	@echo "|  NODE      ghcr.io/intersectmbo/cardano-node:$(cardano_node_image_tag)"
 	@echo "|  DBSYNC    ghcr.io/intersectmbo/cardano-db-sync:$(cardano_db_sync_image_tag)"
 	@echo "|  SSH       $(ssh_url)"
@@ -39,4 +40,4 @@ notify: info log-deployment
 	$(curl) -X POST https://slack.com/api/chat.postMessage\
 		-H "Authorization: Bearer $${GRAFANA_SLACK_OAUTH_TOKEN}" \
 		-H "Content-Type: application/json; charset=utf-8" \
-		--data "{ \"channel\":\"$${GRAFANA_SLACK_RECIPIENT}\", \"text\":\":rocket: *Deploy performed on \`$(env)\`*\n- from *branch* \`$(branch)\` (\`$(commit)\`),\n- using *Cardano Node* version \`$(cardano_node_image_tag)\`,\n- using *Cardano DB Sync* version \`$(cardano_db_sync_image_tag)\`,\n- using *GovTool backend* version \`$(backend_image_tag)\`,\n- using *Govtool frontend* version \`$(frontend_image_tag)\`,\n- using *Govtool status-service* version \`$(status_service_image_tag)\`.\n$(pipeline_info)\" }"
+		--data "{ \"channel\":\"$${GRAFANA_SLACK_RECIPIENT}\", \"text\":\":rocket: *Deploy performed on \`$(env)\`*\n- from *branch* \`$(branch)\` (\`$(commit)\`),\n- using *Cardano Node* version \`$(cardano_node_image_tag)\`,\n- using *Cardano DB Sync* version \`$(cardano_db_sync_image_tag)\`,\n- using *GovTool backend* version \`$(backend_image_tag)\`,\n- using *Govtool frontend* version \`$(frontend_image_tag)\`,\n- using *Govtool status-service* version \`$(status_service_image_tag)\`,\n- using *Govtool metadata-validation* version \`$(metadata_validation_image_tag)\`.\n$(pipeline_info)\" }"

--- a/scripts/govtool/utils.mk
+++ b/scripts/govtool/utils.mk
@@ -15,6 +15,7 @@ docker-compose:
 	export BACKEND_TAG=$(backend_image_tag); \
 	export FRONTEND_TAG=$(frontend_image_tag); \
 	export STATUS_SERVICE_TAG=$(status_service_image_tag); \
+	export METADATA_VALIDATION_TAG=$(metadata_validation_image_tag); \
 	export CARDANO_NODE_TAG=$(cardano_node_image_tag); \
 	export CARDANO_DB_SYNC_TAG=$(cardano_db_sync_image_tag); \
 	$(ssh-keyscan) $(docker_host) 2>/dev/null >> ~/.ssh/known_hosts; \

--- a/scripts/govtool/utils.mk
+++ b/scripts/govtool/utils.mk
@@ -14,6 +14,7 @@ docker-compose:
 	export GRAFANA_ADMIN_PASSWORD=$${GRAFANA_ADMIN_PASSWORD}; \
 	export BACKEND_TAG=$(backend_image_tag); \
 	export FRONTEND_TAG=$(frontend_image_tag); \
+	export STATUS_SERVICE_TAG=$(status_service_image_tag); \
 	export CARDANO_NODE_TAG=$(cardano_node_image_tag); \
 	export CARDANO_DB_SYNC_TAG=$(cardano_db_sync_image_tag); \
 	$(ssh-keyscan) $(docker_host) 2>/dev/null >> ~/.ssh/known_hosts; \


### PR DESCRIPTION
Closes #742.

In response to the issue of failed deployments to the Dev environment due to missing context for the status-service, this pull request aims to address this by creating a status-service AWS registry. The goal is to ensure a successful deployment by providing the necessary context for the status-service. The changes are focused on integrating the status-service docker image utilization into the deploy stack, enabling a smooth deployment process to the Dev environment. Adjustments have been made in various files, such as `Makefile`, in `scripts/govtool/Makefile`, and `docker-compose.yml.tpl`, to incorporate the status-service registry details for optimized deployment functionality.
