### PR TITLE
[#1028] fix: remove incorrectly appended filter yourself to drep directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ changes.
 - Fix all the existing eslint errors [Issue 514](https://github.com/IntersectMBO/govtool/issues/514)
 - Fix all the existing typescript errors [Issue 514](https://github.com/IntersectMBO/govtool/issues/514)
 - Fix endless spinner on a dashboard [Issue 539](https://github.com/IntersectMBO/govtool/issues/539)
+- Remove wrongly appended `Yourself` filter on DRep Directory [Issue 1028](https://github.com/IntersectMBO/govtool/issues/1028)
 
 ### Changed
 

--- a/govtool/frontend/src/consts/dRepDirectory/filters.test.ts
+++ b/govtool/frontend/src/consts/dRepDirectory/filters.test.ts
@@ -1,0 +1,27 @@
+import { DREP_DIRECTORY_FILTERS } from "./filters";
+
+describe("DREP_DIRECTORY_FILTERS", () => {
+  it("should exclude 'Yourself' from filters", () => {
+    // Arrange
+    const expectedFilters = [
+      {
+        key: "Active",
+        label: "Active",
+      },
+      {
+        key: "Inactive",
+        label: "Inactive",
+      },
+      {
+        key: "Retired",
+        label: "Retired",
+      },
+    ];
+
+    // Act
+    const actualFilters = DREP_DIRECTORY_FILTERS;
+
+    // Assert
+    expect(actualFilters).toEqual(expectedFilters);
+  });
+});

--- a/govtool/frontend/src/consts/dRepDirectory/filters.ts
+++ b/govtool/frontend/src/consts/dRepDirectory/filters.ts
@@ -1,6 +1,9 @@
 import { DRepStatus } from "@/models";
 
-export const DREP_DIRECTORY_FILTERS = Object.values(DRepStatus).map((status) => ({
-  key: status,
-  label: status,
-}));
+export const DREP_DIRECTORY_FILTERS = Object.values(DRepStatus)
+  // `Yourself` should be excluded from filters
+  .filter((status) => status !== DRepStatus.Yourself)
+  .map((status) => ({
+    key: status,
+    label: status,
+  }));


### PR DESCRIPTION
## List of changes

- Filter `yourself` was incorrectly appended. This PR filters it out making the DRep directory filter match the requirements.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1028)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [x] I have added tests that prove my fix is effective or that my feature works
