### PR TITLE
fix/861-drep-explorer-when-one-item-is-shown-show-more-button-is-also-shown-and-disappears-when-clicked

### DIFF
--- a/govtool/frontend/src/pages/DRepDirectoryContent.tsx
+++ b/govtool/frontend/src/pages/DRepDirectoryContent.tsx
@@ -193,7 +193,7 @@ export const DRepDirectoryContent: FC<DRepDirectoryContentProps> = ({
           })}
         </Box>
       </>
-      {dRepListHasNextPage && (
+      {dRepListHasNextPage && dRepList.length >= 10 && (
         <Box sx={{ justifyContent: "center", display: "flex" }}>
           <Button
             data-testid="show-more-button"


### PR DESCRIPTION
## List of changes

- fix show more button display

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
