### PR TITLE
fix/928-not-404-page-in-drep-directory

### DIFF
--- a/govtool/frontend/src/components/molecules/EmptyStateDrepDirectory.tsx
+++ b/govtool/frontend/src/components/molecules/EmptyStateDrepDirectory.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from "@hooks";
+
+import { Card } from "./Card";
+import { Typography } from "../atoms";
+
+export const EmptyStateDrepDirectory = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Card
+      border
+      elevation={0}
+      sx={{
+        alignItems: "center",
+        display: "flex",
+        flexDirection: "column",
+        gap: 1,
+        py: 5,
+        width: "-webkit-fill-available",
+      }}
+    >
+      <Typography fontSize={22}>
+        {t("dRepDirectory.noResultsForTheSearchTitle")}
+      </Typography>
+      <Typography fontWeight={400}>
+        {t("dRepDirectory.noResultsForTheSearchDescription")}
+      </Typography>
+    </Card>
+  );
+};

--- a/govtool/frontend/src/components/molecules/index.ts
+++ b/govtool/frontend/src/components/molecules/index.ts
@@ -12,6 +12,7 @@ export * from "./DataActionsSorting";
 export * from "./DataMissingInfoBox";
 export * from "./DelegationAction";
 export * from "./DRepInfoCard";
+export * from "./EmptyStateDrepDirectory";
 export * from "./EmptyStateGovernanceActionsCategory";
 export * from "./Field";
 export * from "./GovActionDetails";

--- a/govtool/frontend/src/pages/DRepDetails.tsx
+++ b/govtool/frontend/src/pages/DRepDetails.tsx
@@ -1,10 +1,5 @@
 import { PropsWithChildren } from "react";
-import {
-  Navigate,
-  useLocation,
-  useNavigate,
-  useParams,
-} from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { Box, ButtonBase, Chip, CircularProgress } from "@mui/material";
 
 import { Button, StatusPill, Typography } from "@atoms";
@@ -16,7 +11,7 @@ import {
   useScreenDimension,
   useTranslation,
 } from "@hooks";
-import { Card, LinkWithIcon, Share } from "@molecules";
+import { Card, EmptyStateDrepDirectory, LinkWithIcon, Share } from "@molecules";
 import {
   correctAdaFormat,
   isSameDRep,
@@ -53,7 +48,7 @@ export const DRepDetails = ({ isConnected }: DRepDetailsProps) => {
   });
   const dRep = dRepData?.[0];
 
-  if (dRep === undefined || isDRepListLoading)
+  if (isDRepListLoading)
     return (
       <Box
         sx={{
@@ -68,7 +63,19 @@ export const DRepDetails = ({ isConnected }: DRepDetailsProps) => {
       </Box>
     );
 
-  if (!dRep) return <Navigate to={PATHS.error} />;
+  if (!dRep)
+    return (
+      <Box
+        sx={{
+          alignItems: "center",
+          display: "flex",
+          flex: 1,
+          justifyContent: "center",
+        }}
+      >
+        <EmptyStateDrepDirectory />
+      </Box>
+    );
 
   const { view, status, votingPower, type } = dRep;
 

--- a/govtool/frontend/src/pages/DRepDirectoryContent.tsx
+++ b/govtool/frontend/src/pages/DRepDirectoryContent.tsx
@@ -11,7 +11,7 @@ import {
   useGetAdaHolderVotingPowerQuery,
   useGetDRepListInfiniteQuery,
 } from "@hooks";
-import { Card, DataActionsBar } from "@molecules";
+import { DataActionsBar, EmptyStateDrepDirectory } from "@molecules";
 import { AutomatedVotingOptions, DRepCard } from "@organisms";
 import { correctAdaFormat, formHexToBech32, isSameDRep } from "@utils";
 import { DRepListSort, DRepStatus } from "@models";
@@ -183,26 +183,7 @@ export const DRepDirectoryContent: FC<DRepDirectoryContentProps> = ({
             flex: 1,
           }}
         >
-          {dRepList?.length === 0 && (
-            <Card
-              border
-              elevation={0}
-              sx={{
-                alignItems: "center",
-                display: "flex",
-                flexDirection: "column",
-                gap: 1,
-                py: 5,
-              }}
-            >
-              <Typography fontSize={22}>
-                {t("dRepDirectory.noResultsForTheSearchTitle")}
-              </Typography>
-              <Typography fontWeight={400}>
-                {t("dRepDirectory.noResultsForTheSearchDescription")}
-              </Typography>
-            </Card>
-          )}
+          {dRepList?.length === 0 && <EmptyStateDrepDirectory />}
           {dRepListToDisplay?.map((dRep) => {
             if (isSameDRep(dRep, myDrep?.view)) {
               return null;


### PR DESCRIPTION
## List of changes

- Fix - move no results card to component and add to drep details

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/928)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
