### PR TITLE
Bump version of Cardano Node and Cardano DB Sync in personal stack

### DIFF
--- a/scripts/govtool/docker-compose.node+dbsync.yml
+++ b/scripts/govtool/docker-compose.node+dbsync.yml
@@ -51,7 +51,7 @@ services:
       retries: 5
 
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:8.8.0-pre
+    image: ghcr.io/intersectmbo/cardano-node:8.10.0-pre
     environment:
       - NETWORK=sanchonet
     volumes:
@@ -65,7 +65,7 @@ services:
       retries: 10
 
   cardano-db-sync:
-    image: ghcr.io/intersectmbo/cardano-db-sync:sancho-4.1.0
+    image: ghcr.io/intersectmbo/cardano-db-sync:sancho-4-2-1
     environment:
       - NETWORK=sanchonet
       - POSTGRES_HOST=postgres


### PR DESCRIPTION
In this pull request, the Cardano Node and Cardano DB Sync versions in the personal stack configuration have been updated. The change involves modifying the Cardano Node image tag from "8.8.0-pre" to "8.10.0-pre," and the Cardano DB Sync image tag from "sancho-4.1.0" to "sancho-4-2-1." These version updates are necessary to ensure that the stack is running with the latest features and improvements. 

These changes will result in the personal stack configuration utilizing the updated versions of Cardano Node and Cardano DB Sync, enhancing performance, security, and compatibility with the latest developments in the Cardano ecosystem. Keeping the software up-to-date is crucial for ensuring smooth operation and access to new features and enhancements provided by the newer versions.

