### PR TITLE
fix(#1244): Fix styling of the markdowns on the slider cards

### DIFF
--- a/govtool/frontend/src/components/molecules/GovernanceActionCard.tsx
+++ b/govtool/frontend/src/components/molecules/GovernanceActionCard.tsx
@@ -94,6 +94,7 @@ export const GovernanceActionCard: FC<ActionTypeProps> = ({ ...props }) => {
           textVariant="twoLines"
           dataTestId="governance-action-abstract"
           isSliderCard
+          isMarkdown
         />
         <GovernanceActionCardElement
           label={t("govActions.governanceActionType")}

--- a/govtool/frontend/src/components/molecules/GovernanceActionCardElement.tsx
+++ b/govtool/frontend/src/components/molecules/GovernanceActionCardElement.tsx
@@ -46,6 +46,8 @@ export const GovernanceActionCardElement = ({
     <Box
       data-testid={dataTestId}
       mb={marginBottom ?? isSliderCard ? "20px" : "32px"}
+      maxHeight={isSliderCard ? "72px" : "none"}
+      overflow={isSliderCard ? "hidden" : "visible"}
     >
       <Box
         sx={{
@@ -108,7 +110,7 @@ export const GovernanceActionCardElement = ({
               display: "flex",
               alignItems: "center",
               overflow: "hidden",
-              flexDirection: "column",
+              flexDirection: isMarkdown ? "column" : "row",
             }}
           >
             {isMarkdown ? (


### PR DESCRIPTION
## List of changes

- Fix styling of the markdowns on the slider cards

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1244)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
