### PR TITLE
Set participation.sanchogov.tools domain to dev service only

### DIFF
--- a/.github/workflows/build-and-deploy-beta.yml
+++ b/.github/workflows/build-and-deploy-beta.yml
@@ -30,7 +30,7 @@ jobs:
       GTM_ID: ${{ secrets.GTM_ID }}
       IP_ADDRESS_BYPASSING_BASIC_AUTH1: ${{ secrets.IP_ADDRESS_BYPASSING_BASIC_AUTH1 }}
       IP_ADDRESS_BYPASSING_BASIC_AUTH2: ${{ secrets.IP_ADDRESS_BYPASSING_BASIC_AUTH2 }}
-      NEXT_PUBLIC_API_URL: "https://sanchogov.tools/api"
+      NEXT_PUBLIC_API_URL: "https://participation.sanchogov.tools"
       NEXT_PUBLIC_GA4_PROPERTY_ID: ${{ secrets.NEXT_PUBLIC_GA4_PROPERTY_ID }}
       NGINX_BASIC_AUTH: ${{ secrets.NGINX_BASIC_AUTH }}
       PIPELINE_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -29,7 +29,7 @@ jobs:
       GTM_ID: ${{ secrets.GTM_ID }}
       IP_ADDRESS_BYPASSING_BASIC_AUTH1: ${{ secrets.IP_ADDRESS_BYPASSING_BASIC_AUTH1 }}
       IP_ADDRESS_BYPASSING_BASIC_AUTH2: ${{ secrets.IP_ADDRESS_BYPASSING_BASIC_AUTH2 }}
-      NEXT_PUBLIC_API_URL: "https://dev-sanchonet.govtool.byron.network/api"
+      NEXT_PUBLIC_API_URL: "https://participation.sanchogov.tools"
       NEXT_PUBLIC_GA4_PROPERTY_ID: ${{ secrets.NEXT_PUBLIC_GA4_PROPERTY_ID }}
       NGINX_BASIC_AUTH: ${{ secrets.NGINX_BASIC_AUTH }}
       PIPELINE_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -31,7 +31,7 @@ jobs:
       GTM_ID: ${{ secrets.GTM_ID }}
       IP_ADDRESS_BYPASSING_BASIC_AUTH1: ${{ secrets.IP_ADDRESS_BYPASSING_BASIC_AUTH1 }}
       IP_ADDRESS_BYPASSING_BASIC_AUTH2: ${{ secrets.IP_ADDRESS_BYPASSING_BASIC_AUTH2 }}
-      NEXT_PUBLIC_API_URL: "https://staging.govtool.byron.network/api"
+      NEXT_PUBLIC_API_URL: "https://participation.sanchogov.tools"
       NEXT_PUBLIC_GA4_PROPERTY_ID: ${{ secrets.NEXT_PUBLIC_GA4_PROPERTY_ID }}
       NGINX_BASIC_AUTH: ${{ secrets.NGINX_BASIC_AUTH }}
       PIPELINE_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/build-and-deploy-test.yml
+++ b/.github/workflows/build-and-deploy-test.yml
@@ -31,7 +31,7 @@ jobs:
       GTM_ID: ${{ secrets.GTM_ID }}
       IP_ADDRESS_BYPASSING_BASIC_AUTH1: ${{ secrets.IP_ADDRESS_BYPASSING_BASIC_AUTH1 }}
       IP_ADDRESS_BYPASSING_BASIC_AUTH2: ${{ secrets.IP_ADDRESS_BYPASSING_BASIC_AUTH2 }}
-      NEXT_PUBLIC_API_URL: "https://test-sanchonet.govtool.byron.network/api"
+      NEXT_PUBLIC_API_URL: "https://participation.sanchogov.tools"
       NEXT_PUBLIC_GA4_PROPERTY_ID: ${{ secrets.NEXT_PUBLIC_GA4_PROPERTY_ID }}
       NGINX_BASIC_AUTH: ${{ secrets.NGINX_BASIC_AUTH }}
       PIPELINE_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/govtool/analytics-dashboard/Dockerfile
+++ b/govtool/analytics-dashboard/Dockerfile
@@ -17,6 +17,7 @@ RUN \
 
 # Rebuild the source code only when needed
 FROM base AS builder
+# Set the build arguments
 ARG NEXT_PUBLIC_API_URL
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules

--- a/scripts/govtool/config/templates/docker-compose.yml.tpl
+++ b/scripts/govtool/config/templates/docker-compose.yml.tpl
@@ -214,7 +214,6 @@ services:
     environment:
       - GA_CLIENT_EMAIL=${GA_CLIENT_EMAIL}
       - GA_PRIVATE_KEY=${GA_PRIVATE_KEY}
-      - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}
       - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/google-credentials.json
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
       - NEXT_PUBLIC_GA4_PROPERTY_ID=${NEXT_PUBLIC_GA4_PROPERTY_ID}
@@ -225,7 +224,7 @@ services:
     restart: always
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.to-analytics-dashboard.rule=Host(`participation.<DOMAIN>`)"
+      - "traefik.http.routers.to-analytics-dashboard.rule=Host(`participation.sanchogov.tools`)"
       - "traefik.http.routers.to-analytics-dashboard.entrypoints=websecure"
       - "traefik.http.routers.to-analytics-dashboard.tls.certresolver=myresolver"
       - "traefik.http.services.analytics-dashboard.loadbalancer.server.port=3000"


### PR DESCRIPTION
The purpose of this pull request is to adjust the configuration of the participation.sanchogov.tools domain so that it exclusively directs traffic to the dev service. This change has implications on various environments such as beta, staging, and test, as well as on the Dockerfile and Docker Compose configuration related to the analytics dashboard.

These modifications result in a setup where requests made to the participation.sanchogov.tools domain are routed solely to the dev service. This enhances the manageability and separation of development and production environments, ensuring that the dev service receives all relevant traffic directed to this domain. Additionally, it streamlines the development process by focusing traffic for testing and development purposes.

https://participation.sanchogov.tools/en