### PR TITLE
fix/1169-wrong-references-object-keys-in-metadata

### DIFF
--- a/govtool/frontend/src/utils/generateMetadataBody.ts
+++ b/govtool/frontend/src/utils/generateMetadataBody.ts
@@ -29,8 +29,8 @@ export const generateMetadataBody = ({
         .filter((link) => link.link)
         .map((link) => ({
           "@type": "Other",
-          [`${standardReference}reference-label`]: "Label",
-          [`${standardReference}reference-uri`]: link.link,
+          [`${CIP_100}reference-label`]: "Label",
+          [`${CIP_100}reference-uri`]: link.link,
         }))
     : undefined;
 

--- a/govtool/frontend/src/utils/tests/generateMetadataBody.test.ts
+++ b/govtool/frontend/src/utils/tests/generateMetadataBody.test.ts
@@ -44,8 +44,6 @@ describe("generateMetadataBody", () => {
       standardReference,
     });
 
-    console.log(result);
-
     expect(result).toEqual({
       "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0108/README.md#name":
         "John Doe",

--- a/govtool/frontend/src/utils/tests/generateMetadataBody.test.ts
+++ b/govtool/frontend/src/utils/tests/generateMetadataBody.test.ts
@@ -44,6 +44,8 @@ describe("generateMetadataBody", () => {
       standardReference,
     });
 
+    console.log(result);
+
     expect(result).toEqual({
       "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0108/README.md#name":
         "John Doe",
@@ -52,16 +54,16 @@ describe("generateMetadataBody", () => {
         [
           {
             "@type": "Other",
-            "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0108/README.md#reference-label":
+            "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#reference-label":
               "Label",
-            "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0108/README.md#reference-uri":
+            "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#reference-uri":
               "https://example.com/link1",
           },
           {
             "@type": "Other",
-            "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0108/README.md#reference-label":
+            "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#reference-label":
               "Label",
-            "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0108/README.md#reference-uri":
+            "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#reference-uri":
               "https://example.com/link2",
           },
         ],


### PR DESCRIPTION
## List of changes

- Fix references body data

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
