### PR TITLE
[#1035] Bump cardano-node and cardano dbsync

### DIFF
--- a/scripts/govtool/Makefile
+++ b/scripts/govtool/Makefile
@@ -10,8 +10,8 @@ include config.mk
 .DEFAULT_GOAL := info
 
 # image tags
-cardano_node_image_tag := 8.10.0-pre
-cardano_db_sync_image_tag := sancho-4-2-1
+cardano_node_image_tag := 8.11.0-sancho
+cardano_db_sync_image_tag := sancho-4-3-0-docker
 
 .PHONY: all
 all: deploy-stack notify

--- a/scripts/govtool/docker-compose.node+dbsync.yml
+++ b/scripts/govtool/docker-compose.node+dbsync.yml
@@ -51,7 +51,7 @@ services:
       retries: 5
 
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:8.10.0-pre
+    image: ghcr.io/intersectmbo/cardano-node:8.11.0-sancho
     environment:
       - NETWORK=sanchonet
     volumes:
@@ -65,7 +65,7 @@ services:
       retries: 10
 
   cardano-db-sync:
-    image: ghcr.io/intersectmbo/cardano-db-sync:sancho-4-2-1
+    image: ghcr.io/intersectmbo/cardano-db-sync:sancho-4-3-0-docker
     environment:
       - NETWORK=sanchonet
       - POSTGRES_HOST=postgres


### PR DESCRIPTION
Closes #1035.

This pull request addresses user story #1035 by bumping the versions of cardano-node and cardano dbsync to 8.11.0-sancho and sancho-4-3-0-docker respectively. The Makefile and docker-compose files were updated to reflect these changes. By ensuring that cardano-node is now at the correct version specified in the user story, the infrastructure configuration was also updated accordingly. This aligns with the pre-release version specified in the user story instructions. The changes made in this pull request fulfill the requirement to maintain consistency in versions and configurations for the specified components.

