### PR TITLE
Fix building analytics image for multiple environments

### DIFF
--- a/scripts/govtool/analytics-dashboard.mk
+++ b/scripts/govtool/analytics-dashboard.mk
@@ -7,7 +7,7 @@ endif
 .DEFAULT_GOAL := push-analytics-dashboard
 
 # image tags
-analytics_dashboard_image_tag := $(shell git log -n 1 --format="%H" -- $(root_dir)/govtool/analytics-dashboard)
+analytics_dashboard_image_tag := $(shell git log -n 1 --format="%H" -- $(root_dir)/govtool/analytics-dashboard)-$(env)
 
 .PHONY: build-analytics-dashboard
 build-analytics-dashboard:


### PR DESCRIPTION
The PR modifies the script `analytics-dashboard.mk` in the `govtool` directory to address the issue of building the analytics image for multiple environments. Previously, the image tag was being generated based on the latest commit hash for the `analytics-dashboard`, which was not sufficient for distinguishing between different environments. To solve this, the script now appends the `$(env)` variable to the image tag, allowing for unique identification of images across various environments.

This addesses the CORS issue on test env.
