### PR TITLE
Fix staging basic auth

### DIFF
--- a/scripts/govtool/config.mk
+++ b/scripts/govtool/config.mk
@@ -98,8 +98,8 @@ $(target_config_dir)/grafana-provisioning/alerting/alerting.yml: $(template_conf
 		-i $@
 
 $(target_config_dir)/nginx/auth.conf: $(target_config_dir)/nginx/
-	@:$(call check_defined, domain)
-	if [[ "$(domain)" == *"sanchonet.govtool.byron.network"* ]]; then \
+	@:$(call check_defined, env)
+	if [[ "$(env)" != "beta" ]]; then \
 	  echo 'map $$http_x_forwarded_for $$auth {' > $@; \
 	  echo "  default \"Restricted\";" >> $@; \
 	  echo "  $${IP_ADDRESS_BYPASSING_BASIC_AUTH1} \"off\";" >> $@; \


### PR DESCRIPTION
In this pull request, the authentication logic for staging environments has been adjusted to enhance flexibility and customization. The script in `scripts/govtool/config.mk` has been modified to consider the environment variable 'env' instead of the domain name when configuring authentication settings for staging environments. This change allows for a more adaptable authentication process tailored to the specific requirements of different staging environments. By updating the authentication configuration based on the 'env' variable, the overall security and functionality of the application is improved, ensuring that the authentication setup is aligned with the precise needs of each staging environment, ultimately enhancing security and user experience.

