### PR TITLE
Reflect VITE_BASE_URL change in test deployment

### DIFF
--- a/tests/test-infrastructure/docker-compose-govtool.yml
+++ b/tests/test-infrastructure/docker-compose-govtool.yml
@@ -39,7 +39,7 @@ services:
     build:
       context: ../../govtool/frontend
       args:
-        VITE_BASE_URL: ""
+        VITE_BASE_URL: "/api"
     environment:
       VIRTUAL_HOST: https://${BASE_DOMAIN}
     networks:


### PR DESCRIPTION
## Change
Frontend's use of  VITE_BASE_URL has changed, and existing `/api` prefix was removed.

To fix Test deployment, `VITE_BASE_URL=/api` is set in docker-compose file.