### PR TITLE
[#926] DRep panel needs to be clickable

### DIFF
--- a/govtool/frontend/src/components/molecules/DelegationAction.tsx
+++ b/govtool/frontend/src/components/molecules/DelegationAction.tsx
@@ -10,7 +10,7 @@ import { DirectVoterActionProps } from "./types";
 
 export const DelegationAction = ({
   dRepId,
-  onClickArrow,
+  onCardClick,
   sx,
 }: DirectVoterActionProps) => {
   const { t } = useTranslation();
@@ -27,10 +27,11 @@ export const DelegationAction = ({
         justifyContent: "space-between",
         px: 1.5,
         py: 1,
+        cursor: "pointer",
         ...sx,
       }}
     >
-      <Box sx={{ width: "90%" }}>
+      <Box sx={{ width: "90%" }} onClick={onCardClick}>
         <Typography fontWeight={600} variant="body2">
           {t("dashboard.cards.drepName")}
         </Typography>
@@ -47,7 +48,6 @@ export const DelegationAction = ({
       </Box>
       <ArrowForwardIosIcon
         color="primary"
-        onClick={onClickArrow}
         sx={{ cursor: "pointer", height: 16, width: 24 }}
       />
     </Card>

--- a/govtool/frontend/src/components/molecules/types.ts
+++ b/govtool/frontend/src/components/molecules/types.ts
@@ -18,7 +18,7 @@ export type StepProps = {
 
 export type DirectVoterActionProps = {
   dRepId: string;
-  onClickArrow: () => void;
+  onCardClick: () => void;
   sx?: SxProps;
 };
 

--- a/govtool/frontend/src/components/organisms/DashboardCards/DelegateDashboardCard.tsx
+++ b/govtool/frontend/src/components/organisms/DashboardCards/DelegateDashboardCard.tsx
@@ -123,7 +123,7 @@ export const DelegateDashboardCard = ({
       {displayedDelegationId && (
         <DelegationAction
           dRepId={displayedDelegationId}
-          onClickArrow={navigateToDRepDetails}
+          onCardClick={navigateToDRepDetails}
           sx={{ mt: 1.5 }}
         />
       )}


### PR DESCRIPTION
## List of changes

- DRep Id panel on dashboard delegation card is now clickable

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/926)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
