### PR TITLE
Fix/888 for sole voter view details button should be hidden

### DIFF
--- a/govtool/frontend/src/components/organisms/DRepCard.tsx
+++ b/govtool/frontend/src/components/organisms/DRepCard.tsx
@@ -145,20 +145,22 @@ export const DRepCard = ({
             },
           }}
         >
-          <Button
-            data-testid={`${view}-view-details-button`}
-            variant="outlined"
-            onClick={() =>
-              navigate(
-                (isConnected
-                  ? PATHS.dashboardDRepDirectoryDRep
-                  : PATHS.dRepDirectoryDRep
-                ).replace(":dRepId", view),
-              )
-            }
-          >
-            {t("viewDetails")}
-          </Button>
+          {type === "DRep" && (
+            <Button
+              data-testid={`${view}-view-details-button`}
+              variant="outlined"
+              onClick={() =>
+                navigate(
+                  (isConnected
+                    ? PATHS.dashboardDRepDirectoryDRep
+                    : PATHS.dRepDirectoryDRep
+                  ).replace(":dRepId", view),
+                )
+              }
+            >
+              {t("viewDetails")}
+            </Button>
+          )}
           {status === "Active" &&
             isConnected &&
             onDelegate &&


### PR DESCRIPTION
## List of changes

- fix show view details button only when drep 

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/888)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
