### PR TITLE
fix/509-ga-submit-where-there-is-not-enough-founds-no-info-modal-view-is-shown-info-desing-ready-todo

### DIFF
--- a/govtool/frontend/src/components/organisms/CreateGovernanceActionSteps/WhatGovernanceActionIsAbout.tsx
+++ b/govtool/frontend/src/components/organisms/CreateGovernanceActionSteps/WhatGovernanceActionIsAbout.tsx
@@ -23,7 +23,7 @@ export const WhatGovernanceActionIsAbout = ({
   const { t } = useTranslation();
   const { isMobile } = useScreenDimension();
 
-  const deposit = getItemFromLocalStorage(PROTOCOL_PARAMS_KEY);
+  const protocolParams = getItemFromLocalStorage(PROTOCOL_PARAMS_KEY);
 
   const onClickContinue = useCallback(() => setStep(2), []);
 
@@ -50,7 +50,7 @@ export const WhatGovernanceActionIsAbout = ({
         <Trans
           i18nKey="createGovernanceAction.creatingAGovernanceActionDescription"
           values={{
-            deposit: correctAdaFormat(deposit.gov_action_deposit),
+            deposit: correctAdaFormat(protocolParams.gov_action_deposit),
           }}
         />
       </Typography>

--- a/govtool/frontend/src/components/organisms/DashboardCards.tsx
+++ b/govtool/frontend/src/components/organisms/DashboardCards.tsx
@@ -7,11 +7,14 @@ import {
   useGetAdaHolderCurrentDelegationQuery,
   useGetVoterInfo,
 } from "@hooks";
+import { PROTOCOL_PARAMS_KEY, getItemFromLocalStorage } from "@utils";
 import { DelegateDashboardCard } from "./DashboardCards/DelegateDashboardCard";
 import { DRepDashboardCard } from "./DashboardCards/DRepDashboardCard";
 import { DirectVoterDashboardCard } from "./DashboardCards/DirectVoterDashboardCard";
 import { ListGovActionsDashboardCards } from "./DashboardCards/ListGovActionsDashboardCard";
 import { ProposeGovActionDashboardCard } from "./DashboardCards/ProposeGovActionDashboardCard";
+
+const protocolParams = getItemFromLocalStorage(PROTOCOL_PARAMS_KEY);
 
 export const DashboardCards = () => {
   const { dRepID, dRepIDBech32, pendingTransaction, stakeKey } = useCardano();
@@ -83,6 +86,8 @@ export const DashboardCards = () => {
 
         <ProposeGovActionDashboardCard
           createGovActionTx={pendingTransaction.createGovAction}
+          deposit={protocolParams.gov_action_deposit}
+          votingPower={votingPower}
         />
       </Box>
     </Box>

--- a/govtool/frontend/src/components/organisms/DashboardCards/ProposeGovActionDashboardCard.tsx
+++ b/govtool/frontend/src/components/organisms/DashboardCards/ProposeGovActionDashboardCard.tsx
@@ -2,19 +2,40 @@ import { useNavigate } from "react-router-dom";
 
 import { IMAGES, PATHS } from "@consts";
 import { PendingTransaction } from "@context";
-import { useTranslation } from "@hooks";
+import { useTranslation, useWalletErrorModal } from "@hooks";
 import { DashboardActionCard } from "@molecules";
-import { openInNewTab } from "@utils";
+import { correctAdaFormat, openInNewTab } from "@utils";
+import { useCallback } from "react";
 
 type ProposeGovActionDashboardCardProps = {
   createGovActionTx: PendingTransaction["createGovAction"];
+  deposit: number;
+  votingPower: number;
 };
 
 export const ProposeGovActionDashboardCard = ({
   createGovActionTx,
+  deposit,
+  votingPower,
 }: ProposeGovActionDashboardCardProps) => {
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const openWalletErrorModal = useWalletErrorModal();
+
+  const onClickPropose = useCallback(() => {
+    if (votingPower <= deposit) {
+      openWalletErrorModal({
+        error: t("errors.insufficientBalanceDescription", {
+          ada: correctAdaFormat(deposit),
+        }),
+        title: t("errors.insufficientBalanceTitle"),
+        dataTestId: "insufficient-balance-error-modal",
+      });
+      return;
+    }
+
+    navigate(PATHS.createGovernanceAction);
+  }, [deposit, votingPower]);
 
   return (
     <DashboardActionCard
@@ -34,7 +55,7 @@ export const ProposeGovActionDashboardCard = ({
               {
                 children: t("dashboard.cards.proposeGovernanceAction.propose"),
                 dataTestId: "propose-governance-actions-button",
-                onClick: () => navigate(PATHS.createGovernanceAction),
+                onClick: onClickPropose,
                 variant: "contained",
               } as const,
             ]),

--- a/govtool/frontend/src/i18n/locales/en.ts
+++ b/govtool/frontend/src/i18n/locales/en.ts
@@ -289,6 +289,9 @@ export const en = {
       appCannotGetVkeys: "Application can not get vkey",
       checkIsWalletConnected: "Check if the wallet is connected.",
       dRepIdNotFound: "DrepId not found",
+      insufficientBalanceDescription:
+        "To submit a Governance Action, you will be required to post a refundable balance of ₳{{ada}}. You do not currently have enough ADA in your wallet to continue.",
+      insufficientBalanceTitle: "Insufficient Balance",
       invalidGovernanceActionType: "Invalid Governance Action Type",
       invalidTreasuryGovernanceActionType: "Invalid Treasury Governance Action",
       noAddressesFound: "No addresses found",


### PR DESCRIPTION
## List of changes

- Add insufficient balance error modal

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
