### PR TITLE
[#920 - bug 2] DRep details page Back button fix

### DIFF
--- a/govtool/frontend/src/components/organisms/DRepCard.tsx
+++ b/govtool/frontend/src/components/organisms/DRepCard.tsx
@@ -168,6 +168,7 @@ export const DRepCard = ({
                     ? PATHS.dashboardDRepDirectoryDRep
                     : PATHS.dRepDirectoryDRep
                   ).replace(":dRepId", view),
+                  { state: { enteredFromWithinApp: true } },
                 )
               }
             >

--- a/govtool/frontend/src/components/organisms/DashboardCards/DRepDashboardCard.tsx
+++ b/govtool/frontend/src/components/organisms/DashboardCards/DRepDashboardCard.tsx
@@ -42,7 +42,10 @@ export const DRepDashboardCard = ({
   };
 
   const navigateToDrepDirectory = () =>
-    navigate(PATHS.dashboardDRepDirectoryDRep.replace(":dRepId", dRepIDBech32));
+    navigate(
+      PATHS.dashboardDRepDirectoryDRep.replace(":dRepId", dRepIDBech32),
+      { state: { enteredFromWithinApp: true } },
+    );
 
   const cardProps: Partial<DashboardActionCardProps> = (() => {
     // transaction in progress

--- a/govtool/frontend/src/components/organisms/DashboardCards/DelegateDashboardCard.tsx
+++ b/govtool/frontend/src/components/organisms/DashboardCards/DelegateDashboardCard.tsx
@@ -104,6 +104,7 @@ export const DelegateDashboardCard = ({
           ":dRepId",
           displayedDelegationId || "",
         ),
+        { state: { enteredFromWithinApp: true } },
       ),
     [displayedDelegationId],
   );

--- a/govtool/frontend/src/i18n/locales/en.ts
+++ b/govtool/frontend/src/i18n/locales/en.ts
@@ -251,6 +251,7 @@ export const en = {
       editBtn: "Edit DRep data",
       delegationOptions: "Delegation Options",
       filterTitle: "DRep Status",
+      goToDRepDirectory: "Go to DRep Directory",
       meAsDRep: "This  DRep ID is connected  to your wallet",
       myDelegation: "You have delegated <strong>₳ {{ada}}</strong> to:",
       myDRep: "This is your DRep",

--- a/govtool/frontend/src/pages/DRepDetails.tsx
+++ b/govtool/frontend/src/pages/DRepDetails.tsx
@@ -76,12 +76,8 @@ export const DRepDetails = ({ isConnected }: DRepDetailsProps) => {
     <>
       <LinkWithIcon
         data-testid="back-to-list-button"
-        label={t("backToList")}
-        onClick={() =>
-          navigate(
-            isConnected ? PATHS.dashboardDRepDirectory : PATHS.dRepDirectory,
-          )
-        }
+        label={t("back")}
+        onClick={() => navigate(-1)}
         sx={{ mb: 2 }}
       />
       <Card

--- a/govtool/frontend/src/pages/DRepDetails.tsx
+++ b/govtool/frontend/src/pages/DRepDetails.tsx
@@ -1,5 +1,10 @@
 import { PropsWithChildren } from "react";
-import { Navigate, useNavigate, useParams } from "react-router-dom";
+import {
+  Navigate,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "react-router-dom";
 import { Box, ButtonBase, Chip, CircularProgress } from "@mui/material";
 
 import { Button, StatusPill, Typography } from "@atoms";
@@ -35,11 +40,13 @@ export const DRepDetails = ({ isConnected }: DRepDetailsProps) => {
   const { dRepID: myDRepId, pendingTransaction } = useCardano();
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
   const { openModal } = useModal();
   const { screenWidth } = useScreenDimension();
   const { dRepId: dRepParam } = useParams();
-
   const { delegate, isDelegating } = useDelegateTodRep();
+
+  const displayBackButton = location.state?.enteredFromWithinApp || false;
 
   const { dRepData, isDRepListLoading } = useGetDRepListInfiniteQuery({
     searchPhrase: dRepParam,
@@ -74,12 +81,25 @@ export const DRepDetails = ({ isConnected }: DRepDetailsProps) => {
 
   return (
     <>
-      <LinkWithIcon
-        data-testid="back-to-list-button"
-        label={t("back")}
-        onClick={() => navigate(-1)}
-        sx={{ mb: 2 }}
-      />
+      {displayBackButton ? (
+        <LinkWithIcon
+          data-testid="back-button"
+          label={t("back")}
+          onClick={() => navigate(-1)}
+          sx={{ mb: 2 }}
+        />
+      ) : (
+        <LinkWithIcon
+          data-testid="go-to-drep-directory-button"
+          label={t("dRepDirectory.goToDRepDirectory")}
+          onClick={() =>
+            navigate(
+              isConnected ? PATHS.dashboardDRepDirectory : PATHS.dRepDirectory,
+            )
+          }
+          sx={{ mb: 2 }}
+        />
+      )}
       <Card
         {...((isMe || isMyDrep) && {
           border: true,


### PR DESCRIPTION
## List of changes

- DRep details page Back button fix (bug 2 from [920](https://github.com/IntersectMBO/govtool/issues/920) - others done in different PRs)


## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/920)
- [x] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
