### PR TITLE
chore: disable pdf for the envs other than develop

### DIFF
--- a/govtool/frontend/src/App.tsx
+++ b/govtool/frontend/src/App.tsx
@@ -34,6 +34,7 @@ import {
   getItemFromLocalStorage,
   WALLET_LS_KEY,
   removeItemFromLocalStorage,
+  isDevEnv,
 } from "@utils";
 
 import { PDFWrapper } from "./components/organisms/PDFWrapper";
@@ -80,6 +81,7 @@ export default () => {
   }, [checkTheWalletIsActive]);
 
   useEffect(() => {
+    if (!isDevEnv) return;
     if (
       window.location.pathname.includes(PDF_PATHS.proposalDiscussion) &&
       !window.location.pathname.includes(PATHS.proposalPillar.replace("/*", ""))
@@ -99,7 +101,7 @@ export default () => {
       <Routes>
         <Route path={PATHS.home} element={<Home />} />
         <Route path={PATHS.governanceActions} element={<GovernanceActions />} />
-        {!isEnabled && (
+        {isDevEnv && !isEnabled && (
           <Route path={PATHS.proposalPillar} element={<PDFWrapper />} />
         )}
         <Route
@@ -112,10 +114,12 @@ export default () => {
         />
         <Route element={<Dashboard />}>
           <Route path={PATHS.dashboard} element={<DashboardCards />} />
-          <Route
-            path={PATHS.connectedProposalPillar}
-            element={<PDFWrapper />}
-          />
+          {isDevEnv && (
+            <Route
+              path={PATHS.connectedProposalPillar}
+              element={<PDFWrapper />}
+            />
+          )}
           <Route
             path={PATHS.dashboardGovernanceActions}
             element={<DashboardGovernanceActions />}

--- a/govtool/frontend/src/consts/navItems.tsx
+++ b/govtool/frontend/src/consts/navItems.tsx
@@ -1,8 +1,10 @@
 import { IconAcademicCap } from "@intersect.mbo/intersectmbo.org-icons-set";
+import { isDevEnv } from "@utils";
 import i18n from "@/i18n";
+import { theme } from "@/theme";
+
 import { ICONS } from "./icons";
 import { PATHS, PDF_PATHS } from "./paths";
-import { theme } from "@/theme";
 
 export const NAV_ITEMS = [
   {
@@ -100,4 +102,9 @@ export const CONNECTED_NAV_ITEMS = [
     icon: ICONS.faqsIcon,
     newTabLink: "https://docs.sanchogov.tools/faqs",
   },
-];
+].filter((item) => {
+  if (!isDevEnv && item.dataTestId === "proposal-discussion-link") {
+    return false;
+  }
+  return true;
+});

--- a/govtool/frontend/src/utils/index.ts
+++ b/govtool/frontend/src/utils/index.ts
@@ -26,3 +26,4 @@ export * from "./removeDuplicatedProposals";
 export * from "./testIdFromLabel";
 export * from "./validateMetadataHash";
 export * from "./wait";
+export * from "./isDevEnv";

--- a/govtool/frontend/src/utils/isDevEnv.ts
+++ b/govtool/frontend/src/utils/isDevEnv.ts
@@ -1,0 +1,3 @@
+export const isDevEnv = import.meta?.env?.VITE_BASE_URL?.includes(
+  "dev-sanchonet",
+);


### PR DESCRIPTION
## List of changes

- For all the envs except dev & local pdf is being disabled.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
