### PR TITLE
Extended Test Coverage for Dashboard and DRep directory

### DIFF
--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.spec.ts
@@ -8,7 +8,7 @@ test.beforeEach(async () => {
   await setAllureEpic("4. Proposal visibility");
 });
 
-test("4A.2. Should access Governance Actions page without connecting wallet", async ({
+test("4A_2. Should access Governance Actions page without connecting wallet", async ({
   page,
 }) => {
   await page.goto("/");
@@ -17,7 +17,7 @@ test("4A.2. Should access Governance Actions page without connecting wallet", as
   await expect(page.getByText(/Governance actions/i)).toHaveCount(2);
 });
 
-test("4B.2. Should restrict voting for users who are not registered as DReps (without wallet connected)", async ({
+test("4B_2. Should restrict voting for users who are not registered as DReps (without wallet connected)", async ({
   page,
 }) => {
   const govActionsPage = new GovernanceActionsPage(page);

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.dRep.spec.ts
@@ -13,7 +13,7 @@ test.use({
   wallet: dRep01Wallet,
 });
 
-test("6H Should restrict dRep registration for dRep", async ({ page }) => {
+test("6H. Should restrict dRep registration for dRep", async ({ page }) => {
   await page.goto(`${environments.frontendUrl}/register_drep`);
 
   await page.waitForTimeout(2_000);

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.dRep.spec.ts
@@ -1,0 +1,22 @@
+import environments from "@constants/environments";
+import { dRep01Wallet } from "@constants/staticWallets";
+import { test } from "@fixtures/walletExtension";
+import { setAllureEpic } from "@helpers/allure";
+import { expect } from "@playwright/test";
+
+test.beforeEach(async () => {
+  await setAllureEpic("6. Miscellaneous");
+});
+
+test.use({
+  storageState: ".auth/dRep01.json",
+  wallet: dRep01Wallet,
+});
+
+test("6H Should restrict dRep registration for dRep", async ({ page }) => {
+  await page.goto(`${environments.frontendUrl}/register_drep`);
+
+  await page.waitForTimeout(2_000);
+
+  await expect(page.getByTestId("name-input")).not.toBeVisible();
+});

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.loggedin.spec.ts
@@ -15,7 +15,7 @@ test.use({
   wallet: user01Wallet,
 });
 
-test("6E Should open Sanchonet docs in a new tab when clicking `Learn More` on dashboards in connected state.", async ({
+test("6E. Should open Sanchonet docs in a new tab when clicking `Learn More` on dashboards in connected state.", async ({
   page,
   context,
 }) => {
@@ -69,7 +69,7 @@ test("6E Should open Sanchonet docs in a new tab when clicking `Learn More` on d
   );
 });
 
-test("6F should open sanchonet docs in a new tab when clicking `info` button of abstain and signal-no-confidence card", async ({
+test("6F. should open sanchonet docs in a new tab when clicking `info` button of abstain and signal-no-confidence card", async ({
   page,
   context,
 }) => {
@@ -95,7 +95,7 @@ test("6F should open sanchonet docs in a new tab when clicking `info` button of 
   );
 });
 
-test("6G Should restrict edit dRep for non dRep", async ({ page }) => {
+test("6G. Should restrict edit dRep for non dRep", async ({ page }) => {
   const editDrepPage = new EditDRepPage(page);
   await editDrepPage.goto();
 

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.loggedin.spec.ts
@@ -1,0 +1,104 @@
+import environments from "@constants/environments";
+import { user01Wallet } from "@constants/staticWallets";
+import { test } from "@fixtures/walletExtension";
+import { setAllureEpic } from "@helpers/allure";
+import DRepDirectoryPage from "@pages/dRepDirectoryPage";
+import EditDRepPage from "@pages/editDRepPage";
+import { expect } from "@playwright/test";
+
+test.beforeEach(async () => {
+  await setAllureEpic("6. Miscellaneous");
+});
+
+test.use({
+  storageState: ".auth/user01.json",
+  wallet: user01Wallet,
+});
+
+test("6E Should open Sanchonet docs in a new tab when clicking `Learn More` on dashboards in connected state.", async ({
+  page,
+  context,
+}) => {
+  await page.goto("/");
+
+  const [delegationLearnMorepage] = await Promise.all([
+    context.waitForEvent("page"),
+    page.getByTestId("delegate-learn-more-button").click(),
+  ]);
+
+  await expect(delegationLearnMorepage).toHaveURL(
+    `${environments.docsUrl}/faqs/ways-to-use-your-voting-power`
+  );
+
+  const [registerLearnMorepage] = await Promise.all([
+    context.waitForEvent("page"),
+    page.getByTestId("register-learn-more-button").click(),
+  ]);
+
+  await expect(registerLearnMorepage).toHaveURL(
+    `${environments.docsUrl}/faqs/what-does-it-mean-to-register-as-a-drep`
+  );
+
+  const [directVoterLearnMorepage] = await Promise.all([
+    context.waitForEvent("page"),
+    page.getByTestId("learn-more-button").first().click(), // BUG should be unique test id
+  ]);
+
+  await expect(directVoterLearnMorepage).toHaveURL(
+    `${environments.docsUrl}/faqs/what-does-it-mean-to-register-as-a-drep`
+  );
+
+  const [GA_LearnMorepage] = await Promise.all([
+    context.waitForEvent("page"),
+    page.getByTestId("learn-more-governance-actions-button").click(),
+  ]);
+
+  await expect(GA_LearnMorepage).toHaveURL("https://sancho.network/actions/");
+
+  const [proposed_GA_VoterLearnMorepage] = await Promise.all([
+    context.waitForEvent("page"),
+    page
+      .locator("div")
+      .filter({ hasText: /^ProposeLearn more$/ })
+      .getByTestId("learn-more-button")
+      .click(),
+  ]); // BUG should be unique test id
+
+  await expect(proposed_GA_VoterLearnMorepage).toHaveURL(
+    `${environments.docsUrl}/faqs/what-is-a-governance-action`
+  );
+});
+
+test("6F should open sanchonet docs in a new tab when clicking `info` button of abstain and signal-no-confidence card", async ({
+  page,
+  context,
+}) => {
+  const dRepDirectoryPage = new DRepDirectoryPage(page);
+  await dRepDirectoryPage.goto();
+
+  await dRepDirectoryPage.automaticDelegationOptionsDropdown.click();
+
+  const [abstain_Info_Page] = await Promise.all([
+    context.waitForEvent("page"),
+    dRepDirectoryPage.abstainInfoButton.click(),
+  ]);
+
+  await expect(abstain_Info_Page).toHaveURL(`${environments.docsUrl}`);
+
+  const [signal_No_Confidence_Info_Page] = await Promise.all([
+    context.waitForEvent("page"),
+    dRepDirectoryPage.signalNoConfidenceInfoButton.click(),
+  ]);
+
+  await expect(signal_No_Confidence_Info_Page).toHaveURL(
+    `${environments.docsUrl}`
+  );
+});
+
+test("6G Should restrict edit dRep for non dRep", async ({ page }) => {
+  const editDrepPage = new EditDRepPage(page);
+  await editDrepPage.goto();
+
+  await page.waitForTimeout(2_000);
+  await expect(editDrepPage.nameInput).not.toBeVisible();
+});

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
@@ -46,7 +46,7 @@ test("6C. Navigation within the dApp", async ({ page, context }) => {
   expect(page.url()).toEqual(`${environments.frontendUrl}/`);
 });
 
-test("6D Should open Sanchonet docs in a new tab when clicking `Learn More` on dashboards in disconnected state.", async ({
+test("6D. Should open Sanchonet docs in a new tab when clicking `Learn More` on dashboards in disconnected state.", async ({
   page,
   context,
 }) => {

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
@@ -1,6 +1,8 @@
+import { user01Wallet } from "@constants/staticWallets";
+import { test } from "@fixtures/walletExtension";
 import { setAllureEpic } from "@helpers/allure";
 import { isMobile, openDrawer } from "@helpers/mobile";
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import environments from "lib/constants/environments";
 
 test.beforeEach(async () => {
@@ -43,4 +45,106 @@ test("6C. Navigation within the dApp", async ({ page, context }) => {
   }
   await page.getByTestId("dashboard-link").click();
   expect(page.url()).toEqual(`${environments.frontendUrl}/`);
+});
+
+test("6D Should open Sanchonet docs in a new tab when clicking `Learn More` on dashboards in disconnected state.", async ({
+  page,
+  context,
+}) => {
+  await page.goto("/");
+
+  const [delegationLearnMorepage] = await Promise.all([
+    context.waitForEvent("page"),
+    page.getByTestId("delegate-learn-more-button").click(),
+  ]);
+
+  await expect(delegationLearnMorepage).toHaveURL(
+    `${environments.docsUrl}/faqs/ways-to-use-your-voting-power`
+  );
+
+  const [registerLearnMorepage] = await Promise.all([
+    context.waitForEvent("page"),
+    page.getByTestId("register-learn-more-button").click(),
+  ]);
+
+  await expect(registerLearnMorepage).toHaveURL(
+    `${environments.docsUrl}/faqs/what-does-it-mean-to-register-as-a-drep`
+  );
+
+  const [directVoterLearnMorepage] = await Promise.all([
+    context.waitForEvent("page"),
+    page.getByTestId("lear-more-about-sole-voter-button").click(),
+  ]);
+
+  await expect(directVoterLearnMorepage).toHaveURL(`${environments.docsUrl}`);
+
+  const [proposed_GA_VoterLearnMorepage] = await Promise.all([
+    context.waitForEvent("page"),
+    page.getByRole("button", { name: "Learn more" }).nth(3).click(),
+  ]);
+
+  await expect(proposed_GA_VoterLearnMorepage).toHaveURL(
+    `${environments.docsUrl}`
+  );
+});
+
+test.describe("wallet connect state", () => {
+  test.use({
+    storageState: ".auth/user01.json",
+    wallet: user01Wallet,
+  });
+
+  test("6E Should open Sanchonet docs in a new tab when clicking `Learn More` on dashboards in connected state.", async ({
+    page,
+    context,
+  }) => {
+    await page.goto("/");
+
+    const [delegationLearnMorepage] = await Promise.all([
+      context.waitForEvent("page"),
+      page.getByTestId("delegate-learn-more-button").click(),
+    ]);
+
+    await expect(delegationLearnMorepage).toHaveURL(
+      `${environments.docsUrl}/faqs/ways-to-use-your-voting-power`
+    );
+
+    const [registerLearnMorepage] = await Promise.all([
+      context.waitForEvent("page"),
+      page.getByTestId("register-learn-more-button").click(),
+    ]);
+
+    await expect(registerLearnMorepage).toHaveURL(
+      `${environments.docsUrl}/faqs/what-does-it-mean-to-register-as-a-drep`
+    );
+
+    const [directVoterLearnMorepage] = await Promise.all([
+      context.waitForEvent("page"),
+      page.getByTestId("learn-more-button").first().click(),
+    ]);
+
+    await expect(directVoterLearnMorepage).toHaveURL(
+      `${environments.docsUrl}/faqs/what-does-it-mean-to-register-as-a-drep`
+    );
+
+    const [GA_LearnMorepage] = await Promise.all([
+      context.waitForEvent("page"),
+      page.getByTestId("learn-more-governance-actions-button").click(),
+    ]);
+
+    await expect(GA_LearnMorepage).toHaveURL("https://sancho.network/actions/");
+
+    const [proposed_GA_VoterLearnMorepage] = await Promise.all([
+      context.waitForEvent("page"),
+      page
+        .locator("div")
+        .filter({ hasText: /^ProposeLearn more$/ })
+        .getByTestId("learn-more-button")
+        .click(),
+    ]);
+
+    await expect(proposed_GA_VoterLearnMorepage).toHaveURL(
+      `${environments.docsUrl}/faqs/what-is-a-governance-action`
+    );
+  });
 });

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
@@ -2,6 +2,7 @@ import { user01Wallet } from "@constants/staticWallets";
 import { test } from "@fixtures/walletExtension";
 import { setAllureEpic } from "@helpers/allure";
 import { isMobile, openDrawer } from "@helpers/mobile";
+import DRepDirectoryPage from "@pages/dRepDirectoryPage";
 import { expect } from "@playwright/test";
 import environments from "lib/constants/environments";
 
@@ -145,6 +146,32 @@ test.describe("wallet connect state", () => {
 
     await expect(proposed_GA_VoterLearnMorepage).toHaveURL(
       `${environments.docsUrl}/faqs/what-is-a-governance-action`
+    );
+  });
+
+  test("6F should open sanchonet docs in a new tab when clicking `info` button of abstain and signal-no-confidence card", async ({
+    page,
+    context,
+  }) => {
+    const dRepDirectoryPage = new DRepDirectoryPage(page);
+    await dRepDirectoryPage.goto();
+
+    await dRepDirectoryPage.automaticDelegationOptionsDropdown.click();
+
+    const [abstain_Info_Page] = await Promise.all([
+      context.waitForEvent("page"),
+      dRepDirectoryPage.abstainInfoButton.click(),
+    ]);
+
+    await expect(abstain_Info_Page).toHaveURL(`${environments.docsUrl}`);
+
+    const [signal_No_Confidence_Info_Page] = await Promise.all([
+      context.waitForEvent("page"),
+      dRepDirectoryPage.signalNoConfidenceInfoButton.click(),
+    ]);
+
+    await expect(signal_No_Confidence_Info_Page).toHaveURL(
+      `${environments.docsUrl}`
     );
   });
 });

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
@@ -1,9 +1,6 @@
-import { dRep01Wallet, user01Wallet } from "@constants/staticWallets";
 import { test } from "@fixtures/walletExtension";
 import { setAllureEpic } from "@helpers/allure";
 import { isMobile, openDrawer } from "@helpers/mobile";
-import DRepDirectoryPage from "@pages/dRepDirectoryPage";
-import EditDRepPage from "@pages/editDRepPage";
 import { expect } from "@playwright/test";
 import environments from "lib/constants/environments";
 
@@ -82,120 +79,10 @@ test("6D Should open Sanchonet docs in a new tab when clicking `Learn More` on d
 
   const [proposed_GA_VoterLearnMorepage] = await Promise.all([
     context.waitForEvent("page"),
-    page.getByRole("button", { name: "Learn more" }).nth(3).click(),
+    page.getByRole("button", { name: "Learn more" }).nth(3).click(), // BUG missing test id
   ]);
 
   await expect(proposed_GA_VoterLearnMorepage).toHaveURL(
     `${environments.docsUrl}`
   );
-});
-
-test.describe("wallet connect state", () => {
-  test.use({
-    storageState: ".auth/user01.json",
-    wallet: user01Wallet,
-  });
-
-  test("6E Should open Sanchonet docs in a new tab when clicking `Learn More` on dashboards in connected state.", async ({
-    page,
-    context,
-  }) => {
-    await page.goto("/");
-
-    const [delegationLearnMorepage] = await Promise.all([
-      context.waitForEvent("page"),
-      page.getByTestId("delegate-learn-more-button").click(),
-    ]);
-
-    await expect(delegationLearnMorepage).toHaveURL(
-      `${environments.docsUrl}/faqs/ways-to-use-your-voting-power`
-    );
-
-    const [registerLearnMorepage] = await Promise.all([
-      context.waitForEvent("page"),
-      page.getByTestId("register-learn-more-button").click(),
-    ]);
-
-    await expect(registerLearnMorepage).toHaveURL(
-      `${environments.docsUrl}/faqs/what-does-it-mean-to-register-as-a-drep`
-    );
-
-    const [directVoterLearnMorepage] = await Promise.all([
-      context.waitForEvent("page"),
-      page.getByTestId("learn-more-button").first().click(),
-    ]);
-
-    await expect(directVoterLearnMorepage).toHaveURL(
-      `${environments.docsUrl}/faqs/what-does-it-mean-to-register-as-a-drep`
-    );
-
-    const [GA_LearnMorepage] = await Promise.all([
-      context.waitForEvent("page"),
-      page.getByTestId("learn-more-governance-actions-button").click(),
-    ]);
-
-    await expect(GA_LearnMorepage).toHaveURL("https://sancho.network/actions/");
-
-    const [proposed_GA_VoterLearnMorepage] = await Promise.all([
-      context.waitForEvent("page"),
-      page
-        .locator("div")
-        .filter({ hasText: /^ProposeLearn more$/ })
-        .getByTestId("learn-more-button")
-        .click(),
-    ]);
-
-    await expect(proposed_GA_VoterLearnMorepage).toHaveURL(
-      `${environments.docsUrl}/faqs/what-is-a-governance-action`
-    );
-  });
-
-  test("6F should open sanchonet docs in a new tab when clicking `info` button of abstain and signal-no-confidence card", async ({
-    page,
-    context,
-  }) => {
-    const dRepDirectoryPage = new DRepDirectoryPage(page);
-    await dRepDirectoryPage.goto();
-
-    await dRepDirectoryPage.automaticDelegationOptionsDropdown.click();
-
-    const [abstain_Info_Page] = await Promise.all([
-      context.waitForEvent("page"),
-      dRepDirectoryPage.abstainInfoButton.click(),
-    ]);
-
-    await expect(abstain_Info_Page).toHaveURL(`${environments.docsUrl}`);
-
-    const [signal_No_Confidence_Info_Page] = await Promise.all([
-      context.waitForEvent("page"),
-      dRepDirectoryPage.signalNoConfidenceInfoButton.click(),
-    ]);
-
-    await expect(signal_No_Confidence_Info_Page).toHaveURL(
-      `${environments.docsUrl}`
-    );
-  });
-
-  test("6G Should restrict edit dRep for non dRep", async ({ page }) => {
-    const editDrepPage = new EditDRepPage(page);
-    await editDrepPage.goto();
-
-    await page.waitForTimeout(2_000);
-    await expect(editDrepPage.nameInput).not.toBeVisible();
-  });
-});
-
-test.describe("Registration Restriction", () => {
-  test.use({
-    storageState: ".auth/dRep01.json",
-    wallet: dRep01Wallet,
-  });
-
-  test("6H Should restrict dRep registration for dRep", async ({ page }) => {
-    await page.goto(`${environments.frontendUrl}/register_drep`);
-
-    await page.waitForTimeout(2_000);
-
-    await expect(page.getByTestId("name-input")).not.toBeVisible();
-  });
 });

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
@@ -1,8 +1,9 @@
-import { user01Wallet } from "@constants/staticWallets";
+import { dRep01Wallet, user01Wallet } from "@constants/staticWallets";
 import { test } from "@fixtures/walletExtension";
 import { setAllureEpic } from "@helpers/allure";
 import { isMobile, openDrawer } from "@helpers/mobile";
 import DRepDirectoryPage from "@pages/dRepDirectoryPage";
+import EditDRepPage from "@pages/editDRepPage";
 import { expect } from "@playwright/test";
 import environments from "lib/constants/environments";
 
@@ -173,5 +174,28 @@ test.describe("wallet connect state", () => {
     await expect(signal_No_Confidence_Info_Page).toHaveURL(
       `${environments.docsUrl}`
     );
+  });
+
+  test("6G Should restrict edit dRep for non dRep", async ({ page }) => {
+    const editDrepPage = new EditDRepPage(page);
+    await editDrepPage.goto();
+
+    await page.waitForTimeout(2_000);
+    await expect(editDrepPage.nameInput).not.toBeVisible();
+  });
+});
+
+test.describe("Registration Restriction", () => {
+  test.use({
+    storageState: ".auth/dRep01.json",
+    wallet: dRep01Wallet,
+  });
+
+  test("6H Should restrict dRep registration for dRep", async ({ page }) => {
+    await page.goto(`${environments.frontendUrl}/register_drep`);
+
+    await page.waitForTimeout(2_000);
+
+    await expect(page.getByTestId("name-input")).not.toBeVisible();
   });
 });


### PR DESCRIPTION
## List of changes

- Added test for dashboard learn more button action
- Added test for abstain and signal-no-confidence info button action
- Added test for  DRep registration and edit dRep registration page restriction

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
