### PR TITLE
fix/1207-dashboard-drep-card-drep_name-is-shown-instead-title-of-drep-passed-during-registration

### DIFF
--- a/govtool/frontend/src/components/molecules/DelegationAction.tsx
+++ b/govtool/frontend/src/components/molecules/DelegationAction.tsx
@@ -3,51 +3,47 @@ import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 
 import { Typography } from "@atoms";
 import { gray } from "@consts";
-import { useTranslation } from "@hooks";
 
 import { Card } from "./Card";
 import { DirectVoterActionProps } from "./types";
 
 export const DelegationAction = ({
   dRepId,
+  drepName,
   onCardClick,
   sx,
-}: DirectVoterActionProps) => {
-  const { t } = useTranslation();
-
-  return (
-    <Card
-      border
-      elevation={0}
-      sx={{
-        alignItems: "center",
-        backgroundColor: (theme) => theme.palette.neutralWhite,
-        borderColor: gray.c100,
-        display: "flex",
-        justifyContent: "space-between",
-        px: 1.5,
-        py: 1,
-        cursor: "pointer",
-        ...sx,
-      }}
-      onCardClick={onCardClick}
-    >
-      <Box sx={{ width: "90%" }}>
-        <Typography fontWeight={600} variant="body2">
-          {t("dashboard.cards.drepName")}
-        </Typography>
-        <Typography
-          sx={{
-            mt: 0.5,
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-          }}
-          variant="body2"
-        >
-          {dRepId}
-        </Typography>
-      </Box>
-      <ArrowForwardIosIcon color="primary" sx={{ height: 16, width: 24 }} />
-    </Card>
-  );
-};
+}: DirectVoterActionProps) => (
+  <Card
+    border
+    elevation={0}
+    sx={{
+      alignItems: "center",
+      backgroundColor: (theme) => theme.palette.neutralWhite,
+      borderColor: gray.c100,
+      display: "flex",
+      justifyContent: "space-between",
+      px: 1.5,
+      py: 1,
+      cursor: "pointer",
+      ...sx,
+    }}
+    onCardClick={onCardClick}
+  >
+    <Box sx={{ width: "90%" }}>
+      <Typography fontWeight={600} variant="body2">
+        {drepName}
+      </Typography>
+      <Typography
+        sx={{
+          mt: 0.5,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        }}
+        variant="body2"
+      >
+        {dRepId}
+      </Typography>
+    </Box>
+    <ArrowForwardIosIcon color="primary" sx={{ height: 16, width: 24 }} />
+  </Card>
+);

--- a/govtool/frontend/src/components/molecules/types.ts
+++ b/govtool/frontend/src/components/molecules/types.ts
@@ -19,6 +19,7 @@ export type StepProps = {
 
 export type DirectVoterActionProps = {
   dRepId: string;
+  drepName: string;
   onCardClick: () => void;
   sx?: SxProps;
 };

--- a/govtool/frontend/src/context/pendingTransaction/utils.tsx
+++ b/govtool/frontend/src/context/pendingTransaction/utils.tsx
@@ -72,7 +72,7 @@ export const refetchData = async (
     ) {
       return data.dRepView;
     }
-    return data.dRepHash;
+    return data.dRepView;
   }
   if (type === "registerAsDrep" || type === "retireAsDrep")
     return data.isRegisteredAsDRep;

--- a/govtool/frontend/src/pages/DRepDirectoryContent.tsx
+++ b/govtool/frontend/src/pages/DRepDirectoryContent.tsx
@@ -107,7 +107,9 @@ export const DRepDirectoryContent: FC<DRepDirectoryContentProps> = ({
     ? [yourselfDRep, ...dRepsWithoutYourself]
     : dRepList;
   const inProgressDelegationDRepData = dRepListToDisplay.find(
-    (dRep) => dRep.drepId === inProgressDelegation,
+    (dRep) =>
+      dRep.drepId === inProgressDelegation ||
+      dRep.view === inProgressDelegation,
   );
 
   const isAnAutomatedVotingOptionChosen =
@@ -221,7 +223,7 @@ export const DRepDirectoryContent: FC<DRepDirectoryContentProps> = ({
                     isDelegating === dRep.view || isDelegating === dRep.drepId
                   }
                   isMe={isSameDRep(dRep, myDRepId)}
-                  onDelegate={() => delegate(dRep.drepId)}
+                  onDelegate={() => delegate(dRep.view)}
                 />
               </Box>
             );


### PR DESCRIPTION
## List of changes

- Add drepname to dashboard delegaition card

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1207)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
