### PR TITLE
fix: fix empty strings drep data validation

### DIFF
--- a/govtool/metadata-validation/src/schemas/cipStandardSchema.ts
+++ b/govtool/metadata-validation/src/schemas/cipStandardSchema.ts
@@ -64,9 +64,9 @@ export const cipStandardSchema: StandardSpecification = {
       '@value': Joi.string().valid('blake2b-256').required(),
     }),
     body: Joi.object({
-      bio: Joi.object({ '@value': Joi.string() }),
-      dRepName: Joi.object({ '@value': Joi.string() }),
-      email: Joi.object({ '@value': Joi.string() }),
+      bio: Joi.object({ '@value': Joi.string().allow('') }),
+      dRepName: Joi.object({ '@value': Joi.string().allow('') }),
+      email: Joi.object({ '@value': Joi.string().allow('') }),
       references: Joi.array().items(
         Joi.object({
           '@type': Joi.string(),


### PR DESCRIPTION
## List of changes

- fix empty strings drep data validation in validation service

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
