### PR TITLE
[#932] Automated voting options voting power fix

### DIFF
--- a/govtool/frontend/src/components/organisms/AutomatedVotingOptions.tsx
+++ b/govtool/frontend/src/components/organisms/AutomatedVotingOptions.tsx
@@ -9,9 +9,9 @@ import {
 import { Typography } from "@atoms";
 import { ICONS } from "@consts";
 import { PendingTransaction } from "@context";
-import { useTranslation } from "@hooks";
+import { useGetNetworkMetrics, useTranslation } from "@hooks";
 import { AutomatedVotingCard } from "@molecules";
-import { openInNewTab } from "@/utils";
+import { correctAdaFormat, openInNewTab } from "@/utils";
 import {
   AutomatedVotingOptionCurrentDelegation,
   AutomatedVotingOptionDelegationId,
@@ -41,6 +41,8 @@ export const AutomatedVotingOptions = ({
   const { t } = useTranslation();
 
   const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const { networkMetrics } = useGetNetworkMetrics();
 
   // TODO: Change to certain automated voted option if available
   const onClickInfo = () => openInNewTab("https://docs.sanchogov.tools/");
@@ -117,7 +119,11 @@ export const AutomatedVotingOptions = ({
                   })
                 : t("dRepDirectory.abstainCardDefaultTitle")
             }
-            votingPower={votingPower}
+            votingPower={
+              networkMetrics
+                ? correctAdaFormat(networkMetrics?.alwaysAbstainVotingPower)
+                : ""
+            }
             transactionId={
               pendingTransaction?.delegate?.resourceId ===
               AutomatedVotingOptionDelegationId.abstain
@@ -148,7 +154,13 @@ export const AutomatedVotingOptions = ({
                   })
                 : t("dRepDirectory.noConfidenceDefaultTitle")
             }
-            votingPower={votingPower}
+            votingPower={
+              networkMetrics
+                ? correctAdaFormat(
+                    networkMetrics?.alwaysNoConfidenceVotingPower,
+                  )
+                : ""
+            }
             transactionId={
               pendingTransaction?.delegate?.resourceId ===
               AutomatedVotingOptionDelegationId.no_confidence

--- a/govtool/frontend/src/consts/queryKeys.ts
+++ b/govtool/frontend/src/consts/queryKeys.ts
@@ -4,6 +4,7 @@ export const QUERY_KEYS = {
   useGetDRepListInfiniteKey: "useGetDRepListInfiniteKey",
   useGetDRepVotesKey: "useGetDRepVotesKey",
   useGetDRepVotingPowerKey: "useGetDRepVotingPowerKey",
+  useGetNetworkMetricsKey: "useGetNetworkMetricsKey",
   useGetProposalKey: "useGetProposalKey",
   useGetProposalsKey: "useGetProposalsKey",
   useGetProposalsInfiniteKey: "useGetProposalsInfiniteKey",

--- a/govtool/frontend/src/hooks/queries/index.ts
+++ b/govtool/frontend/src/hooks/queries/index.ts
@@ -4,6 +4,7 @@ export * from "./useGetVoterInfoQuery";
 export * from "./useGetDRepListQuery";
 export * from "./useGetDRepVotesQuery";
 export * from "./useGetDRepVotingPowerQuery";
+export * from "./useGetNetworkMetrics";
 export * from "./useGetProposalQuery";
 export * from "./useGetProposalsQuery";
 export * from "./useGetProposalsInfiniteQuery";

--- a/govtool/frontend/src/hooks/queries/useGetNetworkMetrics.ts
+++ b/govtool/frontend/src/hooks/queries/useGetNetworkMetrics.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "react-query";
+
+import { getNetworkMetrics } from "@services";
+import { QUERY_KEYS } from "@consts";
+import { useCardano } from "@/context";
+
+export const useGetNetworkMetrics = () => {
+  const { isEnabled } = useCardano();
+
+  const { data } = useQuery({
+    queryKey: QUERY_KEYS.useGetNetworkMetricsKey,
+    queryFn: () => getNetworkMetrics(),
+    enabled: isEnabled,
+  });
+
+  return { networkMetrics: data };
+};

--- a/govtool/frontend/src/services/requests/getNetworkMetrics.ts
+++ b/govtool/frontend/src/services/requests/getNetworkMetrics.ts
@@ -1,0 +1,7 @@
+import { API } from "../API";
+
+export const getNetworkMetrics = async () => {
+  const response = await API.get("/network/metrics");
+
+  return response.data;
+};

--- a/govtool/frontend/src/services/requests/index.ts
+++ b/govtool/frontend/src/services/requests/index.ts
@@ -18,3 +18,4 @@ export * from "./postDRepRemoveVote";
 export * from "./postDRepRetire";
 export * from "./postDRepVote";
 export * from "./metadataValidation";
+export * from "./getNetworkMetrics";


### PR DESCRIPTION
## List of changes

- Automated voting options voting power fix - now voting power in automated voting options shows summed up `abstain` or `no confidence` voting powers from whole network.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/932)
- [x] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
