### PR TITLE
[#926] DRep panel needs to be clickable

### DIFF
--- a/govtool/frontend/src/components/molecules/Card.tsx
+++ b/govtool/frontend/src/components/molecules/Card.tsx
@@ -10,6 +10,7 @@ type CardProps = PropsWithChildren & {
   label?: string;
   sx?: SxProps<Theme>;
   variant?: "default" | "error" | "primary" | "success" | "warning";
+  onCardClick?: () => void;
 };
 
 const COLORS = {
@@ -42,6 +43,7 @@ export const Card = ({
   elevation = 3,
   label,
   sx,
+  onCardClick,
 }: CardProps) => {
   const colors = COLORS[variant];
 
@@ -57,6 +59,7 @@ export const Card = ({
         position: "relative",
         ...sx,
       }}
+      onClick={onCardClick}
     >
       {label && (
         <Chip

--- a/govtool/frontend/src/components/molecules/DelegationAction.tsx
+++ b/govtool/frontend/src/components/molecules/DelegationAction.tsx
@@ -10,7 +10,7 @@ import { DirectVoterActionProps } from "./types";
 
 export const DelegationAction = ({
   dRepId,
-  onClickArrow,
+  onCardClick,
   sx,
 }: DirectVoterActionProps) => {
   const { t } = useTranslation();
@@ -27,8 +27,10 @@ export const DelegationAction = ({
         justifyContent: "space-between",
         px: 1.5,
         py: 1,
+        cursor: "pointer",
         ...sx,
       }}
+      onCardClick={onCardClick}
     >
       <Box sx={{ width: "90%" }}>
         <Typography fontWeight={600} variant="body2">
@@ -45,11 +47,7 @@ export const DelegationAction = ({
           {dRepId}
         </Typography>
       </Box>
-      <ArrowForwardIosIcon
-        color="primary"
-        onClick={onClickArrow}
-        sx={{ cursor: "pointer", height: 16, width: 24 }}
-      />
+      <ArrowForwardIosIcon color="primary" sx={{ height: 16, width: 24 }} />
     </Card>
   );
 };

--- a/govtool/frontend/src/components/molecules/types.ts
+++ b/govtool/frontend/src/components/molecules/types.ts
@@ -18,7 +18,7 @@ export type StepProps = {
 
 export type DirectVoterActionProps = {
   dRepId: string;
-  onClickArrow: () => void;
+  onCardClick: () => void;
   sx?: SxProps;
 };
 

--- a/govtool/frontend/src/components/organisms/DashboardCards/DelegateDashboardCard.tsx
+++ b/govtool/frontend/src/components/organisms/DashboardCards/DelegateDashboardCard.tsx
@@ -123,7 +123,7 @@ export const DelegateDashboardCard = ({
       {displayedDelegationId && (
         <DelegationAction
           dRepId={displayedDelegationId}
-          onClickArrow={navigateToDRepDetails}
+          onCardClick={navigateToDRepDetails}
           sx={{ mt: 1.5 }}
         />
       )}


### PR DESCRIPTION
## List of changes

- DRep Id panel on dashboard delegation card is now clickable

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/926)
- [x] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
