### PR TITLE
fix/1253-dashboard-drep-explorer-drep-details-drep-name-appears-beyond-label

### DIFF
--- a/govtool/frontend/src/components/molecules/DataMissingHeader.tsx
+++ b/govtool/frontend/src/components/molecules/DataMissingHeader.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@mui/material";
+import { Box, SxProps } from "@mui/material";
 
 import { Typography } from "@atoms";
 import { Share } from "@molecules";
@@ -9,12 +9,14 @@ type DataMissingHeaderProps = {
   isDataMissing: MetadataValidationStatus | null;
   shareLink?: string;
   title?: string;
+  titleStyle?: SxProps;
 };
 
 export const DataMissingHeader = ({
   title,
   isDataMissing,
   shareLink,
+  titleStyle,
 }: DataMissingHeaderProps) => (
   <Box
     sx={{
@@ -39,6 +41,7 @@ export const DataMissingHeader = ({
           whiteSpace: "nowrap",
           fontWeight: 600,
           ...(isDataMissing && { color: "errorRed" }),
+          ...titleStyle,
         }}
         variant="title2"
       >

--- a/govtool/frontend/src/components/molecules/DelegationAction.tsx
+++ b/govtool/frontend/src/components/molecules/DelegationAction.tsx
@@ -3,6 +3,7 @@ import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 
 import { Typography } from "@atoms";
 import { gray } from "@consts";
+import { ellipsizeText } from "@utils";
 
 import { Card } from "./Card";
 import { DirectVoterActionProps } from "./types";
@@ -31,7 +32,7 @@ export const DelegationAction = ({
   >
     <Box sx={{ width: "90%" }}>
       <Typography fontWeight={600} variant="body2">
-        {drepName}
+        {ellipsizeText(drepName, 25)}
       </Typography>
       <Typography
         sx={{

--- a/govtool/frontend/src/components/molecules/DelegationAction.tsx
+++ b/govtool/frontend/src/components/molecules/DelegationAction.tsx
@@ -32,7 +32,7 @@ export const DelegationAction = ({
   >
     <Box sx={{ width: "90%" }}>
       <Typography fontWeight={600} variant="body2">
-        {ellipsizeText(drepName, 25)}
+        {ellipsizeText(drepName, 30)}
       </Typography>
       <Typography
         sx={{

--- a/govtool/frontend/src/components/organisms/DRepCard.tsx
+++ b/govtool/frontend/src/components/organisms/DRepCard.tsx
@@ -9,6 +9,7 @@ import { DRepData, DRepStatus } from "@models";
 import { Card } from "@molecules";
 import {
   correctDRepDirectoryFormat,
+  ellipsizeText,
   getMetadataDataMissingStatusTranslation,
 } from "@utils";
 
@@ -103,7 +104,7 @@ export const DRepCard = ({
               >
                 {metadataStatus
                   ? getMetadataDataMissingStatusTranslation(metadataStatus)
-                  : dRepName}
+                  : ellipsizeText(dRepName ?? "", 25)}
               </Typography>
               <ButtonBase
                 data-testid={`${view}-copy-id-button`}

--- a/govtool/frontend/src/pages/DRepDetails.tsx
+++ b/govtool/frontend/src/pages/DRepDetails.tsx
@@ -222,6 +222,7 @@ export const DRepDetails = ({ isConnected }: DRepDetailsProps) => {
             title={dRepName ?? undefined}
             isDataMissing={metadataStatus}
             shareLink={!isMe ? window.location.href : undefined}
+            titleStyle={{ wordBreak: "break-word", whiteSpace: "wrap" }}
           />
           {metadataStatus && (
             <DataMissingInfoBox


### PR DESCRIPTION
## List of changes

- Add ellipsize text for drep name

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1253)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
