### PR TITLE
fix: fix error handling for metadata service; add optional support for CIP-119

### DIFF
--- a/govtool/metadata-validation/src/dto/validateMetadata.dto.ts
+++ b/govtool/metadata-validation/src/dto/validateMetadata.dto.ts
@@ -1,15 +1,9 @@
-import { IsUrl, IsNotEmpty, IsEnum, IsOptional } from 'class-validator';
-
 import { MetadataStandard } from '@types';
 
 export class ValidateMetadataDTO {
-  @IsNotEmpty()
   hash: string;
 
-  @IsUrl()
   url: string;
 
-  @IsOptional()
-  @IsEnum(MetadataStandard)
   standard?: MetadataStandard;
 }

--- a/govtool/metadata-validation/src/main.ts
+++ b/govtool/metadata-validation/src/main.ts
@@ -17,7 +17,12 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
 
-  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      // Do not throw error on missing fields
+      exceptionFactory: () => ({ status: 200, valid: false }),
+    }),
+  );
   await app.listen(process.env.PORT);
 }
 bootstrap();

--- a/govtool/metadata-validation/src/schemas/cipStandardSchema.ts
+++ b/govtool/metadata-validation/src/schemas/cipStandardSchema.ts
@@ -9,6 +9,10 @@ const CIP100_URL =
 const CIP108_URL =
   'https://github.com/cardano-foundation/CIPs/blob/master/CIP-0108/README.md#';
 
+// Temporary URL for the CIP-119 metadata
+const CIPQQQ_URL =
+  'https://github.com/cardano-foundation/CIPs/blob/master/CIP-QQQ/README.md#';
+
 export const cipStandardSchema: StandardSpecification = {
   // Source of CIP-108: https://github.com/Ryun1/CIPs/blob/governance-metadata-actions/CIP-0108/README.md
   [MetadataStandard.CIP108]: Joi.object({
@@ -43,6 +47,40 @@ export const cipStandardSchema: StandardSpecification = {
             hashAlgorithm: Joi.string().required(),
           }),
         }).required(),
+      ),
+    }),
+  }),
+  [MetadataStandard.CIPQQQ]: Joi.object({
+    '@context': Joi.object({
+      '@language': Joi.string().required(),
+      CIP100: Joi.string().valid(CIP100_URL).required(),
+      CIPQQQ: Joi.string().valid(CIPQQQ_URL).required(),
+      hashAlgorithm: Joi.string().valid('CIP100:hashAlgorithm').required(),
+      body: Joi.object(),
+      authors: Joi.object(),
+    }),
+    authors: Joi.array(),
+    hashAlgorithm: Joi.object({
+      '@value': Joi.string().valid('blake2b-256').required(),
+    }),
+    body: Joi.object({
+      bio: Joi.object({ '@value': Joi.string() }),
+      dRepName: Joi.object({ '@value': Joi.string() }),
+      email: Joi.object({ '@value': Joi.string() }),
+      references: Joi.array().items(
+        Joi.object({
+          '@type': Joi.string(),
+          'CIPQQQ:reference-label': Joi.object({
+            '@value': Joi.string().required(),
+          }),
+          'CIPQQQ:reference-uri': Joi.object({
+            '@value': Joi.string().uri().required(),
+          }),
+          'CIPQQQ:reference-hash': Joi.object({
+            hashDigest: Joi.string().required(),
+            hashAlgorithm: Joi.string().required(),
+          }),
+        }),
       ),
     }),
   }),

--- a/govtool/metadata-validation/src/types/validateMetadata.ts
+++ b/govtool/metadata-validation/src/types/validateMetadata.ts
@@ -2,6 +2,7 @@ import { MetadataValidationStatus } from '@enums';
 
 export enum MetadataStandard {
   CIP108 = 'CIP108',
+  CIPQQQ = 'CIPQQQ',
 }
 
 export type ValidateMetadataResult = {

--- a/govtool/metadata-validation/src/utils/parseMetadata.ts
+++ b/govtool/metadata-validation/src/utils/parseMetadata.ts
@@ -1,7 +1,11 @@
 import { MetadataStandard } from '@/types';
 
 const CIP_108_VALUE_KEYS = ['abstract', 'motivation', 'rationale', 'title'];
-export const parseMetadata = (metadata: any, standard: MetadataStandard) => {
+const CIP_QQQ_VALUE_KEYS = ['bio', 'dRepName', 'email', 'references'];
+export const parseMetadata = (
+  metadata: any,
+  standard = MetadataStandard.CIP108,
+) => {
   const parsedMetadata = {};
   switch (standard) {
     case MetadataStandard.CIP108:
@@ -13,6 +17,19 @@ export const parseMetadata = (metadata: any, standard: MetadataStandard) => {
         if (key === 'references') {
           parsedMetadata[key] = (Array.isArray(value) ? value : [])?.map(
             (reference) => reference['CIP108:reference-uri']['@value'],
+          );
+        }
+      }
+      return parsedMetadata;
+
+    case MetadataStandard.CIPQQQ:
+      for (const [key, value] of Object.entries(metadata)) {
+        if (CIP_QQQ_VALUE_KEYS.includes(key)) {
+          parsedMetadata[key] = value['@value'];
+        }
+        if (key === 'references') {
+          parsedMetadata[key] = (Array.isArray(value) ? value : [])?.map(
+            (reference) => reference['CIPQQQ:reference-uri']['@value'],
           );
         }
       }


### PR DESCRIPTION
## List of changes

- add optional support for CIP-119
- fix error handling for metadata service

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
