### PR TITLE
chore: set defaults for PDF in yml deploy workflows

### DIFF
--- a/.github/workflows/build-and-deploy-beta.yml
+++ b/.github/workflows/build-and-deploy-beta.yml
@@ -38,6 +38,7 @@ jobs:
       SENTRY_IGNORE_API_RESOLUTION_ERROR: "1"
       TRAEFIK_LE_EMAIL: "admin+govtool@binarapps.com"
       USERSNAP_SPACE_API_KEY: ${{ secrets.USERSNAP_SPACE_API_KEY }}
+      IS_PROPOSAL_DISCUSSION_FORUM_ENABLED: "false"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -40,6 +40,7 @@ jobs:
       SENTRY_IGNORE_API_RESOLUTION_ERROR: "1"
       TRAEFIK_LE_EMAIL: "admin+govtool@binarapps.com"
       USERSNAP_SPACE_API_KEY: ${{ secrets.USERSNAP_SPACE_API_KEY }}
+      IS_PROPOSAL_DISCUSSION_FORUM_ENABLED: "false"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-deploy-test.yml
+++ b/.github/workflows/build-and-deploy-test.yml
@@ -40,6 +40,7 @@ jobs:
       SENTRY_IGNORE_API_RESOLUTION_ERROR: "1"
       TRAEFIK_LE_EMAIL: "admin+govtool@binarapps.com"
       USERSNAP_SPACE_API_KEY: ${{ secrets.USERSNAP_SPACE_API_KEY }}
+      IS_PROPOSAL_DISCUSSION_FORUM_ENABLED: "false"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## List of changes

- set defaults for PDF in yml deploy workflows
- These defaults are passed as build arguments to frontend dockerfile. Having them set makes the deployment available

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
