### PR TITLE
fix/911-registed-as-a-drep-but-dashboard-says-vote-on-governance-actions-as-a-sole-voter

### DIFF
--- a/govtool/frontend/src/i18n/locales/en.ts
+++ b/govtool/frontend/src/i18n/locales/en.ts
@@ -104,7 +104,7 @@ export const en = {
             "Your Voting Power of ₳<strong>{{votingPower}}</strong> can be used to vote.",
           register: "Register",
           registerDescription:
-            "Vote on Governance Actions using your own voting power of ₳<strong>{{votingPower}}</strong>.",
+            "Register to Vote on Governance Actions using your own voting power of ₳<strong>{{votingPower}}</strong>.",
           registerTitle: "Become a Direct Voter",
           reRegister: "Re-register",
           registration: "Direct Voter Registration",


### PR DESCRIPTION
## List of changes

- Change direct voter card description

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/911)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
