### PR TITLE
Update backend config with metadata-validation service address

### DIFF
--- a/scripts/govtool/config/templates/backend-config.json.tpl
+++ b/scripts/govtool/config/templates/backend-config.json.tpl
@@ -10,6 +10,6 @@
     "host" : "0.0.0.0",
     "cachedurationseconds": 20,
     "sentrydsn": "<SENTRY_DSN>",
-    "metadatavalidationhost": "metadata-validation",
+    "metadatavalidationhost": "http://metadata-validation",
     "metadatavalidationport": "3000"   
 }


### PR DESCRIPTION
This is a hotfix that solves problem with wrong request configuration to metadata-validation service.
