### PR TITLE
Allow backend to receive POST mehod

### DIFF
--- a/scripts/govtool/config/templates/docker-compose.yml.tpl
+++ b/scripts/govtool/config/templates/docker-compose.yml.tpl
@@ -244,7 +244,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.middlewares.backend-stripprefix.stripprefix.prefixes=/api"
-      - "traefik.http.middlewares.backend-cors.headers.accesscontrolallowmethods=GET,HEAD,OPTIONS"
+      - "traefik.http.middlewares.backend-cors.headers.accesscontrolallowmethods=GET,POST,HEAD,OPTIONS"
       - "traefik.http.middlewares.backend-cors.headers.accesscontrolallowheaders=*"
       - "traefik.http.middlewares.backend-cors.headers.accesscontrolalloworiginlist=https://<DOMAIN><CSP_ALLOWED_HOSTS>"
       - "traefik.http.middlewares.backend-cors.headers.accesscontrolmaxage=100"


### PR DESCRIPTION
In order to facilitate the metadata validation on backend service we set the POST method to be allowed in CORS.
