### PR TITLE
[#1234] Add reddis support for storing metadata validation results

### DIFF
--- a/.github/workflows/build-and-deploy-beta.yml
+++ b/.github/workflows/build-and-deploy-beta.yml
@@ -57,6 +57,7 @@ jobs:
       TRAEFIK_LE_EMAIL: "admin+govtool@binarapps.com"
       USERSNAP_SPACE_API_KEY: ${{ secrets.USERSNAP_SPACE_API_KEY }}
       IS_PROPOSAL_DISCUSSION_FORUM_ENABLED: ${{ inputs.isProposalDiscussionForumEnabled == 'enabled' }}
+      REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -57,6 +57,7 @@ jobs:
       TRAEFIK_LE_EMAIL: "admin+govtool@binarapps.com"
       USERSNAP_SPACE_API_KEY: ${{ secrets.USERSNAP_SPACE_API_KEY }}
       IS_PROPOSAL_DISCUSSION_FORUM_ENABLED: ${{ inputs.isProposalDiscussionForumEnabled == 'enabled' }}
+      REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -60,6 +60,7 @@ jobs:
       TRAEFIK_LE_EMAIL: "admin+govtool@binarapps.com"
       USERSNAP_SPACE_API_KEY: ${{ secrets.USERSNAP_SPACE_API_KEY }}
       IS_PROPOSAL_DISCUSSION_FORUM_ENABLED: ${{github.event_name == 'push' && 'false' || inputs.isProposalDiscussionForumEnabled == 'enabled'}}
+      REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-deploy-test.yml
+++ b/.github/workflows/build-and-deploy-test.yml
@@ -60,6 +60,7 @@ jobs:
       TRAEFIK_LE_EMAIL: "admin+govtool@binarapps.com"
       USERSNAP_SPACE_API_KEY: ${{ secrets.USERSNAP_SPACE_API_KEY }}
       IS_PROPOSAL_DISCUSSION_FORUM_ENABLED: ${{github.event_name == 'push' && 'false' || inputs.isProposalDiscussionForumEnabled == 'enabled'}}
+      REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ changes.
 
 ### Added
 
+- added separate async process that fetches new voting_anchors, validates their metadata using metadata-validation service, and then stores it in Redis database [Issue 1234](https://github.com/IntersectMBO/govtool/issues/1234)
 - added `bio` `dRepName` `email` `references` `metadataValid` and `metadataStatus` fields to `drep/list`
 - added `metadatavalidationmaxconcurrentrequests` field to the backend config
 - added `metadata/validate` endpoint [Issue 876](https://github.com/IntersectMBO/govtool/issues/876)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ changes.
 
 ### Changed
 
+- `redis` config fields changed [Issue 1234](https://github.com/IntersectMBO/govtool/issues/1234)
 - `proposal.about` changed to `proposal.abstract`
 - `drep/info` now returns 4 different tx hashes instead of one latest tx hash [Issue 688](https://github.com/IntersectMBO/govtool/issues/688)
 - `proposal/list` allows user to search by tx hash [Issue 603](https://github.com/IntersectMBO/govtool/issues/603)

--- a/govtool/backend/app/Main.hs
+++ b/govtool/backend/app/Main.hs
@@ -8,6 +8,7 @@
 
 module Main where
 
+import           Control.Concurrent                     (forkIO)
 import           Control.Concurrent.QSem                (newQSem)
 import           Control.Exception                      (Exception,
                                                          SomeException,
@@ -70,6 +71,7 @@ import           VVA.API
 import           VVA.API.Types
 import           VVA.CommandLine
 import           VVA.Config
+import           VVA.Metadata (startFetchProcess)
 import           VVA.Types                              (AppEnv (..),
                                                          AppError (CriticalError, NotFoundError, ValidationError, InternalError),
                                                          CacheEnv (..))
@@ -136,6 +138,13 @@ startApp vvaConfig = do
   vvaTlsManager <- newManager tlsManagerSettings
   qsem <- newQSem (metadataValidationMaxConcurrentRequests vvaConfig)
   let appEnv = AppEnv {vvaConfig=vvaConfig, vvaCache=cacheEnv, vvaConnectionPool=connectionPool, vvaTlsManager, vvaMetadataQSem=qsem}
+
+  _ <- forkIO $ do
+     result <- runReaderT (runExceptT startFetchProcess) appEnv
+     case result of
+        Left e -> throw e
+        Right _ -> return ()
+
   server' <- mkVVAServer appEnv
   runSettings settings server'
 

--- a/govtool/backend/example-config.json
+++ b/govtool/backend/example-config.json
@@ -13,5 +13,7 @@
     "sentryenv": "dev",
     "metadatavalidationhost": "localhost",
     "metadatavalidationport": 3001,
-    "metadatavalidationmaxconcurrentrequests": 10
+    "metadatavalidationmaxconcurrentrequests": 10,
+    "redishost": "localhost",
+    "redisport": 6379
 }

--- a/govtool/backend/example-config.json
+++ b/govtool/backend/example-config.json
@@ -14,6 +14,9 @@
     "metadatavalidationhost": "localhost",
     "metadatavalidationport": 3001,
     "metadatavalidationmaxconcurrentrequests": 10,
-    "redishost": "localhost",
-    "redisport": 6379
+    "redisconfig" : {
+      "host"    : "localhost",
+      "port"    : 8094,
+      "password": null
+  }
 }

--- a/govtool/backend/sql/get-voting-anchors.sql
+++ b/govtool/backend/sql/get-voting-anchors.sql
@@ -1,0 +1,3 @@
+select id, url, encode(data_hash, 'hex'), type::text
+from voting_anchor
+where voting_anchor.id > ?

--- a/govtool/backend/src/VVA/Config.hs
+++ b/govtool/backend/src/VVA/Config.hs
@@ -23,6 +23,8 @@ module VVA.Config
     , getDbSyncConnectionString
     , getServerHost
     , getServerPort
+    , getRedisHost
+    , getRedisPort
     , vvaConfigToText
     , getMetadataValidationHost
     , getMetadataValidationPort
@@ -88,6 +90,10 @@ data VVAConfigInternal
       , vVAConfigInternalMetadataValidationPort :: Int
         -- | Maximum number of concurrent metadata requests
       , vVAConfigInternalMetadataValidationMaxConcurrentRequests :: Int
+        -- | Redis host
+      , vVAConfigInternalRedisHost :: Text
+        -- | Redis port
+      , vVAConfigInternalRedisPort :: Int
       }
   deriving (FromConfig, Generic, Show)
 
@@ -102,7 +108,9 @@ instance DefaultConfig VVAConfigInternal where
         vVAConfigInternalSentryEnv = "development",
         vVAConfigInternalMetadataValidationHost = "localhost",
         vVAConfigInternalMetadataValidationPort = 3001,
-        vVAConfigInternalMetadataValidationMaxConcurrentRequests = 10
+        vVAConfigInternalMetadataValidationMaxConcurrentRequests = 10,
+        vVAConfigInternalRedisHost = "localhost",
+        vVAConfigInternalRedisPort = 6379
       }
 
 -- | DEX configuration.
@@ -126,6 +134,10 @@ data VVAConfig
       , metadataValidationPort :: Int
         -- | Maximum number of concurrent metadata requests
       , metadataValidationMaxConcurrentRequests :: Int
+        -- | Redis host
+      , redisHost :: Text
+        -- | Redis port
+      , redisPort :: Int
       }
   deriving (Generic, Show, ToJSON)
 
@@ -169,7 +181,9 @@ convertConfig VVAConfigInternal {..} =
       sentryEnv = vVAConfigInternalSentryEnv,
       metadataValidationHost = vVAConfigInternalMetadataValidationHost,
       metadataValidationPort = vVAConfigInternalMetadataValidationPort,
-      metadataValidationMaxConcurrentRequests = vVAConfigInternalMetadataValidationMaxConcurrentRequests
+      metadataValidationMaxConcurrentRequests = vVAConfigInternalMetadataValidationMaxConcurrentRequests,
+      redisHost = vVAConfigInternalRedisHost,
+      redisPort = vVAConfigInternalRedisPort
     }
 
 -- | Load configuration from a file specified on the command line.  Load from
@@ -207,6 +221,18 @@ getServerHost ::
   (Has VVAConfig r, MonadReader r m) =>
   m Text
 getServerHost = asks (serverHost . getter)
+
+-- | Access redis host
+getRedisHost ::
+  (Has VVAConfig r, MonadReader r m) =>
+  m Text
+getRedisHost = asks (redisHost . getter)
+
+-- | Access redis port
+getRedisPort ::
+  (Has VVAConfig r, MonadReader r m) =>
+  m Int
+getRedisPort = asks (redisPort . getter)
 
 -- | Access MetadataValidationService host
 getMetadataValidationHost ::

--- a/govtool/backend/src/VVA/Metadata.hs
+++ b/govtool/backend/src/VVA/Metadata.hs
@@ -97,7 +97,12 @@ storeMetadata ::
 storeMetadata metadataResults = do
     port <- getRedisPort
     host <- getRedisHost
-    conn <- liftIO $ Redis.checkedConnect $ Redis.defaultConnectInfo {Redis.connectHost = unpack host, Redis.connectPort = Redis.PortNumber $ fromIntegral port}
+    pass <- fmap Text.encodeUtf8 <$> getRedisPassword
+    conn <- liftIO $ Redis.checkedConnect $ Redis.defaultConnectInfo
+        { Redis.connectHost = unpack host
+        , Redis.connectPort = Redis.PortNumber $ fromIntegral port
+        , Redis.connectAuth = pass
+        }
     liftIO $ Redis.runRedis conn $ do
         forM metadataResults $ \(reddisId, metadataValidationResult) -> do
                 _ <- Redis.set (Text.encodeUtf8 reddisId) (toStrict $ encode metadataValidationResult)

--- a/govtool/backend/src/VVA/Metadata.hs
+++ b/govtool/backend/src/VVA/Metadata.hs
@@ -1,10 +1,15 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeApplications  #-}
 
 module VVA.Metadata where
 
-import Prelude hiding (lookup)
+import qualified Database.Redis as Redis
+import Control.Concurrent (threadDelay)
+import           Prelude hiding (lookup)
 import           Control.Monad.Except       (MonadError, throwError)
 import           Control.Monad.Reader
 import           Control.Exception          (try, Exception)
@@ -12,16 +17,16 @@ import           Control.Exception          (try, Exception)
 import           Data.Typeable              (Typeable)
 import           Data.Vector                (toList)
 import           Data.Aeson.KeyMap          (lookup)
-import           Data.Aeson                 (Value(..), decode, encode, object, (.=))
+import           Data.Aeson                 (FromJSON, ToJSON, Value(..), decode, encode, object, (.=))
 import           Data.Maybe                 (fromJust)
-import           Data.ByteString            (ByteString)
+import           Data.ByteString            (ByteString, fromStrict, toStrict)
 import           Data.FileEmbed             (embedFile)
 import           Data.Has                   (Has, getter)
 import           Data.String                (fromString)
 import           Data.Text                  (Text, unpack, pack)
 import qualified Data.Text.Encoding         as Text
 import           Data.Time.Clock
-
+import           Data.List                  (partition)
 import qualified Database.PostgreSQL.Simple as SQL
 
 import           VVA.Config
@@ -30,9 +35,92 @@ import           VVA.Types
 import Network.HTTP.Client
 import Network.HTTP.Client.TLS
 import Data.Aeson (encode, object, (.=))
+import           Data.Scientific
 
-validateMetadata
-    :: (Has VVAConfig r, Has Manager r, MonadReader r m, MonadIO m, MonadError AppError m)
+sqlFrom :: ByteString -> SQL.Query
+sqlFrom bs = fromString $ unpack $ Text.decodeUtf8 bs
+
+getVotingAnchorsSql :: SQL.Query
+getVotingAnchorsSql = sqlFrom $(embedFile "sql/get-voting-anchors.sql")
+
+getNewVotingAnchors ::
+    (Has ConnectionPool r, Has Manager r, Has VVAConfig r, MonadReader r m, MonadIO m, MonadFail m, MonadError AppError m)
+    => Integer
+    -> m [VotingAnchor]
+getNewVotingAnchors lastId = do
+    anchors <- withPool $ \conn -> do
+        liftIO $ SQL.query conn getVotingAnchorsSql $ SQL.Only (lastId :: Integer)
+    return $ map (\(id, url, hash, type') -> VotingAnchor (floor @Scientific id) url hash type') anchors
+
+startFetchProcess ::
+    (Has ConnectionPool r, Has Manager r, Has VVAConfig r, MonadReader r m, MonadIO m, MonadFail m, MonadError AppError m)
+    => m ()
+startFetchProcess = go 0
+    where
+        go latestKnownId = do
+            liftIO $ putStrLn "Fetching metadata..."
+
+            anchors <- getNewVotingAnchors latestKnownId
+            if null anchors
+                then do
+                    liftIO $ threadDelay (20 * 1000000)
+                    go latestKnownId
+                else do
+                    (drepMetadata, proposalMetadata) <- processAnchors anchors
+                    storeMetadata drepMetadata
+                    storeMetadata proposalMetadata
+
+                    let newId = maximum $ map votingAnchorId anchors
+
+                    liftIO $ putStrLn ("Stored " <> show (length anchors) <> " voting anchors")
+
+                    liftIO $ threadDelay (20 * 1000000)
+                    go newId
+
+
+processAnchors ::
+   (Has ConnectionPool r, Has Manager r, Has VVAConfig r, MonadReader r m, MonadIO m, MonadFail m, MonadError AppError m)
+   => [VotingAnchor]
+   -> m ( [(Text, MetadataValidationResult DRepMetadata)]
+        , [(Text, MetadataValidationResult ProposalMetadata)]
+        )
+processAnchors anchors = do
+    let (drepAnchors, proposalAnchors) = partition ((== "other") . votingAnchorType) anchors
+    drepMetadata <- mapM (\(VotingAnchor id url hash _) -> (url<>"#"<>hash, ) <$> getDRepMetadataValidationResult' url hash) drepAnchors
+    proposalMetadata <- mapM (\(VotingAnchor id url hash _) -> (url<>"#"<>hash, ) <$> getProposalMetadataValidationResult' url hash) proposalAnchors
+    return (drepMetadata, proposalMetadata)
+
+storeMetadata ::
+    (Has ConnectionPool r, Has Manager r, Has VVAConfig r, MonadReader r m, MonadIO m, MonadFail m, MonadError AppError m, ToJSON a)
+    => [(Text, MetadataValidationResult a)]
+    -> m ()
+storeMetadata metadataResults = do
+    port <- getRedisPort
+    host <- getRedisHost
+    conn <- liftIO $ Redis.checkedConnect $ Redis.defaultConnectInfo {Redis.connectHost = unpack host, Redis.connectPort = Redis.PortNumber $ fromIntegral port}
+    liftIO $ Redis.runRedis conn $ do
+        forM metadataResults $ \(reddisId, metadataValidationResult) -> do
+                _ <- Redis.set (Text.encodeUtf8 reddisId) (toStrict $ encode metadataValidationResult)
+                return ()
+    return ()
+
+fetchMetadataValidationResult ::
+    (Has ConnectionPool r, Has Manager r, Has VVAConfig r, MonadReader r m, MonadIO m, MonadFail m, MonadError AppError m, FromJSON a)
+    => Text
+    -> Text
+    -> m (Maybe (MetadataValidationResult a))
+fetchMetadataValidationResult url hash = do
+    conn <- liftIO $ Redis.checkedConnect Redis.defaultConnectInfo
+    result <- liftIO $ Redis.runRedis conn $ Redis.get (Text.encodeUtf8 $ url<>"#"<>hash)
+    case result of
+        Left _ -> return Nothing
+        Right (Just x) -> case decode $ fromStrict x of
+            Nothing -> return Nothing
+            Just x -> return $ Just x
+        Right Nothing -> return Nothing
+
+validateMetadata ::
+    (Has ConnectionPool r, Has Manager r, Has VVAConfig r, MonadReader r m, MonadIO m, MonadFail m, MonadError AppError m)
     => Text
     -> Text
     -> Maybe Text
@@ -55,12 +143,25 @@ validateMetadata url hash standard = do
             Nothing -> throwError $ InternalError "Failed to validate metadata"
             Just x -> return $ Right x
 
+
 getProposalMetadataValidationResult ::
     (Has ConnectionPool r, Has Manager r, Has VVAConfig r, MonadReader r m, MonadIO m, MonadFail m, MonadError AppError m) =>
     Text ->
     Text ->
     m (MetadataValidationResult ProposalMetadata)
 getProposalMetadataValidationResult url hash = do
+    result <- fetchMetadataValidationResult url hash
+    case result of
+        Just x -> return x
+        Nothing -> getProposalMetadataValidationResult' url hash
+
+
+getProposalMetadataValidationResult' ::
+    (Has ConnectionPool r, Has Manager r, Has VVAConfig r, MonadReader r m, MonadIO m, MonadFail m, MonadError AppError m) =>
+    Text ->
+    Text ->
+    m (MetadataValidationResult ProposalMetadata)
+getProposalMetadataValidationResult' url hash = do
         result <- validateMetadata url hash (Just "CIP108")
         case result of
             Left e -> return $ MetadataValidationResult False (Just e) Nothing
@@ -83,14 +184,24 @@ getProposalMetadataValidationResult url hash = do
                     ProposalMetadata <$> abstract <*> motivation <*> rationale <*> title <*> references
                 return $ MetadataValidationResult valid status proposalMetadata
 
-
-
 getDRepMetadataValidationResult ::
     (Has ConnectionPool r, Has Manager r, Has VVAConfig r, MonadReader r m, MonadIO m, MonadFail m, MonadError AppError m) =>
     Text ->
     Text ->
     m (MetadataValidationResult DRepMetadata)
 getDRepMetadataValidationResult url hash = do
+    result <- fetchMetadataValidationResult url hash
+    case result of
+        Just x -> return x
+        Nothing -> getDRepMetadataValidationResult' url hash
+
+
+getDRepMetadataValidationResult' ::
+    (Has ConnectionPool r, Has Manager r, Has VVAConfig r, MonadReader r m, MonadIO m, MonadFail m, MonadError AppError m) =>
+    Text ->
+    Text ->
+    m (MetadataValidationResult DRepMetadata)
+getDRepMetadataValidationResult' url hash = do
         result <- validateMetadata url hash (Just "CIPQQQ")
         case result of
             Left e -> return $ MetadataValidationResult False (Just e) Nothing

--- a/govtool/backend/vva-be.cabal
+++ b/govtool/backend/vva-be.cabal
@@ -33,6 +33,7 @@ extra-source-files:
   sql/get-transaction-status.sql
   sql/get-stake-key-voting-power.sql
   sql/get-network-metrics.sql
+  sql/get-voting-anchors.sql
 executable vva-be
     main-is:          Main.hs
 
@@ -103,6 +104,7 @@ library
                , http-client-tls
                , vector
                , async
+               , hedis
 
   exposed-modules: VVA.Config
                  , VVA.CommandLine

--- a/scripts/govtool/config.mk
+++ b/scripts/govtool/config.mk
@@ -81,6 +81,7 @@ $(target_config_dir)/backend-config.json: $(config_dir)/templates/backend-config
 		-e "s|<DBSYNC_POSTGRES_PASSWORD>|$${DBSYNC_POSTGRES_PASSWORD}|" \
 		-e "s|<SENTRY_DSN>|$${SENTRY_DSN_BACKEND}|" \
 		-e "s|<SENTRY_ENV>|$(env)|" \
+		-e "s|<REDIS_PASSWORD>|$${REDIS_PASSWORD}|" \
 		$< > $@
 
 $(target_config_dir)/%.yml: $(template_config_dir)/%.yml $(target_config_dir)/

--- a/scripts/govtool/config/templates/backend-config.json.tpl
+++ b/scripts/govtool/config/templates/backend-config.json.tpl
@@ -13,5 +13,7 @@
     "sentryenv": "<SENTRY_ENV>",
     "metadatavalidationhost": "http://metadata-validation",
     "metadatavalidationport": "3000",
-    "metadatavalidationmaxconcurrentrequests": 10
+    "metadatavalidationmaxconcurrentrequests": 10,
+    "redishost": "localhost",
+    "redisport": 6379
 }

--- a/scripts/govtool/config/templates/backend-config.json.tpl
+++ b/scripts/govtool/config/templates/backend-config.json.tpl
@@ -14,6 +14,9 @@
     "metadatavalidationhost": "http://metadata-validation",
     "metadatavalidationport": "3000",
     "metadatavalidationmaxconcurrentrequests": 10,
-    "redishost": "localhost",
-    "redisport": 6379
+    "redisconfig" : {
+        "host"    : "http://redis",
+        "port"    : 8094,
+        "password": "<REDIS_PASSWORD>"
+    }
 }

--- a/scripts/govtool/config/templates/docker-compose.yml.tpl
+++ b/scripts/govtool/config/templates/docker-compose.yml.tpl
@@ -228,6 +228,15 @@ services:
       - "traefik.http.routers.to-analytics-dashboard.entrypoints=websecure"
       - "traefik.http.routers.to-analytics-dashboard.tls.certresolver=myresolver"
       - "traefik.http.services.analytics-dashboard.loadbalancer.server.port=3000"
+ 
+  redis:
+    image: docker.io/bitnami/redis:7.2
+    ports:
+      - '8094:8094'
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
+    volumes:
+      - 'redis_data:/bitnami/redis/data'
 
   backend:
     image: <REPO_URL>/backend:${BACKEND_TAG}
@@ -302,3 +311,4 @@ volumes:
   node-db:
   node-ipc:
   loki-data:
+  redis_data:


### PR DESCRIPTION
## List of changes

Add
- Reddis port, and host in backend config
- Async process that fetches and processes metadata
- querying Metadata returns result from Redis cache if available

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1234)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
