### PR TITLE
[#907] Move DRep yourself card to top in DRep Directory

### DIFF
--- a/govtool/frontend/src/pages/DRepDirectoryContent.tsx
+++ b/govtool/frontend/src/pages/DRepDirectoryContent.tsx
@@ -58,6 +58,11 @@ export const DRepDirectoryContent: FC<DRepDirectoryContentProps> = ({
   );
   const myDrep = myDRepList?.[0];
 
+  const { dRepData: yourselfDRepList } = useGetDRepListInfiniteQuery({
+    searchPhrase: myDRepId,
+  });
+  const yourselfDRep = yourselfDRepList?.[0];
+
   const {
     dRepData: dRepList,
     isPreviousData,
@@ -84,6 +89,13 @@ export const DRepDirectoryContent: FC<DRepDirectoryContentProps> = ({
 
   const ada = correctAdaFormat(votingPower);
 
+  const dRepsWithoutYourself = dRepList?.filter(
+    (dRep) => !isSameDRep(dRep, myDRepId),
+  );
+  const dRepListToDisplay = yourselfDRep
+    ? [yourselfDRep, ...dRepsWithoutYourself]
+    : dRepList;
+
   return (
     <Box display="flex" flex={1} flexDirection="column" gap={4}>
       {/* My delegation */}
@@ -96,6 +108,7 @@ export const DRepDirectoryContent: FC<DRepDirectoryContentProps> = ({
             dRep={myDrep}
             isConnected={!!isConnected}
             isInProgress={isSameDRep(myDrep, inProgressDelegation)}
+            isMe={isSameDRep(myDrep, myDRepId)}
           />
         </div>
       )}
@@ -175,7 +188,7 @@ export const DRepDirectoryContent: FC<DRepDirectoryContentProps> = ({
               </Typography>
             </Card>
           )}
-          {dRepList?.map((dRep) => {
+          {dRepListToDisplay?.map((dRep) => {
             if (isSameDRep(dRep, myDrep?.view)) {
               return null;
             }


### PR DESCRIPTION
## List of changes

- DRep yourself card moved to the top of the list in DRep Directory

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/907)
- [x] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
