### PR TITLE
fix: fix uri validation of metadatas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ changes.
 - Fix all the existing typescript errors [Issue 514](https://github.com/IntersectMBO/govtool/issues/514)
 - Fix endless spinner on a dashboard [Issue 539](https://github.com/IntersectMBO/govtool/issues/539)
 - Remove wrongly appended `Yourself` filter on DRep Directory [Issue 1028](https://github.com/IntersectMBO/govtool/issues/1028)
+- Fix validation of uris in metadata [Issue 1011](https://github.com/IntersectMBO/govtool/issues/1011)
 
 ### Changed
 

--- a/govtool/metadata-validation/src/schemas/cipStandardSchema.ts
+++ b/govtool/metadata-validation/src/schemas/cipStandardSchema.ts
@@ -40,7 +40,7 @@ export const cipStandardSchema: StandardSpecification = {
             '@value': Joi.string().required(),
           }),
           uri: Joi.object({
-            '@value': Joi.string().uri().required(),
+            '@value': Joi.string().required(),
           }),
           referenceHash: Joi.object({
             hashDigest: Joi.string().required(),
@@ -71,10 +71,10 @@ export const cipStandardSchema: StandardSpecification = {
         Joi.object({
           '@type': Joi.string(),
           label: Joi.object({
-            '@value': Joi.string().required(),
+            '@value': Joi.string().allow('').required(),
           }),
           uri: Joi.object({
-            '@value': Joi.string().uri().required(),
+            '@value': Joi.string().required(),
           }),
           referenceHash: Joi.object({
             hashDigest: Joi.string().required(),


### PR DESCRIPTION
## List of changes

- fix uri validation of metadatas
Now it should allow urls without a protocol.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1011)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
