### PR TITLE
1210-drep-registration-json-file-name-beyond-view-when-drep-title-is-long

### DIFF
--- a/govtool/frontend/src/components/organisms/CreateGovernanceActionSteps/StorageInformation.tsx
+++ b/govtool/frontend/src/components/organisms/CreateGovernanceActionSteps/StorageInformation.tsx
@@ -11,7 +11,7 @@ import {
 } from "@hooks";
 import { Step } from "@molecules";
 import { BgCard, ControlledField } from "@organisms";
-import { URL_REGEX, openInNewTab } from "@utils";
+import { URL_REGEX, ellipsizeText, openInNewTab } from "@utils";
 
 type StorageInformationProps = {
   setStep: Dispatch<SetStateAction<number>>;
@@ -31,7 +31,7 @@ export const StorageInformation = ({ setStep }: StorageInformationProps) => {
   } = useCreateGovernanceActionForm(setStep);
   const { screenWidth } = useScreenDimension();
 
-  const fileName = getValues("governance_action_type");
+  const fileName = getValues("governance_action_type") as string;
 
   const openGuideAboutStoringInformation = () =>
     openInNewTab(
@@ -94,7 +94,7 @@ export const StorageInformation = ({ setStep }: StorageInformationProps) => {
               }}
               variant="outlined"
             >
-              {`${fileName}.jsonld`}
+              {`${ellipsizeText(fileName, 8)}.jsonld`}
             </Button>
           }
           componentsLayoutStyles={{

--- a/govtool/frontend/src/components/organisms/EditDRepInfoSteps/EditDRepStorageInformation.tsx
+++ b/govtool/frontend/src/components/organisms/EditDRepInfoSteps/EditDRepStorageInformation.tsx
@@ -11,7 +11,7 @@ import {
 } from "@hooks";
 import { Step } from "@molecules";
 import { BgCard, ControlledField } from "@organisms";
-import { openInNewTab } from "@utils";
+import { ellipsizeText, openInNewTab } from "@utils";
 
 type StorageInformationProps = {
   setStep: Dispatch<SetStateAction<number>>;
@@ -94,7 +94,7 @@ export const EditDRepStorageInformation = ({
               }}
               variant="outlined"
             >
-              {`${fileName}.jsonld`}
+              {`${ellipsizeText(fileName, 8)}.jsonld`}
             </Button>
           }
           label={t("editMetadata.storingInformationStep1Label")}


### PR DESCRIPTION
## List of changes

- Add trim func to file lenght for edit drep data and creat GA forms

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1210)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
