### PR TITLE
fix: fix footer alignment across pages

### DIFF
--- a/govtool/frontend/src/components/molecules/CenteredBoxPageWrapper.tsx
+++ b/govtool/frontend/src/components/molecules/CenteredBoxPageWrapper.tsx
@@ -82,6 +82,8 @@ export const CenteredBoxPageWrapper: FC<PropsWithChildren<Props>> = ({
             </Box>
           </Box>
         </Box>
+        {/* FIXME: Footer should be on top of the layout.
+        Should not be rerendered across the pages */}
         <Footer />
       </Box>
     </Background>

--- a/govtool/frontend/src/components/organisms/DashboardTopNav.tsx
+++ b/govtool/frontend/src/components/organisms/DashboardTopNav.tsx
@@ -40,6 +40,7 @@ export const DashboardTopNav = ({
   return (
     <>
       <Box
+        component="nav"
         sx={{
           alignItems: "center",
           backdropFilter: "blur(10px)",

--- a/govtool/frontend/src/components/organisms/Footer.tsx
+++ b/govtool/frontend/src/components/organisms/Footer.tsx
@@ -46,58 +46,64 @@ export const Footer = () => {
   const onClickFeedback = () => openFeedbackWindow();
 
   return (
-    <Box
-      sx={{
-        alignItems: screenWidth < 640 ? undefined : "center",
-        display: "flex",
-        flexDirection: screenWidth < 640 ? "column" : "row",
-        justifyContent: "space-between",
-        px: screenWidth < 640 ? 2 : 5,
-        py: 2,
-      }}
-    >
-      <Typography fontWeight={500} variant="caption">
-        {t("footer.copyright")}
-      </Typography>
+    <>
+      {/* TODO: That box below should not be needed.
+      Footer should be aligned under shared Layout component */}
+      <Box sx={{ flex: 1 }} />
       <Box
+        component="footer"
         sx={{
+          alignItems: screenWidth < 640 ? undefined : "center",
           display: "flex",
-          flexDirection: "row",
-          gap: 3,
-          mt: screenWidth < 640 ? 1.5 : 0,
+          flexDirection: screenWidth < 640 ? "column" : "row",
+          justifyContent: "space-between",
+          px: screenWidth < 640 ? 2 : 5,
+          py: 2,
         }}
       >
-        <FooterLink
-          label={t("footer.privacyPolicy")}
-          onClick={onClickPrivacyPolicy}
-        />
-        <FooterLink
-          label={t("footer.termOfService")}
-          onClick={onClickTermOfService}
-        />
-      </Box>
-      <Box
-        sx={{
-          display: "flex",
-          flexDirection: "row",
-          gap: 3,
-          justifyContent: screenWidth < 640 ? "space-between" : undefined,
-          mt: screenWidth < 640 ? 1.5 : 0,
-        }}
-      >
-        <Button
-          onClick={onClickHelp}
-          size="small"
-          startIcon={<img alt="helpIcon" src={ICONS.helpIcon} />}
-          sx={{ color: "#26252D" }}
-          variant="text"
+        <Typography fontWeight={500} variant="caption">
+          {t("footer.copyright")}
+        </Typography>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            gap: 3,
+            mt: screenWidth < 640 ? 1.5 : 0,
+          }}
         >
-          {t("menu.help")}
-        </Button>
-        <Button onClick={onClickFeedback} size="small" variant="outlined">
-          {t("feedback")}
-        </Button>
+          <FooterLink
+            label={t("footer.privacyPolicy")}
+            onClick={onClickPrivacyPolicy}
+          />
+          <FooterLink
+            label={t("footer.termOfService")}
+            onClick={onClickTermOfService}
+          />
+        </Box>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            gap: 3,
+            justifyContent: screenWidth < 640 ? "space-between" : undefined,
+            mt: screenWidth < 640 ? 1.5 : 0,
+          }}
+        >
+          <Button
+            onClick={onClickHelp}
+            size="small"
+            startIcon={<img alt="helpIcon" src={ICONS.helpIcon} />}
+            sx={{ color: "#26252D" }}
+            variant="text"
+          >
+            {t("menu.help")}
+          </Button>
+          <Button onClick={onClickFeedback} size="small" variant="outlined">
+            {t("feedback")}
+          </Button>
+        </Box>
       </Box>
-    </Box>
+    </>
   );
 };

--- a/govtool/frontend/src/pages/ChooseStakeKey.tsx
+++ b/govtool/frontend/src/pages/ChooseStakeKey.tsx
@@ -11,6 +11,8 @@ export const ChooseStakeKey = () => (
       <Box display="flex" flex={1} justifyContent="center">
         <ChooseStakeKeyPanel />
       </Box>
+      {/* FIXME: Footer should be on top of the layout.
+          Should not be rerendered across the pages */}
       <Footer />
     </Box>
   </Background>

--- a/govtool/frontend/src/pages/CreateGovernanceAction.tsx
+++ b/govtool/frontend/src/pages/CreateGovernanceAction.tsx
@@ -88,6 +88,8 @@ export const CreateGovernanceAction = () => {
           {step === 5 && <StoreDataInfo setStep={setStep} />}
           {step === 6 && <StorageInformation setStep={setStep} />}
         </FormProvider>
+        {/* FIXME: Footer should be on top of the layout.
+        Should not be rerendered across the pages */}
         <Footer />
       </Box>
     </Background>

--- a/govtool/frontend/src/pages/DRepDirectory.tsx
+++ b/govtool/frontend/src/pages/DRepDirectory.tsx
@@ -38,6 +38,8 @@ export const DRepDirectory = () => {
             <Outlet />
           </ContentBox>
         </PagePaddingBox>
+        {/* FIXME: Footer should be on top of the layout.
+        Should not be rerendered across the pages */}
         <Footer />
       </Box>
     </Background>

--- a/govtool/frontend/src/pages/Dashboard.tsx
+++ b/govtool/frontend/src/pages/Dashboard.tsx
@@ -60,6 +60,8 @@ export const Dashboard = () => {
           <DashboardTopNav title={getPageTitle(window.location.pathname)} />
           <ScrollToManage />
           <Outlet />
+          {/* FIXME: Footer should be on top of the layout.
+          Should not be rerendered across the pages */}
           <Footer />
         </Box>
       </Box>

--- a/govtool/frontend/src/pages/EditDRepMetadata.tsx
+++ b/govtool/frontend/src/pages/EditDRepMetadata.tsx
@@ -82,6 +82,8 @@ export const EditDRepMetadata = () => {
           {step === 2 && <EditDRepStoreDataInfo setStep={setStep} />}
           {step === 3 && <EditDRepStorageInformation setStep={setStep} />}
         </FormProvider>
+        {/* FIXME: Footer should be on top of the layout.
+        Should not be rerendered across the pages */}
         <Footer />
       </Box>
     </Background>

--- a/govtool/frontend/src/pages/GovernanceActionDetails.tsx
+++ b/govtool/frontend/src/pages/GovernanceActionDetails.tsx
@@ -181,6 +181,8 @@ export const GovernanceActionDetails = () => {
             )}
           </Box>
         </Box>
+        {/* FIXME: Footer should be on top of the layout.
+        Should not be rerendered across the pages */}
         <Footer />
       </Box>
     </Background>

--- a/govtool/frontend/src/pages/GovernanceActions.tsx
+++ b/govtool/frontend/src/pages/GovernanceActions.tsx
@@ -100,6 +100,8 @@ export const GovernanceActions = () => {
             )}
           </Box>
         </Box>
+        {/* FIXME: Footer should be on top of the layout.
+        Should not be rerendered across the pages */}
         <Footer />
       </Box>
     </Background>

--- a/govtool/frontend/src/pages/GovernanceActionsCategory.tsx
+++ b/govtool/frontend/src/pages/GovernanceActionsCategory.tsx
@@ -173,6 +173,8 @@ export const GovernanceActionsCategory = () => {
             )}
           </Box>
         </Box>
+        {/* FIXME: Footer should be on top of the layout.
+        Should not be rerendered across the pages */}
         <Footer />
       </Box>
     </Background>

--- a/govtool/frontend/src/pages/Home.tsx
+++ b/govtool/frontend/src/pages/Home.tsx
@@ -24,6 +24,8 @@ export const Home = () => {
         <TopNav />
         <Hero />
         <HomeCards />
+        {/* FIXME: Footer should be on top of the layout.
+        Should not be rerendered across the pages */}
         <Footer />
       </Box>
     </Background>

--- a/govtool/frontend/src/pages/RegisterAsdRep.tsx
+++ b/govtool/frontend/src/pages/RegisterAsdRep.tsx
@@ -115,6 +115,8 @@ export const RegisterAsdRep = () => {
             </FormProvider>
           </>
         )}
+        {/* FIXME: Footer should be on top of the layout.
+        Should not be rerendered across the pages */}
         <Footer />
       </Box>
     </Background>

--- a/govtool/frontend/src/pages/RetireAsDrep.tsx
+++ b/govtool/frontend/src/pages/RetireAsDrep.tsx
@@ -41,6 +41,8 @@ export const RetireAsDrep = () => {
           }}
         />
         <WhatRetirementMeans onClickCancel={onClickBackToDashboard} />
+        {/* FIXME: Footer should be on top of the layout.
+        Should not be rerendered across the pages */}
         <Footer />
       </Box>
     </Background>


### PR DESCRIPTION
## List of changes

- add workaround box filling the area above the footer. Have in my mind that it can't be the final solution. We need to relayout the pages (that will be done with the composing architecture implementation). As current Footer is wrongly reused on multiple pages. That should not be needed.
