### PR TITLE
feat(#1267): hide the external link button when the metadata fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ changes.
 - Changed documents to prepare for open source [Issue 737](https://github.com/IntersectMBO/govtool/issues/737)
 - Changed copy on maintenance page [Issue 753](https://github.com/IntersectMBO/govtool/issues/753)
 - Update link to docs [Issue 1246](https://github.com/IntersectMBO/govtool/issues/1246)
+- Hide the external data link when the metadata validation fails [Issue 1267](https://github.com/IntersectMBO/govtool/issues/1267)
 
 ### Removed
 

--- a/govtool/frontend/src/components/organisms/GovernanceActionDetailsCardData.tsx
+++ b/govtool/frontend/src/components/organisms/GovernanceActionDetailsCardData.tsx
@@ -97,7 +97,7 @@ export const GovernanceActionDetailsCardData = ({
         expiryEpochNo={expiryEpochNo}
         createdEpochNo={createdEpochNo}
       />
-      {isDataMissing && (
+      {!isDataMissing && (
         <ExternalModalButton
           url={url}
           label={t("govActions.seeExternalData")}

--- a/govtool/frontend/src/pages/DRepDetails.tsx
+++ b/govtool/frontend/src/pages/DRepDetails.tsx
@@ -92,6 +92,7 @@ export const DRepDetails = ({ isConnected }: DRepDetailsProps) => {
     url,
     view,
     votingPower,
+    metadataValid,
   } = dRep;
 
   const isMe = isSameDRep(dRep, myDRepId);
@@ -231,7 +232,7 @@ export const DRepDetails = ({ isConnected }: DRepDetailsProps) => {
               sx={{ mb: 3 }}
             />
           )}
-          {metadataStatus && !!url && (
+          {metadataValid && !!url && (
             <ExternalModalButton
               label={t("govActions.seeExternalData")}
               sx={{ mb: 3 }}


### PR DESCRIPTION
## List of changes

- hide the external link button when the metadata fails

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1267)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
