### PR TITLE
[#1195] Remove unnecessary deployment config dependancy

### DIFF
--- a/scripts/govtool/Makefile
+++ b/scripts/govtool/Makefile
@@ -56,7 +56,7 @@ destroy-cardano-node-and-dbsync: prepare-config
 	$(docker) volume rm $${volumes}
 
 .PHONY: toggle-maintenance
-toggle-maintenance: docker-login prepare-config
+toggle-maintenance: docker-login
 	@:$(call check_defined, cardano_network)
 	@:$(call check_defined, env)
 	@:$(call check_defined, maintenance)


### PR DESCRIPTION
Closes #1195.

The PR optimizes the workflow by eliminating redundant steps, specifically related to the deployment config for the toggle-maintenance target. This adjustment simplifies the process, making it more straightforward and less prone to errors caused by unnecessary dependencies.