### PR TITLE
fix: ensure directory creation with mkdir -p

### DIFF
--- a/.github/workflows/test_integration_playwright.yml
+++ b/.github/workflows/test_integration_playwright.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run tests
         run: |
-          mkdir ./lib/_mock
+          mkdir -p ./lib/_mock
           chmod +w ./lib/_mock
           npm run generate-wallets
           npm test


### PR DESCRIPTION
## List of changes

- Ensured mock directory creation for generating static wallets.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
