### PR TITLE
 fix: Default cardano_api_metadata host url

### DIFF
--- a/tests/govtool-frontend/playwright/lib/constants/environments.ts
+++ b/tests/govtool-frontend/playwright/lib/constants/environments.ts
@@ -1,6 +1,11 @@
+const CARDANO_API_METADATA_HOST_URL =
+  process.env.CARDANOAPI_METADATA_URL ||
+  "https://metadata-govtool.cardanoapi.io";
+const SERVER_HOST_URL = process.env.HOST_URL || "http://localhost:8080";
+
 const environments = {
-  frontendUrl: process.env.HOST_URL || "http://localhost:8080",
-  apiUrl: `${process.env.HOST_URL}/api` || "http://localhost:8080/api",
+  frontendUrl: SERVER_HOST_URL,
+  apiUrl: `${SERVER_HOST_URL}/api`,
   docsUrl: process.env.DOCS_URL || "https://docs.sanchogov.tools",
   networkId: parseInt(process.env.NETWORK_ID) || 0,
   faucet: {
@@ -14,12 +19,8 @@ const environments = {
     apiKey: process.env.KUBER_API_KEY || "",
   },
   txTimeOut: parseInt(process.env.TX_TIMEOUT) || 240000,
-  metadataBucketUrl:
-    `${process.env.CARDANOAPI_METADATA_URL}/data` ||
-    "https://metadata.cardanoapi.io/data",
-  lockInterceptorUrl:
-    `${process.env.CARDANOAPI_METADATA_URL}/data` ||
-    "https://metadata.cardanoapi.io/lock",
+  metadataBucketUrl: `${CARDANO_API_METADATA_HOST_URL}/data`,
+  lockInterceptorUrl: `${CARDANO_API_METADATA_HOST_URL}/lock`,
 };
 
 export default environments;


### PR DESCRIPTION
## List of changes

- Resolved the metadata bucket URL issue
Link to the [report](https://intersectmbo.github.io/govtool-test-reports/govtool-frontend/3/#behaviors/f7eea6c55a554c79a959f2fe9524fccc/c60d6fcadf7483fc/)

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
