### PR TITLE
[#876] add metadata/validate endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ changes.
 
 ### Added
 
+- added `metadata/validate` endpoint [Issue 876](https://github.com/IntersectMBO/govtool/issues/876)
 - added pagination to `drep/list` [Issue 756](https://github.com/IntersectMBO/govtool/issues/756)
 - added search query param to the `drep/getVotes` [Issue 640](https://github.com/IntersectMBO/govtool/issues/640)
 - added filtering and sorting capabilities to the `drep/list` [Issue 722](https://github.com/IntersectMBO/govtool/issues/722)

--- a/govtool/backend/example-config.json
+++ b/govtool/backend/example-config.json
@@ -9,5 +9,7 @@
     "port" : 9999,
     "host" : "localhost",
     "cachedurationseconds": 20,
-    "sentrydsn": "https://username:password@senty.host/id"
+    "sentrydsn": "https://username:password@senty.host/id",
+    "metadatavalidationhost": "localhost",
+    "metadatavalidationport": 3001
 }

--- a/govtool/backend/src/VVA/Config.hs
+++ b/govtool/backend/src/VVA/Config.hs
@@ -24,6 +24,8 @@ module VVA.Config
     , getServerHost
     , getServerPort
     , vvaConfigToText
+    , getMetadataValidationHost
+    , getMetadataValidationPort
     ) where
 
 import           Conferer
@@ -69,15 +71,19 @@ instance DefaultConfig DBConfig where
 data VVAConfigInternal
   = VVAConfigInternal
       { -- | db-sync database access.
-        vVAConfigInternalDbsyncconfig         :: DBConfig
+        vVAConfigInternalDbsyncconfig           :: DBConfig
         -- | Server port.
-      , vVAConfigInternalPort                 :: Int
+      , vVAConfigInternalPort                   :: Int
         -- | Server host.
-      , vVAConfigInternalHost                 :: Text
+      , vVAConfigInternalHost                   :: Text
         -- | Request cache duration
-      , vVaConfigInternalCacheDurationSeconds :: Int
+      , vVaConfigInternalCacheDurationSeconds   :: Int
         -- | Sentry DSN
-      , vVAConfigInternalSentrydsn            :: String
+      , vVAConfigInternalSentrydsn              :: String
+        -- | Metadata validation service host
+      , vVAConfigInternalMetadataValidationHost :: Text
+        -- | Metadata validation service port
+      , vVAConfigInternalMetadataValidationPort :: Int
       }
   deriving (FromConfig, Generic, Show)
 
@@ -88,7 +94,9 @@ instance DefaultConfig VVAConfigInternal where
         vVAConfigInternalPort = 3000,
         vVAConfigInternalHost = "localhost",
         vVaConfigInternalCacheDurationSeconds = 20,
-        vVAConfigInternalSentrydsn = "https://username:password@senty.host/id"
+        vVAConfigInternalSentrydsn = "https://username:password@senty.host/id",
+        vVAConfigInternalMetadataValidationHost = "localhost",
+        vVAConfigInternalMetadataValidationPort = 3001
       }
 
 -- | DEX configuration.
@@ -104,6 +112,10 @@ data VVAConfig
       , cacheDurationSeconds   :: Int
         -- | Sentry DSN
       , sentryDSN              :: String
+        -- | Metadata validation service host
+      , metadataValidationHost :: Text
+        -- | Metadata validation service port
+      , metadataValidationPort :: Int
       }
   deriving (Generic, Show, ToJSON)
 
@@ -143,7 +155,9 @@ convertConfig VVAConfigInternal {..} =
       serverPort = vVAConfigInternalPort,
       serverHost = vVAConfigInternalHost,
       cacheDurationSeconds = vVaConfigInternalCacheDurationSeconds,
-      sentryDSN = vVAConfigInternalSentrydsn
+      sentryDSN = vVAConfigInternalSentrydsn,
+      metadataValidationHost = vVAConfigInternalMetadataValidationHost,
+      metadataValidationPort = vVAConfigInternalMetadataValidationPort
     }
 
 -- | Load configuration from a file specified on the command line.  Load from
@@ -181,3 +195,15 @@ getServerHost ::
   (Has VVAConfig r, MonadReader r m) =>
   m Text
 getServerHost = asks (serverHost . getter)
+
+-- | Access MetadataValidationService host
+getMetadataValidationHost ::
+  (Has VVAConfig r, MonadReader r m) =>
+  m Text
+getMetadataValidationHost = asks (metadataValidationHost . getter)
+
+-- | Access MetadataValidationService port
+getMetadataValidationPort ::
+  (Has VVAConfig r, MonadReader r m) =>
+  m Int
+getMetadataValidationPort = asks (metadataValidationPort . getter)

--- a/govtool/backend/src/VVA/Metadata.hs
+++ b/govtool/backend/src/VVA/Metadata.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeApplications  #-}
+
+module VVA.Metadata where
+
+import           Control.Monad.Except       (MonadError, throwError)
+import           Control.Monad.Reader
+
+import           Data.Aeson                 (Value, decode)
+import           Data.Maybe                 (fromJust)
+import           Data.ByteString            (ByteString)
+import           Data.FileEmbed             (embedFile)
+import           Data.Has                   (Has, getter)
+import           Data.String                (fromString)
+import           Data.Text                  (Text, unpack)
+import qualified Data.Text.Encoding         as Text
+import           Data.Time.Clock
+
+import qualified Database.PostgreSQL.Simple as SQL
+
+import           VVA.Config
+import           VVA.Pool                   (ConnectionPool, withPool)
+import           VVA.Types
+import Network.HTTP.Client
+import Network.HTTP.Client.TLS
+import Data.Aeson (encode, object, (.=))
+
+validateMetadata
+    :: (Has VVAConfig r, Has Manager r, MonadReader r m, MonadIO m, MonadError AppError m)
+    => Text
+    -> Text
+    -> m Value
+validateMetadata url hash = do
+    metadataHost <- getMetadataValidationHost
+    metadataPort <- getMetadataValidationPort
+    manager <- asks getter
+    let requestBody = encode $ object ["url" .= unpack url, "hash" .= unpack hash]
+    initialRequest <- liftIO $ parseRequest (unpack metadataHost <> ":" <> show metadataPort <> "/validate")
+    let request = initialRequest
+            { method = "POST"
+            , requestBody = RequestBodyLBS requestBody
+            , requestHeaders = [("Content-Type", "application/json")]
+            }
+    response <- liftIO $ httpLbs request manager
+    return $ fromJust $ decode $ responseBody response

--- a/govtool/backend/vva-be.cabal
+++ b/govtool/backend/vva-be.cabal
@@ -114,3 +114,4 @@ library
                  , VVA.Pool
                  , VVA.Types
                  , VVA.Network
+                 , VVA.Metadata

--- a/govtool/frontend/src/models/metadataValidation.ts
+++ b/govtool/frontend/src/models/metadataValidation.ts
@@ -13,12 +13,7 @@ export type ValidateMetadataResult = {
   metadata?: any;
 };
 
-export enum MetadataStandard {
-  CIP108 = "CIP108",
-}
-
 export type MetadataValidationDTO = {
   url: string;
   hash: string;
-  standard?: MetadataStandard;
 };

--- a/govtool/frontend/src/services/API.ts
+++ b/govtool/frontend/src/services/API.ts
@@ -3,19 +3,11 @@ import { NavigateFunction } from "react-router-dom";
 
 import { PATHS } from "@consts";
 
-const TIMEOUT_IN_SECONDS = 30 * 1000; // 1000 ms is 1 s then its 10 s
+const TIMEOUT_IN_SECONDS = 30 * 1000; // 1000 ms is 1 s then its 30 s
 const BASE_URL = import.meta.env.VITE_BASE_URL;
 
-// Validation should be performed directly on the server
-// than no metadata service is needed and `/api` might be removed
 export const API = axios.create({
-  baseURL: `${BASE_URL}/api`,
-  timeout: TIMEOUT_IN_SECONDS,
-});
-
-// TODO: Remove this service and use the API service
-export const METADATA_VALIDATION_API = axios.create({
-  baseURL: `${BASE_URL}/metadata-validation`,
+  baseURL: `${BASE_URL}`,
   timeout: TIMEOUT_IN_SECONDS,
 });
 

--- a/govtool/frontend/src/services/API.ts
+++ b/govtool/frontend/src/services/API.ts
@@ -7,7 +7,7 @@ const TIMEOUT_IN_SECONDS = 30 * 1000; // 1000 ms is 1 s then its 30 s
 const BASE_URL = import.meta.env.VITE_BASE_URL;
 
 export const API = axios.create({
-  baseURL: `${BASE_URL}`,
+  baseURL: BASE_URL,
   timeout: TIMEOUT_IN_SECONDS,
 });
 

--- a/govtool/frontend/src/services/requests/metadataValidation/postValidate.ts
+++ b/govtool/frontend/src/services/requests/metadataValidation/postValidate.ts
@@ -1,9 +1,9 @@
 import type { MetadataValidationDTO, ValidateMetadataResult } from "@models";
-import { METADATA_VALIDATION_API } from "../../API";
+import { API } from "@services";
 
 export const postValidate = async (body: MetadataValidationDTO) => {
-  const response = await METADATA_VALIDATION_API.post<ValidateMetadataResult>(
-    `/validate`,
+  const response = await API.post<ValidateMetadataResult>(
+    `/metadata/validate`,
     body,
   );
 

--- a/govtool/frontend/src/utils/tests/validateMetadataHash.test.ts
+++ b/govtool/frontend/src/utils/tests/validateMetadataHash.test.ts
@@ -1,7 +1,7 @@
 import { vi } from "vitest";
 import { postValidate } from "@services";
 import { checkIsMissingGAMetadata } from "..";
-import { MetadataStandard, MetadataValidationStatus } from "@/models";
+import { MetadataValidationStatus } from "@/models";
 
 const url = "https://example.com";
 const hash = "abcdefg";
@@ -28,7 +28,6 @@ describe("checkIsMissingGAMetadata", () => {
     expect(mockPostValidate).toHaveBeenCalledWith({
       url,
       hash,
-      standard: MetadataStandard.CIP108,
     });
   });
 
@@ -44,7 +43,6 @@ describe("checkIsMissingGAMetadata", () => {
     expect(mockPostValidate).toHaveBeenCalledWith({
       url,
       hash,
-      standard: MetadataStandard.CIP108,
     });
   });
 
@@ -60,7 +58,6 @@ describe("checkIsMissingGAMetadata", () => {
     expect(mockPostValidate).toHaveBeenCalledWith({
       url,
       hash,
-      standard: MetadataStandard.CIP108,
     });
   });
 
@@ -73,7 +70,6 @@ describe("checkIsMissingGAMetadata", () => {
     expect(mockPostValidate).toHaveBeenCalledWith({
       url,
       hash,
-      standard: MetadataStandard.CIP108,
     });
   });
 });

--- a/govtool/frontend/src/utils/validateMetadataHash.ts
+++ b/govtool/frontend/src/utils/validateMetadataHash.ts
@@ -1,6 +1,6 @@
 import { postValidate } from "@services";
 
-import { MetadataStandard, MetadataValidationStatus } from "@/models";
+import { MetadataValidationStatus } from "@/models";
 
 type CheckIsMissingGAMetadataResponse = {
   status?: MetadataValidationStatus;
@@ -20,7 +20,6 @@ export const checkIsMissingGAMetadata = async ({
     const { status, metadata, valid } = await postValidate({
       url,
       hash,
-      standard: MetadataStandard.CIP108,
     });
     if (status) {
       return { status, valid };

--- a/govtool/metadata-validation/src/main.ts
+++ b/govtool/metadata-validation/src/main.ts
@@ -5,7 +5,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, { cors: true });
 
   const config = new DocumentBuilder()
     .setTitle('Submission Tool')


### PR DESCRIPTION
a/validate endpoint

## List of changes

Added
- `metadata/validate` endpoint (which under the hood calls /validate endpoint of metadata validation service)
- all endpoint's returning proposals now return additional field "metadataStatus"

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
