### PR TITLE
fix/929-drep-links-are-appended-to-govtool-url

### DIFF
--- a/govtool/frontend/src/pages/DRepDetails.tsx
+++ b/govtool/frontend/src/pages/DRepDetails.tsx
@@ -175,9 +175,11 @@ export const DRepDetails = ({ isConnected }: DRepDetailsProps) => {
           </DRepDetailsInfoItem>
           {/* TODO: fetch metadata, add views for metadata errors */}
           <DRepDetailsInfoItem label={t("email")}>
+            {/* TODO: change email*/}
             <MoreInfoLink
               label="darlenelonglink.DRepwebsiteorwhatever.com"
-              navTo="google.com"
+              navTo="example@gmail.com"
+              isEmail
             />
           </DRepDetailsInfoItem>
           <DRepDetailsInfoItem label={t("moreInformation")}>
@@ -187,8 +189,13 @@ export const DRepDetails = ({ isConnected }: DRepDetailsProps) => {
               flexDirection="column"
               gap={1.5}
             >
+              {/* TODO: update links*/}
               {LINKS.map((link) => (
-                <MoreInfoLink key={link} label={link} navTo={link} />
+                <MoreInfoLink
+                  key={link}
+                  label={link}
+                  navTo="https://sancho.network/"
+                />
               ))}
             </Box>
           </DRepDetailsInfoItem>
@@ -299,10 +306,12 @@ const DRepId = ({ children }: PropsWithChildren) => (
 type LinkWithIconProps = {
   label: string;
   navTo: string;
+  isEmail?: boolean;
 };
 
-const MoreInfoLink = ({ label, navTo }: LinkWithIconProps) => {
-  const openLink = () => openInNewTab(navTo);
+const MoreInfoLink = ({ label, navTo, isEmail = false }: LinkWithIconProps) => {
+  const openLink = () =>
+    isEmail ? window.location.assign(`mailto:${navTo}`) : openInNewTab(navTo);
 
   return (
     <ButtonBase

--- a/govtool/frontend/src/pages/DRepDetails.tsx
+++ b/govtool/frontend/src/pages/DRepDetails.tsx
@@ -175,7 +175,7 @@ export const DRepDetails = ({ isConnected }: DRepDetailsProps) => {
           </DRepDetailsInfoItem>
           {/* TODO: fetch metadata, add views for metadata errors */}
           <DRepDetailsInfoItem label={t("email")}>
-            {/* TODO: change email*/}
+            {/* TODO: change email */}
             <MoreInfoLink
               label="darlenelonglink.DRepwebsiteorwhatever.com"
               navTo="example@gmail.com"
@@ -189,7 +189,7 @@ export const DRepDetails = ({ isConnected }: DRepDetailsProps) => {
               flexDirection="column"
               gap={1.5}
             >
-              {/* TODO: update links*/}
+              {/* TODO: update links */}
               {LINKS.map((link) => (
                 <MoreInfoLink
                   key={link}
@@ -310,8 +310,14 @@ type LinkWithIconProps = {
 };
 
 const MoreInfoLink = ({ label, navTo, isEmail = false }: LinkWithIconProps) => {
-  const openLink = () =>
-    isEmail ? window.location.assign(`mailto:${navTo}`) : openInNewTab(navTo);
+  const openLink = () => {
+    if (isEmail) {
+      window.location.assign(`mailto:${navTo}`);
+
+      return;
+    }
+    openInNewTab(navTo);
+  };
 
   return (
     <ButtonBase


### PR DESCRIPTION
## List of changes

- Change navto items

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/929)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
