### PR TITLE
[#1235] add /transaction/watch endpoint & background tx status process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ changes.
 
 ### Added
 
+- added `websocketlifetimeseconds` config field for webscoket connections, and watched transactions.  [Issue 1235](https://github.com/IntersectMBO/govtool/issues/1235)
 - added separate async process that fetches new voting_anchors, validates their metadata using metadata-validation service, and then stores it in Redis database [Issue 1234](https://github.com/IntersectMBO/govtool/issues/1234)
 - added `bio` `dRepName` `email` `references` `metadataValid` and `metadataStatus` fields to `drep/list`
 - added `metadatavalidationmaxconcurrentrequests` field to the backend config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ changes.
 ## [Unreleased]
 
 - Added 'sentryenv' field in backend config file [Issue 1401](https://github.com/IntersectMBO/govtool/issues/1401)
+- Add websocket transaction status endpoint /transaction/watch/<TX-HASH> [Issue 1235](https://github.com/IntersectMBO/govtool/issues/1235)
 - Add wallet connector package [Issue 898](https://github.com/IntersectMBO/govtool/issues/898)
 - Change DRep without metadata name from "Sole Voter" to "Direct Voter" [Issue 880](https://github.com/IntersectMBO/govtool/issues/880)
 - Inicialize Usersnap into App [Issue 546](https://github.com/IntersectMBO/govtool/issues/546)

--- a/govtool/backend/app/Main.hs
+++ b/govtool/backend/app/Main.hs
@@ -139,8 +139,12 @@ startApp vvaConfig = do
   connectionPool <- createPool (connectPostgreSQL (encodeUtf8 (dbSyncConnectionString $ getter vvaConfig))) close 1 1 60
   vvaTlsManager <- newManager tlsManagerSettings
   qsem <- newQSem (metadataValidationMaxConcurrentRequests vvaConfig)
+<<<<<<< HEAD
   websocketConnectionsTVar <- newTVarIO mempty
   let appEnv = AppEnv {vvaConfig=vvaConfig, vvaCache=cacheEnv, vvaConnectionPool=connectionPool, vvaTlsManager, vvaMetadataQSem=qsem, vvaWebSocketConnections=websocketConnectionsTVar}
+=======
+  let appEnv = AppEnv {vvaConfig=vvaConfig, vvaCache=cacheEnv, vvaConnectionPool=connectionPool, vvaTlsManager, vvaMetadataQSem=qsem}
+>>>>>>> b45e63d1... [#1234] Add reddis support for storing metadata validation results
 
   _ <- forkIO $ do
      result <- runReaderT (runExceptT startFetchProcess) appEnv
@@ -148,12 +152,15 @@ startApp vvaConfig = do
         Left e -> throw e
         Right _ -> return ()
 
+<<<<<<< HEAD
   _ <- forkIO $ do
       result <- runReaderT (runExceptT $ processTransactionStatuses websocketConnectionsTVar) appEnv
       case result of
         Left e -> throw e
         Right _ -> return ()
 
+=======
+>>>>>>> b45e63d1... [#1234] Add reddis support for storing metadata validation results
   server' <- mkVVAServer appEnv
   runSettings settings server'
 

--- a/govtool/backend/app/Main.hs
+++ b/govtool/backend/app/Main.hs
@@ -139,12 +139,8 @@ startApp vvaConfig = do
   connectionPool <- createPool (connectPostgreSQL (encodeUtf8 (dbSyncConnectionString $ getter vvaConfig))) close 1 1 60
   vvaTlsManager <- newManager tlsManagerSettings
   qsem <- newQSem (metadataValidationMaxConcurrentRequests vvaConfig)
-<<<<<<< HEAD
   websocketConnectionsTVar <- newTVarIO mempty
   let appEnv = AppEnv {vvaConfig=vvaConfig, vvaCache=cacheEnv, vvaConnectionPool=connectionPool, vvaTlsManager, vvaMetadataQSem=qsem, vvaWebSocketConnections=websocketConnectionsTVar}
-=======
-  let appEnv = AppEnv {vvaConfig=vvaConfig, vvaCache=cacheEnv, vvaConnectionPool=connectionPool, vvaTlsManager, vvaMetadataQSem=qsem}
->>>>>>> b45e63d1... [#1234] Add reddis support for storing metadata validation results
 
   _ <- forkIO $ do
      result <- runReaderT (runExceptT startFetchProcess) appEnv
@@ -152,15 +148,12 @@ startApp vvaConfig = do
         Left e -> throw e
         Right _ -> return ()
 
-<<<<<<< HEAD
   _ <- forkIO $ do
       result <- runReaderT (runExceptT $ processTransactionStatuses websocketConnectionsTVar) appEnv
       case result of
         Left e -> throw e
         Right _ -> return ()
 
-=======
->>>>>>> b45e63d1... [#1234] Add reddis support for storing metadata validation results
   server' <- mkVVAServer appEnv
   runSettings settings server'
 

--- a/govtool/backend/app/Main.hs
+++ b/govtool/backend/app/Main.hs
@@ -8,6 +8,7 @@
 
 module Main where
 
+import GHC.Conc (newTVarIO)
 import           Control.Concurrent                     (forkIO)
 import           Control.Concurrent.QSem                (newQSem)
 import           Control.Exception                      (Exception,
@@ -77,6 +78,7 @@ import           VVA.Types                              (AppEnv (..),
                                                          CacheEnv (..))
 import Network.HTTP.Client hiding (Proxy, Request)
 import Network.HTTP.Client.TLS
+import           VVA.Transaction (processTransactionStatuses)
 
 proxyAPI :: Proxy (VVAApi :<|> SwaggerAPI)
 proxyAPI = Proxy
@@ -137,11 +139,18 @@ startApp vvaConfig = do
   connectionPool <- createPool (connectPostgreSQL (encodeUtf8 (dbSyncConnectionString $ getter vvaConfig))) close 1 1 60
   vvaTlsManager <- newManager tlsManagerSettings
   qsem <- newQSem (metadataValidationMaxConcurrentRequests vvaConfig)
-  let appEnv = AppEnv {vvaConfig=vvaConfig, vvaCache=cacheEnv, vvaConnectionPool=connectionPool, vvaTlsManager, vvaMetadataQSem=qsem}
+  websocketConnectionsTVar <- newTVarIO mempty
+  let appEnv = AppEnv {vvaConfig=vvaConfig, vvaCache=cacheEnv, vvaConnectionPool=connectionPool, vvaTlsManager, vvaMetadataQSem=qsem, vvaWebSocketConnections=websocketConnectionsTVar}
 
   _ <- forkIO $ do
      result <- runReaderT (runExceptT startFetchProcess) appEnv
      case result of
+        Left e -> throw e
+        Right _ -> return ()
+
+  _ <- forkIO $ do
+      result <- runReaderT (runExceptT $ processTransactionStatuses websocketConnectionsTVar) appEnv
+      case result of
         Left e -> throw e
         Right _ -> return ()
 

--- a/govtool/backend/example-config.json
+++ b/govtool/backend/example-config.json
@@ -18,5 +18,6 @@
       "host"    : "localhost",
       "port"    : 8094,
       "password": null
-  }
+    },
+    "websocketlifetimeseconds": 60
 }

--- a/govtool/backend/src/VVA/API.hs
+++ b/govtool/backend/src/VVA/API.hs
@@ -5,9 +5,12 @@
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TypeOperators     #-}
 {-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 
 module VVA.API where
 
+import qualified Network.WebSockets.Connection as WS
+import Servant.API.WebSocket (WebSocket)
 import Control.Concurrent.QSem (waitQSem, signalQSem)
 import Control.Concurrent.Async (mapConcurrently)
 import           Control.Exception    (throw, throwIO)
@@ -44,6 +47,7 @@ import           VVA.Types            (App, AppEnv (..),
                                        AppError (CriticalError, ValidationError, InternalError),
                                        CacheEnv (..))
 import qualified VVA.Metadata         as Metadata
+import Servant.OpenApi (HasOpenApi, toOpenApi)
 
 type VVAApi =
          "drep" :> "list"
@@ -78,6 +82,8 @@ type VVAApi =
     :<|> "network" :> "metrics" :> Get '[JSON] GetNetworkMetricsResponse
     :<|> "proposal" :> "metadata" :> "validate" :> ReqBody '[JSON] MetadataValidationParams :> Post '[JSON] MetadataValidationResponse
     :<|> "drep" :> "metadata" :> "validate" :> ReqBody '[JSON] MetadataValidationParams :> Post '[JSON] MetadataValidationResponse
+    :<|> "transaction" :> "watch" :> Capture "transactionId" HexText :> WebSocket
+
 server :: App m => ServerT VVAApi m
 server = drepList
     :<|> getVotingPower
@@ -93,6 +99,20 @@ server = drepList
     :<|> getNetworkMetrics
     :<|> getProposalMetadataValidationResponse
     :<|> getDRepMetadataValidationResponse
+    :<|> transactionWatch
+
+instance HasOpenApi WebSocket where
+  toOpenApi _ = mempty
+
+
+transactionWatch :: App m => HexText -> WS.Connection -> m ()
+transactionWatch (unHexText -> transactionId) c = do
+  tvar <- asks vvaWebSocketConnections
+  Transaction.watchTransaction tvar transactionId c
+  liftIO $ forever $ do
+        msg <- WS.receiveData c
+        putStrLn $ Text.unpack $ ("Received: " <> msg)
+        WS.sendTextData c (msg :: Text)
 
 
 mapDRepType :: Types.DRepType -> DRepType

--- a/govtool/backend/src/VVA/Config.hs
+++ b/govtool/backend/src/VVA/Config.hs
@@ -29,6 +29,7 @@ module VVA.Config
     , vvaConfigToText
     , getMetadataValidationHost
     , getMetadataValidationPort
+    , getWebsocketLifetimeSeconds
     ) where
 
 import           Conferer
@@ -101,6 +102,8 @@ data VVAConfigInternal
       , vVAConfigInternalMetadataValidationMaxConcurrentRequests :: Int
         -- | Redis config
       , vVAConfigInternalRedisConfig :: RedisInternalConfig
+        -- | WebSocket lifetime in seconds
+      , vVAConfigInternalWebsocketLifetimeSeconds :: Int
       }
   deriving (FromConfig, Generic, Show)
 
@@ -116,7 +119,8 @@ instance DefaultConfig VVAConfigInternal where
         vVAConfigInternalMetadataValidationHost = "localhost",
         vVAConfigInternalMetadataValidationPort = 3001,
         vVAConfigInternalMetadataValidationMaxConcurrentRequests = 10,
-        vVAConfigInternalRedisConfig = RedisInternalConfig "localhost" 6379 Nothing
+        vVAConfigInternalRedisConfig = RedisInternalConfig "localhost" 6379 Nothing,
+        vVAConfigInternalWebsocketLifetimeSeconds = 60 * 1
       }
 
 data RedisConfig
@@ -150,6 +154,8 @@ data VVAConfig
       , metadataValidationMaxConcurrentRequests :: Int
         -- | Redis config
       , redisConfig :: RedisConfig
+        -- | WebSocket lifetime in seconds
+      , websocketLifetimeSeconds :: Int
       }
   deriving (Generic, Show, ToJSON)
 
@@ -199,6 +205,7 @@ convertConfig VVAConfigInternal {..} =
           redisPort = redisInternalConfigPort $ vVAConfigInternalRedisConfig,
           redisPassword = redisInternalConfigPassword $ vVAConfigInternalRedisConfig
         }
+      websocketLifetimeSeconds = vVAConfigInternalWebsocketLifetimeSeconds
     }
 
 -- | Load configuration from a file specified on the command line.  Load from
@@ -265,3 +272,9 @@ getMetadataValidationPort ::
   (Has VVAConfig r, MonadReader r m) =>
   m Int
 getMetadataValidationPort = asks (metadataValidationPort . getter)
+
+-- | Access websocket lifetime in seconds
+getWebsocketLifetimeSeconds ::
+  (Has VVAConfig r, MonadReader r m) =>
+  m Int
+getWebsocketLifetimeSeconds = asks (websocketLifetimeSeconds . getter)

--- a/govtool/backend/src/VVA/Config.hs
+++ b/govtool/backend/src/VVA/Config.hs
@@ -204,7 +204,7 @@ convertConfig VVAConfigInternal {..} =
         { redisHost = redisInternalConfigHost $ vVAConfigInternalRedisConfig,
           redisPort = redisInternalConfigPort $ vVAConfigInternalRedisConfig,
           redisPassword = redisInternalConfigPassword $ vVAConfigInternalRedisConfig
-        }
+        },
       websocketLifetimeSeconds = vVAConfigInternalWebsocketLifetimeSeconds
     }
 

--- a/govtool/backend/src/VVA/Metadata.hs
+++ b/govtool/backend/src/VVA/Metadata.hs
@@ -58,8 +58,6 @@ startFetchProcess ::
 startFetchProcess = go 0
     where
         go latestKnownId = do
-            liftIO $ putStrLn "Fetching metadata..."
-
             anchors <- getNewVotingAnchors latestKnownId
             if null anchors
                 then do

--- a/govtool/backend/src/VVA/Transaction.hs
+++ b/govtool/backend/src/VVA/Transaction.hs
@@ -10,7 +10,6 @@ import           Data.Map (Map)
 import qualified Network.WebSockets.Connection as WS
 import           GHC.Conc (TVar, threadDelay, readTVar, readTVarIO, writeTVar, atomically)
 import           Data.Maybe
-import           Data.Either.Extra (mapRight)
 import Data.UUID.V4 (nextRandom)
 import           Network.WebSockets.Connection (Connection)
 import qualified Database.Redis as Redis

--- a/govtool/backend/src/VVA/Transaction.hs
+++ b/govtool/backend/src/VVA/Transaction.hs
@@ -1,9 +1,19 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeApplications  #-}
 
 module VVA.Transaction where
 
+import qualified Data.Map as Map
+import           Data.Map (Map)
+import qualified Network.WebSockets.Connection as WS
+import           GHC.Conc (TVar, threadDelay, readTVar, readTVarIO, writeTVar, atomically)
+import           Data.Maybe
+import           Data.Either.Extra (mapRight)
+import Data.UUID.V4 (nextRandom)
+import           Network.WebSockets.Connection (Connection)
+import qualified Database.Redis as Redis
 import           Control.Exception          (throw)
 import           Control.Monad.Except       (MonadError, throwError)
 import           Control.Monad.Reader
@@ -20,8 +30,8 @@ import qualified Database.PostgreSQL.Simple as SQL
 
 import           VVA.Config
 import           VVA.Pool                   (ConnectionPool, withPool)
-import           VVA.Types                  (AppError (..),
-                                             TransactionStatus (..))
+import           VVA.Types                  (AppError (..), AppEnv (..), WebsocketTvar,
+                                             TransactionStatus (..), vvaWebSocketConnections)
 
 sqlFrom :: ByteString -> SQL.Query
 sqlFrom bs = fromString $ unpack $ Text.decodeUtf8 bs
@@ -39,3 +49,104 @@ getTransactionStatus transactionId = withPool $ \conn -> do
     [SQL.Only True] -> return TransactionConfirmed
     [SQL.Only False] -> return TransactionUnconfirmed
     x -> throwError $ CriticalError ("Expected exactly one result from get-transaction-status.sql but got " <> pack (show (length x)) <> " of them. This should never happen")
+
+processTransactionStatuses ::
+  (Has AppEnv r, Has ConnectionPool r, Has VVAConfig r, MonadReader r m, MonadIO m, MonadError AppError m)
+  => WebsocketTvar
+  -> m ()
+processTransactionStatuses tvar = do
+  txs <- getWatchedTransactions
+  forM_ txs $ \(txHash, uuid) -> do
+    status <- getTransactionStatus txHash
+    case status of
+      TransactionConfirmed -> do
+        connection <- getWebsocketConnection tvar uuid
+        case connection of
+          Just conn -> do
+            liftIO $ WS.sendTextData conn ("{\"status\": \"confirmed\"}" :: Text)
+            removeWebsocketConnection tvar uuid
+          Nothing -> return ()
+      TransactionUnconfirmed -> return ()
+
+  liftIO $ threadDelay (20 * 1000000)
+  processTransactionStatuses tvar
+
+
+watchTransaction ::
+  (Has AppEnv r, Has ConnectionPool r, Has VVAConfig r, MonadReader r m, MonadIO m, MonadError AppError m)
+  => WebsocketTvar
+  -> Text
+  -> Connection
+  -> m ()
+watchTransaction tVar txHash connection = do
+
+  uuid <- (pack . show) <$> liftIO nextRandom
+
+  port <- getRedisPort
+  host <- getRedisHost
+  conn <- liftIO $ Redis.checkedConnect $ Redis.defaultConnectInfo {Redis.connectHost = unpack host, Redis.connectPort = Redis.PortNumber $ fromIntegral port, Redis.connectDatabase = 1}
+
+  liftIO $ Redis.runRedis conn $ do
+    _ <- Redis.set (Text.encodeUtf8 txHash) (Text.encodeUtf8 uuid)
+
+    return ()
+  setWebsocketConnection tVar uuid connection
+
+
+
+getWatchedTransactions ::
+  (Has ConnectionPool r, Has VVAConfig r, MonadReader r m, MonadIO m, MonadError AppError m)
+  => m [(Text, Text)]
+getWatchedTransactions = do
+  port <- getRedisPort
+  host <- getRedisHost
+  conn <- liftIO $ Redis.checkedConnect $ Redis.defaultConnectInfo {Redis.connectHost = unpack host, Redis.connectPort = Redis.PortNumber $ fromIntegral port, Redis.connectDatabase = 1}
+  keysResult <- liftIO $ Redis.runRedis conn $ Redis.keys "*"
+  case keysResult of
+    Left err -> do
+      -- handle error, maybe throw an AppError
+      throwError $ CriticalError $ "Error fetching keys: " <> (pack . show) err
+    Right keys -> do
+      keyValuePairs <- liftIO $ Redis.runRedis conn $ mapM getKeyValue keys
+      let filteredPairs = catMaybes keyValuePairs
+      pure filteredPairs
+
+
+getKeyValue :: ByteString -> Redis.Redis (Maybe (Text, Text))
+getKeyValue key = do
+  valueResult <- Redis.get key
+  return $ case valueResult of
+    Left _ -> Nothing
+    Right Nothing -> Nothing
+    Right (Just value) -> Just (Text.decodeUtf8 key, Text.decodeUtf8 value)
+
+setWebsocketConnection ::
+  (MonadReader r m, MonadIO m, MonadError AppError m)
+  => WebsocketTvar
+  -> Text
+  -> Connection
+  -> m ()
+setWebsocketConnection tvar txHash connection = do
+  liftIO $ atomically $ do
+    connections <- readTVar tvar
+    writeTVar tvar $ Map.insert txHash connection connections
+
+
+getWebsocketConnection ::
+  (MonadReader r m, MonadIO m, MonadError AppError m)
+  => WebsocketTvar
+  -> Text
+  -> m (Maybe Connection)
+getWebsocketConnection tvar txHash = do
+  connections <- liftIO $ readTVarIO tvar
+  return $ Map.lookup txHash connections
+
+removeWebsocketConnection ::
+  (MonadReader r m, MonadIO m, MonadError AppError m)
+  => WebsocketTvar
+  -> Text
+  -> m ()
+removeWebsocketConnection tvar txHash = do
+  liftIO $ atomically $ do
+    connections <- readTVar tvar
+    writeTVar tvar $ Map.delete txHash connections

--- a/govtool/backend/src/VVA/Types.hs
+++ b/govtool/backend/src/VVA/Types.hs
@@ -208,7 +208,7 @@ data VotingAnchor
 
 type App m = (MonadReader AppEnv m, MonadIO m, MonadFail m, MonadError AppError m)
 
-type WebsocketTvar = TVar (Map Text WS.Connection)
+type WebsocketTvar = TVar (Map Text (WS.Connection, UTCTime))
 
 data AppEnv
   = AppEnv
@@ -240,7 +240,7 @@ instance Has QSem AppEnv where
   getter AppEnv {vvaMetadataQSem} = vvaMetadataQSem
   modifier f a@AppEnv {vvaMetadataQSem} = a {vvaMetadataQSem = f vvaMetadataQSem}
 
-instance Has (TVar (Map Text WS.Connection)) AppEnv where
+instance Has (TVar (Map Text (WS.Connection, UTCTime))) AppEnv where
   getter AppEnv {vvaWebSocketConnections} = vvaWebSocketConnections
   modifier f a@AppEnv {vvaWebSocketConnections} = a {vvaWebSocketConnections = f vvaWebSocketConnections}
 

--- a/govtool/backend/src/VVA/Types.hs
+++ b/govtool/backend/src/VVA/Types.hs
@@ -9,8 +9,6 @@
 
 module VVA.Types where
 
-
-
 import           GHC.Conc (TVar)
 import qualified Network.WebSockets.Connection as WS
 import           Data.Aeson.TH              (deriveJSON)
@@ -245,3 +243,4 @@ instance Has QSem AppEnv where
 instance Has (TVar (Map Text WS.Connection)) AppEnv where
   getter AppEnv {vvaWebSocketConnections} = vvaWebSocketConnections
   modifier f a@AppEnv {vvaWebSocketConnections} = a {vvaWebSocketConnections = f vvaWebSocketConnections}
+

--- a/govtool/backend/src/VVA/Types.hs
+++ b/govtool/backend/src/VVA/Types.hs
@@ -9,6 +9,10 @@
 
 module VVA.Types where
 
+
+
+import           GHC.Conc (TVar)
+import qualified Network.WebSockets.Connection as WS
 import           Data.Aeson.TH              (deriveJSON)
 import VVA.API.Utils (jsonOptions)
 import GHC.Generics (Generic)
@@ -24,6 +28,7 @@ import           Data.Has
 import           Data.Pool                  (Pool)
 import           Data.Text                  (Text)
 import           Data.Time                  (UTCTime)
+import           Data.Map                   (Map)
 
 import           Database.PostgreSQL.Simple (Connection)
 
@@ -205,6 +210,8 @@ data VotingAnchor
 
 type App m = (MonadReader AppEnv m, MonadIO m, MonadFail m, MonadError AppError m)
 
+type WebsocketTvar = TVar (Map Text WS.Connection)
+
 data AppEnv
   = AppEnv
       { vvaConfig         :: VVAConfig
@@ -212,6 +219,7 @@ data AppEnv
       , vvaConnectionPool :: Pool Connection
       , vvaTlsManager     :: Manager
       , vvaMetadataQSem   :: QSem
+      , vvaWebSocketConnections :: WebsocketTvar
       }
 
 instance Has VVAConfig AppEnv where
@@ -233,3 +241,7 @@ instance Has Manager AppEnv where
 instance Has QSem AppEnv where
   getter AppEnv {vvaMetadataQSem} = vvaMetadataQSem
   modifier f a@AppEnv {vvaMetadataQSem} = a {vvaMetadataQSem = f vvaMetadataQSem}
+
+instance Has (TVar (Map Text WS.Connection)) AppEnv where
+  getter AppEnv {vvaWebSocketConnections} = vvaWebSocketConnections
+  modifier f a@AppEnv {vvaWebSocketConnections} = a {vvaWebSocketConnections = f vvaWebSocketConnections}

--- a/govtool/backend/vva-be.cabal
+++ b/govtool/backend/vva-be.cabal
@@ -105,6 +105,10 @@ library
                , vector
                , async
                , hedis
+               , websockets
+               , uuid
+               , servant-websockets
+               , servant-openapi3
 
   exposed-modules: VVA.Config
                  , VVA.CommandLine

--- a/govtool/backend/vva-be.cabal
+++ b/govtool/backend/vva-be.cabal
@@ -109,6 +109,7 @@ library
                , uuid
                , servant-websockets
                , servant-openapi3
+               , monad-loops
 
   exposed-modules: VVA.Config
                  , VVA.CommandLine

--- a/scripts/govtool/config/templates/backend-config.json.tpl
+++ b/scripts/govtool/config/templates/backend-config.json.tpl
@@ -18,5 +18,6 @@
         "host"    : "http://redis",
         "port"    : 8094,
         "password": "<REDIS_PASSWORD>"
-    }
+    },
+    "websocketlifetimeseconds": 60
 }


### PR DESCRIPTION
## List of changes

Added
- /transaction/watch/<TX-HASH> websocket endpoint
- background transaction status process, that looks for watched transactions and sends {"status": "confirmed"} via websocket when transaction is found. This process works in iterations, once per 20 seconds.


IMPORTANT!!!

each /transaction/watch request stores a UUID in Redis in database number 1 (not 0)
this redis store, together with in-memory uuid to WebSocket.Connection map is used to notify user, that transaction of interest is confirmed.


## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1235)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
