### PR TITLE
fix/649-design-bug-payment-address-needs-to-be-copyablereadable

### DIFF
--- a/govtool/frontend/src/components/molecules/GovernanceActionCardElement.tsx
+++ b/govtool/frontend/src/components/molecules/GovernanceActionCardElement.tsx
@@ -5,7 +5,7 @@ import { Typography, Tooltip, CopyButton, TooltipProps } from "@atoms";
 
 type BaseProps = {
   label: string;
-  text?: string;
+  text?: string | number;
   dataTestId?: string;
   isSliderCard?: boolean;
   tooltipProps?: Omit<TooltipProps, "children">;
@@ -109,6 +109,7 @@ export const GovernanceActionCardElement = ({
               sx={{
                 fontSize: isSliderCard ? 14 : 16,
                 fontWeight: 400,
+                maxWidth: textVariant === "oneLine" ? "283px" : "auto",
                 lineHeight: isSliderCard ? "20px" : "24px",
                 ...(textVariant === "oneLine" && { whiteSpace: "nowrap" }),
                 ...((textVariant === "oneLine" ||
@@ -131,7 +132,7 @@ export const GovernanceActionCardElement = ({
             </Typography>
             {isCopyButton && (
               <Box ml={1}>
-                <CopyButton text={text} variant="blueThin" />
+                <CopyButton text={text.toString()} variant="blueThin" />
               </Box>
             )}
           </Box>

--- a/govtool/frontend/src/components/organisms/GovernanceActionDetailsCardData.tsx
+++ b/govtool/frontend/src/components/organisms/GovernanceActionDetailsCardData.tsx
@@ -10,7 +10,7 @@ import {
   GovernanceActionDetailsCardOnChainData,
 } from "@molecules";
 import { useScreenDimension, useTranslation } from "@hooks";
-import { getProposalTypeNoEmptySpaces } from "@utils";
+import { getProposalTypeNoEmptySpaces, testIdFromLabel } from "@utils";
 import { MetadataValidationStatus } from "@models";
 
 type GovernanceActionDetailsCardDataProps = {
@@ -120,9 +120,16 @@ export const GovernanceActionDetailsCardData = ({
         textVariant="longText"
         dataTestId="rationale"
       />
-      {details && Object.keys(details).length !== 0 && (
-        <GovernanceActionDetailsCardOnChainData data={details} />
-      )}
+      {details &&
+        Object.keys(details).length !== 0 &&
+        Object.entries(details).map(([label, content]) => (
+          <GovernanceActionCardElement
+            isCopyButton={label.toLowerCase().includes("address")}
+            label={label}
+            text={content}
+            dataTestId={testIdFromLabel(label)}
+          />
+        ))}
       <GovernanceActionDetailsCardLinks links={links} />
     </Box>
   );

--- a/govtool/frontend/src/components/organisms/GovernanceActionDetailsCardData.tsx
+++ b/govtool/frontend/src/components/organisms/GovernanceActionDetailsCardData.tsx
@@ -7,7 +7,6 @@ import {
   DataMissingInfoBox,
   GovernanceActionDetailsCardHeader,
   GovernanceActionsDatesBox,
-  GovernanceActionDetailsCardOnChainData,
 } from "@molecules";
 import { useScreenDimension, useTranslation } from "@hooks";
 import { getProposalTypeNoEmptySpaces, testIdFromLabel } from "@utils";


### PR DESCRIPTION
## List of changes

- Add posibility to copy address from Treasury GA

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/649)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
