### PR TITLE
fix/1257-dashboard-shows-delegation-in-two-places-should-be-one-after-becoming-a-drep

### DIFF
--- a/govtool/frontend/src/components/organisms/DashboardCards/DelegateDashboardCard.tsx
+++ b/govtool/frontend/src/components/organisms/DashboardCards/DelegateDashboardCard.tsx
@@ -151,24 +151,25 @@ export const DelegateDashboardCard = ({
       }
       {...cardProps}
     >
-      {(delegateTx && delegateTx?.resourceId !== dRepID) ||
-      (!delegateTx &&
-        currentDelegation &&
-        currentDelegation?.dRepHash !== dRepID) ? (
-          <DelegationAction
-            drepName={
-              isDRepListFetching
-                ? "Loading..."
-                : myDRepDelegationData?.metadataStatus
-                ? getMetadataDataMissingStatusTranslation(
-                    myDRepDelegationData.metadataStatus,
-                  )
-                : myDRepDelegationData?.dRepName ?? ""
-            }
-            dRepId={displayedDelegationId ?? ""}
-            onCardClick={navigateToDRepDetails}
-            sx={{ mt: 1.5 }}
-          />
+      {displayedDelegationId &&
+      ((delegateTx && delegateTx?.resourceId !== dRepID) ||
+        (!delegateTx &&
+          currentDelegation &&
+          currentDelegation?.dRepHash !== dRepID)) ? (
+            <DelegationAction
+              drepName={
+                isDRepListFetching
+                  ? "Loading..."
+                  : myDRepDelegationData?.metadataStatus
+                  ? getMetadataDataMissingStatusTranslation(
+                      myDRepDelegationData.metadataStatus,
+                    )
+                  : myDRepDelegationData?.dRepName ?? ""
+              }
+              dRepId={displayedDelegationId}
+              onCardClick={navigateToDRepDetails}
+              sx={{ mt: 1.5 }}
+            />
       ) : null}
     </DashboardActionCard>
   );

--- a/govtool/frontend/src/components/organisms/DashboardCards/DelegateDashboardCard.tsx
+++ b/govtool/frontend/src/components/organisms/DashboardCards/DelegateDashboardCard.tsx
@@ -34,14 +34,14 @@ export const DelegateDashboardCard = ({
   currentDelegation,
   delegateTx,
   dRepID,
-  voter,
   votingPower,
 }: DelegateDashboardCardProps) => {
   const navigate = useNavigate();
   const { t } = useTranslation();
+
   const { dRepData, isDRepListFetching } = useGetDRepListInfiniteQuery(
     {
-      searchPhrase: currentDelegation?.dRepHash ?? delegateTx?.resourceId ?? "",
+      searchPhrase: delegateTx?.resourceId ?? currentDelegation?.dRepHash ?? "",
     },
     {
       enabled: !!currentDelegation?.dRepHash || !!delegateTx?.resourceId,
@@ -73,10 +73,7 @@ export const DelegateDashboardCard = ({
 
   const cardProps: Partial<DashboardActionCardProps> = (() => {
     // transaction in progress
-    if (
-      delegateTx &&
-      (!(delegateTx?.resourceId === dRepID) || voter?.isRegisteredAsDRep)
-    ) {
+    if (delegateTx && delegateTx?.resourceId !== dRepID) {
       return {
         buttons: [learnMoreButton],
         description: getProgressDescription(delegateTx?.resourceId, ada),
@@ -87,8 +84,9 @@ export const DelegateDashboardCard = ({
 
     // current delegation
     if (
+      !delegateTx &&
       currentDelegation &&
-      (!(currentDelegation?.dRepHash === dRepID) || voter?.isRegisteredAsDRep)
+      currentDelegation?.dRepHash !== dRepID
     ) {
       return {
         buttons: currentDelegation?.dRepView
@@ -141,21 +139,22 @@ export const DelegateDashboardCard = ({
       imageURL={IMAGES.govActionDelegateImage}
       isSpaceBetweenButtons={
         !!currentDelegation?.dRepView &&
-        (!(currentDelegation?.dRepHash === dRepID) || voter?.isRegisteredAsDRep)
+        !(currentDelegation?.dRepHash === dRepID)
       }
       transactionId={
-        !(currentDelegation?.dRepHash === dRepID) ||
-        voter?.isRegisteredAsDRep ||
-        !voter?.isRegisteredAsSoleVoter
+        (delegateTx && delegateTx?.resourceId !== dRepID) ||
+        (!delegateTx &&
+          currentDelegation &&
+          currentDelegation?.dRepHash !== dRepID)
           ? delegateTx?.transactionHash ?? currentDelegation?.txHash
           : undefined
       }
       {...cardProps}
     >
-      {displayedDelegationId &&
-        (!(currentDelegation?.dRepHash === dRepID) ||
-          voter?.isRegisteredAsDRep ||
-          !voter?.isRegisteredAsSoleVoter) && (
+      {(delegateTx && delegateTx?.resourceId !== dRepID) ||
+      (!delegateTx &&
+        currentDelegation &&
+        currentDelegation?.dRepHash !== dRepID) ? (
           <DelegationAction
             drepName={
               isDRepListFetching
@@ -166,11 +165,11 @@ export const DelegateDashboardCard = ({
                   )
                 : myDRepDelegationData?.dRepName ?? ""
             }
-            dRepId={displayedDelegationId}
+            dRepId={displayedDelegationId ?? ""}
             onCardClick={navigateToDRepDetails}
             sx={{ mt: 1.5 }}
           />
-        )}
+      ) : null}
     </DashboardActionCard>
   );
 };

--- a/govtool/frontend/src/context/pendingTransaction/utils.tsx
+++ b/govtool/frontend/src/context/pendingTransaction/utils.tsx
@@ -72,7 +72,7 @@ export const refetchData = async (
     ) {
       return data.dRepView;
     }
-    return data.dRepView;
+    return data.dRepHash;
   }
   if (type === "registerAsDrep" || type === "retireAsDrep")
     return data.isRegisteredAsDRep;

--- a/govtool/frontend/src/pages/DRepDetails.tsx
+++ b/govtool/frontend/src/pages/DRepDetails.tsx
@@ -288,7 +288,7 @@ export const DRepDetails = ({ isConnected }: DRepDetailsProps) => {
               isLoading={
                 isDelegating === dRep.view || isDelegating === dRep.drepId
               }
-              onClick={() => delegate(dRep.view)}
+              onClick={() => delegate(dRep.drepId)}
               size="extraLarge"
               sx={{ width: "100%" }}
               variant="contained"

--- a/govtool/frontend/src/pages/DRepDirectoryContent.tsx
+++ b/govtool/frontend/src/pages/DRepDirectoryContent.tsx
@@ -10,7 +10,6 @@ import {
   useGetAdaHolderCurrentDelegationQuery,
   useGetAdaHolderVotingPowerQuery,
   useGetDRepListInfiniteQuery,
-  useGetVoterInfo,
 } from "@hooks";
 import { DataActionsBar, EmptyStateDrepDirectory } from "@molecules";
 import { AutomatedVotingOptions, DRepCard } from "@organisms";
@@ -49,7 +48,6 @@ export const DRepDirectoryContent: FC<DRepDirectoryContentProps> = ({
 
   const { delegate, isDelegating } = useDelegateTodRep();
 
-  const { voter } = useGetVoterInfo();
   const { votingPower } = useGetAdaHolderVotingPowerQuery(stakeKey);
   const { currentDelegation } = useGetAdaHolderCurrentDelegationQuery(stakeKey);
   const inProgressDelegation = pendingTransaction.delegate?.resourceId;
@@ -106,6 +104,7 @@ export const DRepDirectoryContent: FC<DRepDirectoryContentProps> = ({
   const dRepListToDisplay = yourselfDRep
     ? [yourselfDRep, ...dRepsWithoutYourself]
     : dRepList;
+
   const inProgressDelegationDRepData = dRepListToDisplay.find(
     (dRep) =>
       dRep.drepId === inProgressDelegation ||
@@ -124,8 +123,8 @@ export const DRepDirectoryContent: FC<DRepDirectoryContentProps> = ({
       {/* My delegation */}
       {myDrep &&
         !inProgressDelegation &&
-        (!(currentDelegation?.dRepHash === myDRepId) ||
-          voter?.isRegisteredAsDRep) && (
+        currentDelegation &&
+        currentDelegation?.dRepHash !== myDRepId && (
           <div>
             <Typography variant="title2" sx={{ mb: 2 }}>
               <Trans i18nKey="dRepDirectory.myDelegation" values={{ ada }} />
@@ -138,14 +137,16 @@ export const DRepDirectoryContent: FC<DRepDirectoryContentProps> = ({
             />
           </div>
         )}
-      {inProgressDelegation && inProgressDelegationDRepData && (
-        <DRepCard
-          dRep={inProgressDelegationDRepData}
-          isConnected={!!isConnected}
-          isMe={isSameDRep(inProgressDelegationDRepData, myDRepId)}
-          isInProgress
-        />
-      )}
+      {inProgressDelegation &&
+        inProgressDelegation !== myDRepId &&
+        inProgressDelegationDRepData && (
+          <DRepCard
+            dRep={inProgressDelegationDRepData}
+            isConnected={!!isConnected}
+            isMe={isSameDRep(inProgressDelegationDRepData, myDRepId)}
+            isInProgress
+          />
+        )}
 
       {/* Automated voting options */}
       {isConnected && (
@@ -223,7 +224,7 @@ export const DRepDirectoryContent: FC<DRepDirectoryContentProps> = ({
                     isDelegating === dRep.view || isDelegating === dRep.drepId
                   }
                   isMe={isSameDRep(dRep, myDRepId)}
-                  onDelegate={() => delegate(dRep.view)}
+                  onDelegate={() => delegate(dRep.drepId)}
                 />
               </Box>
             );


### PR DESCRIPTION
## List of changes

- Hide delegation for delegation on myself

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1257)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
