### PR TITLE
fix(#1141): change error modal for incompatible wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ changes.
 - Changed documents to prepare for open source [Issue 737](https://github.com/IntersectMBO/govtool/issues/737)
 - Changed copy on maintenance page [Issue 753](https://github.com/IntersectMBO/govtool/issues/753)
 - Update link to docs [Issue 1246](https://github.com/IntersectMBO/govtool/issues/1246)
+- Change error modal while connecting the wallet that has no supported extensions [Issue 1141](https://github.com/IntersectMBO/govtool/issues/1141)
 
 ### Removed
 

--- a/govtool/frontend/src/components/organisms/Modal/ChooseWalletModal.tsx
+++ b/govtool/frontend/src/components/organisms/Modal/ChooseWalletModal.tsx
@@ -1,13 +1,12 @@
 import { Box, Link, Typography } from "@mui/material";
-import { useMemo } from "react";
+import { To } from "react-router-dom";
 
 import { ModalContents, ModalHeader, ModalWrapper } from "@atoms";
 import { useModal } from "@context";
 import type { WalletOption } from "@molecules";
 import { WalletOptionButton } from "@molecules";
-import { openInNewTab } from "@utils";
+import { openInNewTab, getCip95Wallets } from "@utils";
 import { useTranslation } from "@hooks";
-import { To } from "react-router-dom";
 
 type ChooseWalletModalState = {
   pathToNavigate?: To;
@@ -17,34 +16,7 @@ export const ChooseWalletModal = () => {
   const { t } = useTranslation();
   const { state } = useModal<ChooseWalletModalState>();
 
-  const walletOptions: WalletOption[] = useMemo(() => {
-    if (!window.cardano) return [];
-    const keys = Object.keys(window.cardano);
-    const resultWallets: WalletOption[] = [];
-    keys.forEach((k: string) => {
-      const { icon, name, supportedExtensions } = window.cardano[k];
-      if (icon && name && supportedExtensions) {
-        // Check if the name already exists in resultWallets
-        const isNameDuplicate = resultWallets.some(
-          (wallet) => wallet.label === name,
-        );
-        // Check if the supportedExtensions array contains an entry with cip === 95
-        const isCip95Available = Boolean(
-          supportedExtensions?.find((i) => i.cip === 95),
-        );
-        // If the name is not a duplicate and cip === 95 is available, add it to resultWallets
-        if (!isNameDuplicate && isCip95Available) {
-          resultWallets.push({
-            icon,
-            label: name,
-            name: k,
-            cip95Available: true,
-          });
-        }
-      }
-    });
-    return resultWallets;
-  }, [window]);
+  const walletOptions: WalletOption[] = getCip95Wallets(window.cardano);
 
   return (
     <ModalWrapper dataTestId="connect-your-wallet-modal">

--- a/govtool/frontend/src/context/wallet.tsx
+++ b/govtool/frontend/src/context/wallet.tsx
@@ -232,7 +232,6 @@ const CardanoProvider = (props: Props) => {
       setIsEnableLoading(walletName);
       await checkIsMaintenanceOn();
 
-      // todo: use .getSupportedExtensions() to check if wallet supports CIP-95
       if (!isEnabled && walletName) {
         try {
           // Check that this wallet supports CIP-95 connection
@@ -247,9 +246,7 @@ const CardanoProvider = (props: Props) => {
           }
           // Enable wallet connection
           const enabledApi: CardanoApiWallet = await window.cardano[walletName]
-            .enable({
-              extensions: [{ cip: 95 }],
-            })
+            .enable({ extensions: [{ cip: 95 }] })
             .catch((e) => {
               Sentry.captureException(e);
               throw e.info;
@@ -258,8 +255,13 @@ const CardanoProvider = (props: Props) => {
           await getUsedAddresses(enabledApi);
           setIsEnabled(true);
           setWalletApi(enabledApi);
+
           // Check if wallet has enabled the CIP-95 extension
-          const enabledExtensions = await enabledApi.getExtensions();
+          const enabledExtensions = await enabledApi?.getExtensions();
+          if (!enabledExtensions) {
+            throw new Error(t("errors.walletNoCIP30Support"));
+          }
+
           if (!enabledExtensions.some((item) => item.cip === 95)) {
             throw new Error(t("errors.walletNoCIP90FunctionsEnabled"));
           }

--- a/govtool/frontend/src/utils/getCip95Wallets.ts
+++ b/govtool/frontend/src/utils/getCip95Wallets.ts
@@ -1,0 +1,33 @@
+import type { WalletOption } from "@molecules";
+
+/**
+ * Retrieves the CIP-95 wallets from the window.cardano object.
+ * @returns {Array} An array of CIP-95 wallets, each containing the icon, label, and name.
+ */
+export const getCip95Wallets = (cardanoWindowObject: typeof window.cardano) => {
+  const walletNames = Object.keys(cardanoWindowObject);
+  const resultWallets: WalletOption[] = [];
+  walletNames.forEach((walletName: string) => {
+    const { icon, name, supportedExtensions } = cardanoWindowObject[walletName];
+    if (icon && name && supportedExtensions) {
+      // Check if the name already exists in resultWallets
+      const isNameDuplicate = resultWallets.some(
+        (wallet) => wallet.label === name,
+      );
+      // Check if the supportedExtensions array contains an entry with cip === 95
+      const isCip95Available = Boolean(
+        supportedExtensions?.some((extension) => extension.cip === 95),
+      );
+      // If the name is not a duplicate and cip === 95 is available, add it to resultWallets
+      if (!isNameDuplicate && isCip95Available) {
+        resultWallets.push({
+          icon,
+          label: name,
+          name: walletName,
+          cip95Available: true,
+        });
+      }
+    }
+  });
+  return resultWallets;
+};

--- a/govtool/frontend/src/utils/index.ts
+++ b/govtool/frontend/src/utils/index.ts
@@ -25,3 +25,4 @@ export * from "./openInNewTab";
 export * from "./removeDuplicatedProposals";
 export * from "./testIdFromLabel";
 export * from "./wait";
+export * from "./getCip95Wallets";

--- a/govtool/frontend/src/utils/tests/getCip95Wallets.test.ts
+++ b/govtool/frontend/src/utils/tests/getCip95Wallets.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import { getCip95Wallets } from "../getCip95Wallets";
+
+describe("getCip95Wallets", () => {
+  it("should return an array of CIP-95 wallets", () => {
+    const cardanoWindowObject: typeof window.cardano = {
+      wallet1: {
+        icon: "icon1",
+        name: "wallet1",
+        supportedExtensions: [{ cip: 95 }],
+        apiVersion: "1.0.0",
+        enable: vi.fn(),
+        isEnabled: vi.fn(),
+      },
+      wallet2: {
+        icon: "icon2",
+        name: "wallet2",
+        supportedExtensions: [{ cip: 95 }],
+        apiVersion: "1.0.0",
+        enable: vi.fn(),
+        isEnabled: vi.fn(),
+      },
+      duplicateNameWallet: {
+        icon: "icon3",
+        name: "wallet1",
+        supportedExtensions: [{ cip: 95 }],
+        apiVersion: "1.0.0",
+        enable: vi.fn(),
+        isEnabled: vi.fn(),
+      },
+      incompatibleWallet: {
+        icon: "icon3",
+        name: "incompatibleWallet",
+        supportedExtensions: [{ cip: 94 }],
+        apiVersion: "1.0.0",
+        enable: vi.fn(),
+        isEnabled: vi.fn(),
+      },
+      emptyArrayWallet: {
+        icon: "icon4",
+        name: "emptyArrayWallet",
+        supportedExtensions: [],
+        apiVersion: "1.0.0",
+        enable: vi.fn(),
+        isEnabled: vi.fn(),
+      },
+      // For testing purposes
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      noExtensionsWallet: {
+        icon: "icon4",
+        name: "noExtensionsWallet",
+        apiVersion: "1.0.0",
+        enable: vi.fn(),
+        isEnabled: vi.fn(),
+      },
+    };
+    const result = getCip95Wallets(cardanoWindowObject);
+    const expected = [
+      {
+        icon: "icon1",
+        label: "wallet1",
+        name: "wallet1",
+        cip95Available: true,
+      },
+      {
+        icon: "icon2",
+        label: "wallet2",
+        name: "wallet2",
+        cip95Available: true,
+      },
+    ];
+    expect(result).toStrictEqual(expected);
+  });
+});


### PR DESCRIPTION
## List of changes

- change way of filtering out cip-95 wallets
- display error modal when wallet does not support the `enabledExtensions`

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1141)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [x] I have added tests that prove my fix is effective or that my feature works
