### PR TITLE
Adjust temporary wallet counts

### DIFF
--- a/tests/govtool-frontend/playwright/lib/constants/staticWallets.ts
+++ b/tests/govtool-frontend/playwright/lib/constants/staticWallets.ts
@@ -22,6 +22,7 @@ export const adaHolderWallets = [
   adaHolder03Wallet,
   adaHolder04Wallet,
   adaHolder05Wallet,
+  adaHolder06Wallet,
 ];
 
 export const userWallets = [user01Wallet];

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
@@ -117,8 +117,6 @@ test.describe("Register DRep state", () => {
   let dRepPage: Page;
   let wallet: StaticWallet;
 
-  test.describe.configure({ retries: 3 });
-
   test.beforeEach(async ({ page, browser }) => {
     wallet = await walletManager.popWallet("registerDRep");
 
@@ -128,16 +126,16 @@ test.describe("Register DRep state", () => {
       wallet,
       enableStakeSigning: true,
     });
+
+    await dRepPage.goto("/");
+    await dRepPage.waitForTimeout(2_000); // Waits to ensure the wallet-connection modal not interfere with interactions
   });
 
   test("2E. Should register as Direct voter", async ({}, testInfo) => {
     test.setTimeout(testInfo.timeout + environments.txTimeOut);
     const dRepId = wallet.dRepId;
 
-    await dRepPage.goto("/");
     await dRepPage.getByTestId("register-as-sole-voter-button").click();
-
-    await expect(dRepPage.getByTestId("continue-button")).toBeVisible();
     await dRepPage.getByTestId("continue-button").click();
     await expect(
       dRepPage.getByTestId("registration-transaction-submitted-modal")
@@ -162,10 +160,7 @@ test.describe("Register DRep state", () => {
   test("2S. Should retire as a Direct Voter on delegating to another DRep", async ({}, testInfo) => {
     test.setTimeout(testInfo.timeout + environments.txTimeOut);
 
-    await dRepPage.goto("/");
     await dRepPage.getByTestId("register-as-sole-voter-button").click();
-
-    await expect(dRepPage.getByTestId("continue-button")).toBeVisible();
     await dRepPage.getByTestId("continue-button").click();
     await expect(
       dRepPage.getByTestId("registration-transaction-submitted-modal")

--- a/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
@@ -138,6 +138,8 @@ test.describe("Perform voting", () => {
   let dRepPage: Page;
 
   test.beforeEach(async ({ page, browser }) => {
+    test.slow(); // Due to queue in pop wallets
+
     const wallet = await walletManager.popWallet("registeredDRep");
 
     const tempDRepAuth = await createTempDRepAuth(page, wallet);

--- a/tests/govtool-frontend/playwright/tests/dRep.setup.ts
+++ b/tests/govtool-frontend/playwright/tests/dRep.setup.ts
@@ -7,8 +7,8 @@ import { expect, test as setup } from "@playwright/test";
 import kuberService from "@services/kuberService";
 import walletManager from "lib/walletManager";
 
-const REGISTER_DREP_WALLETS_COUNT = 8;
-const DREP_WALLETS_COUNT = 7;
+const REGISTER_DREP_WALLETS_COUNT = 5;
+const DREP_WALLETS_COUNT = 9;
 
 setup.beforeEach(async () => {
   await setAllureEpic("Setup");

--- a/tests/govtool-frontend/playwright/tests/dRep.setup.ts
+++ b/tests/govtool-frontend/playwright/tests/dRep.setup.ts
@@ -7,8 +7,8 @@ import { expect, test as setup } from "@playwright/test";
 import kuberService from "@services/kuberService";
 import walletManager from "lib/walletManager";
 
-const REGISTER_DREP_WALLETS_COUNT = 9;
-const DREP_WALLETS_COUNT = 9;
+const REGISTER_DREP_WALLETS_COUNT = 8;
+const DREP_WALLETS_COUNT = 7;
 
 setup.beforeEach(async () => {
   await setAllureEpic("Setup");


### PR DESCRIPTION
## List of changes

- Adjusted temporary wallets count
- Removed retries for 2E, 2S and Added timeout to ensure wallet-connection modal not interfere with interactions.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
