### PR TITLE
fix/1231-ga-treasury-unable-to-add-proposal-with-this-type-when-bech32-receiving-address-is-used

### DIFF
--- a/govtool/frontend/src/consts/governanceAction/fields.ts
+++ b/govtool/frontend/src/consts/governanceAction/fields.ts
@@ -1,4 +1,4 @@
-import { bech32Validation, numberValidation } from "@utils";
+import { isRewardAddress, numberValidation } from "@utils";
 import I18n from "@/i18n";
 import {
   GovernanceActionType,
@@ -106,7 +106,7 @@ export const GOVERNANCE_ACTION_FIELDS: GovernanceActionFields = {
       placeholderI18nKey:
         "createGovernanceAction.fields.declarations.receivingAddress.placeholder",
       rules: {
-        validate: bech32Validation,
+        validate: isRewardAddress,
       },
     },
     amount: {

--- a/govtool/frontend/src/i18n/locales/en.ts
+++ b/govtool/frontend/src/i18n/locales/en.ts
@@ -370,6 +370,7 @@ export const en = {
       },
       errors: {
         tooLongUrl: "Url must be less than 128 bytes",
+        mustBeStakeAddress: "It must be reward address in bech32 format",
       },
       registerAsDRep: {
         bio: "Bio",

--- a/govtool/frontend/src/utils/isValidFormat.ts
+++ b/govtool/frontend/src/utils/isValidFormat.ts
@@ -1,3 +1,7 @@
+import {
+  Address,
+  RewardAddress,
+} from "@emurgo/cardano-serialization-lib-asmjs";
 import i18n from "@/i18n";
 
 export const URL_REGEX =
@@ -25,4 +29,13 @@ export function isValidURLLength(s: string) {
   const byteLength = encoder.encode(s).length;
 
   return byteLength <= 128 ? true : i18n.t("forms.errors.tooLongUrl");
+}
+
+export async function isRewardAddress(address: string) {
+  try {
+    const stake = RewardAddress.from_address(Address.from_bech32(address));
+    return stake ? true : i18n.t("forms.errors.mustBeStakeAddress");
+  } catch (e) {
+    return i18n.t("forms.errors.mustBeStakeAddress");
+  }
 }

--- a/govtool/frontend/src/utils/tests/isValidFormat.test.ts
+++ b/govtool/frontend/src/utils/tests/isValidFormat.test.ts
@@ -1,4 +1,5 @@
-import { isValidURLFormat, isValidHashFormat } from "..";
+import i18n from "@/i18n";
+import { isValidURLFormat, isValidHashFormat, isRewardAddress } from "..";
 
 describe("isValidURLFormat", () => {
   it("returns true for valid HTTP URLs", () => {
@@ -67,5 +68,26 @@ describe("isValidHashFormat", () => {
   it("returns false for empty string", () => {
     const empty = "";
     expect(isValidHashFormat(empty)).toBe(false);
+  });
+});
+
+describe("isRewardAddress", () => {
+  it("returns true for stake address", async () => {
+    const validStake =
+      "stake_test1urmj8g9d09pdhrzxcuhhfkx2rxmldnrzyumyt90qvmurrpgg4c5zj";
+    const result = await isRewardAddress(validStake);
+    expect(result).toBe(true);
+  });
+
+  it("returns error for empty string", async () => {
+    const invalid = "";
+    const result = await isRewardAddress(invalid);
+    expect(result).toBe(i18n.t("forms.errors.mustBeStakeAddress"));
+  });
+
+  it("returns error for another bech32 string", async () => {
+    const invalid = "drep1l8uyy66sm8u82h82gc8hkcy2xu24dl8ffsh58aa0v7d37yp48u8";
+    const result = await isRewardAddress(invalid);
+    expect(result).toBe(i18n.t("forms.errors.mustBeStakeAddress"));
   });
 });


### PR DESCRIPTION
## List of changes

- Add reward address CSL validation

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
