### PR TITLE
fix/1078-bug-abstain-and-signal-no-confidence-delegate-buttons-load-incorrectly-on-drep-directory

### DIFF
--- a/govtool/frontend/src/components/atoms/Button.tsx
+++ b/govtool/frontend/src/components/atoms/Button.tsx
@@ -24,7 +24,6 @@ export const Button = ({
 
   return (
     <MUIButton
-      disabled={isLoading || props?.disabled}
       sx={{
         fontSize: size === "extraLarge" ? 16 : 14,
         height,
@@ -34,6 +33,7 @@ export const Button = ({
       }}
       variant={variant}
       {...props}
+      disabled={isLoading || props?.disabled}
     >
       {isLoading && (
         <CircularProgress size={26} sx={{ position: "absolute" }} />

--- a/govtool/frontend/src/components/organisms/AutomatedVotingOptions.tsx
+++ b/govtool/frontend/src/components/organisms/AutomatedVotingOptions.tsx
@@ -23,7 +23,7 @@ type AutomatedVotingOptionsProps = {
   votingPower: string;
   delegationInProgress?: string;
   isConnected?: boolean;
-  isDelegationLoading?: boolean;
+  isDelegationLoading?: string | null;
   pendingTransaction?: PendingTransaction;
   txHash?: string | null;
 };
@@ -110,7 +110,9 @@ export const AutomatedVotingOptions = ({
             }
             inProgress={isDelegationToAbstainInProgress}
             isConnected={isConnected}
-            isDelegateLoading={isDelegationLoading}
+            isDelegateLoading={
+              isDelegationLoading === AutomatedVotingOptionDelegationId.abstain
+            }
             isSelected={isDelegatedToAbstain}
             onClickDelegate={() =>
               delegate(AutomatedVotingOptionDelegationId.abstain)
@@ -146,7 +148,10 @@ export const AutomatedVotingOptions = ({
             }
             inProgress={isDelegationToNoConfidenceInProgress}
             isConnected={isConnected}
-            isDelegateLoading={isDelegationLoading}
+            isDelegateLoading={
+              isDelegationLoading ===
+              AutomatedVotingOptionDelegationId.no_confidence
+            }
             isSelected={isDelegatedToNoConfidence}
             onClickDelegate={() =>
               delegate(AutomatedVotingOptionDelegationId.no_confidence)

--- a/govtool/frontend/src/components/organisms/DRepCard.tsx
+++ b/govtool/frontend/src/components/organisms/DRepCard.tsx
@@ -12,6 +12,7 @@ import { correctDRepDirectoryFormat } from "@utils";
 type DRepCardProps = {
   dRep: DRepData;
   isConnected: boolean;
+  isDelegationLoading?: boolean;
   isInProgress?: boolean;
   isMe?: boolean;
   onDelegate?: () => void;
@@ -20,6 +21,7 @@ type DRepCardProps = {
 export const DRepCard = ({
   dRep: { status, type, view, votingPower },
   isConnected,
+  isDelegationLoading,
   isInProgress,
   isMe,
   onDelegate,
@@ -200,6 +202,7 @@ export const DRepCard = ({
               <Button
                 data-testid={`${view}-delegate-button`}
                 onClick={onDelegate}
+                isLoading={isDelegationLoading}
               >
                 {t("delegate")}
               </Button>

--- a/govtool/frontend/src/hooks/useDelegateToDrep.ts
+++ b/govtool/frontend/src/hooks/useDelegateToDrep.ts
@@ -15,12 +15,12 @@ export const useDelegateTodRep = () => {
   const openWalletErrorModal = useWalletErrorModal();
   const { voter } = useGetVoterInfo();
 
-  const [isDelegating, setIsDelegating] = useState(false);
+  const [isDelegating, setIsDelegating] = useState<string | null>(null);
 
   const delegate = useCallback(
     async (dRepId: string | undefined) => {
       if (!dRepId) return;
-      setIsDelegating(true);
+      setIsDelegating(dRepId);
       try {
         if (voter?.isRegisteredAsSoleVoter && !voter?.deposit) {
           throw new Error(t("errors.appCannotGetDeposit"));
@@ -46,7 +46,7 @@ export const useDelegateTodRep = () => {
         });
         Sentry.captureException(error);
       } finally {
-        setIsDelegating(false);
+        setIsDelegating(null);
       }
     },
     [

--- a/govtool/frontend/src/pages/DRepDetails.tsx
+++ b/govtool/frontend/src/pages/DRepDetails.tsx
@@ -275,7 +275,7 @@ export const DRepDetails = ({ isConnected }: DRepDetailsProps) => {
             <Button
               data-testid="delegate-button"
               disabled={!!pendingTransaction.delegate}
-              isLoading={isDelegating}
+              isLoading={isDelegating === dRep.drepId}
               onClick={() => delegate(dRep.view)}
               size="extraLarge"
               sx={{ width: "100%" }}

--- a/govtool/frontend/src/pages/DRepDetails.tsx
+++ b/govtool/frontend/src/pages/DRepDetails.tsx
@@ -275,7 +275,9 @@ export const DRepDetails = ({ isConnected }: DRepDetailsProps) => {
             <Button
               data-testid="delegate-button"
               disabled={!!pendingTransaction.delegate}
-              isLoading={isDelegating === dRep.drepId}
+              isLoading={
+                isDelegating === dRep.view || isDelegating === dRep.drepId
+              }
               onClick={() => delegate(dRep.view)}
               size="extraLarge"
               sx={{ width: "100%" }}

--- a/govtool/frontend/src/pages/DRepDirectoryContent.tsx
+++ b/govtool/frontend/src/pages/DRepDirectoryContent.tsx
@@ -212,7 +212,9 @@ export const DRepDirectoryContent: FC<DRepDirectoryContentProps> = ({
                 <DRepCard
                   dRep={dRep}
                   isConnected={!!isConnected}
-                  isDelegationLoading={isDelegating === dRep.drepId}
+                  isDelegationLoading={
+                    isDelegating === dRep.view || isDelegating === dRep.drepId
+                  }
                   isMe={isSameDRep(dRep, myDRepId)}
                   onDelegate={() => delegate(dRep.drepId)}
                 />

--- a/govtool/frontend/src/pages/DRepDirectoryContent.tsx
+++ b/govtool/frontend/src/pages/DRepDirectoryContent.tsx
@@ -212,6 +212,7 @@ export const DRepDirectoryContent: FC<DRepDirectoryContentProps> = ({
                 <DRepCard
                   dRep={dRep}
                   isConnected={!!isConnected}
+                  isDelegationLoading={isDelegating === dRep.drepId}
                   isMe={isSameDRep(dRep, myDRepId)}
                   onDelegate={() => delegate(dRep.drepId)}
                 />


### PR DESCRIPTION
## List of changes

- change way to handle is delegation process on DRrep Directory

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
