### PR TITLE
fix(#1313): fix blank screen on GAs voting when wallet is not initially connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ changes.
 - Fix wrong link to the GA Details once it is in progress [Issue 1252](https://github.com/IntersectMBO/govtool/issues/1252)
 - Fix validation of the GAs with missing references [Issue 1282](https://github.com/IntersectMBO/govtool/issues/1282)
 - Fix displaying the GA Markdowns [Issue 1244](https://github.com/IntersectMBO/govtool/issues/1244)
+- Fix app crash on voting on the GA without the connected wallet before [Issue 1313](https://github.com/IntersectMBO/govtool/issues/1313)
 
 ### Changed
 

--- a/govtool/frontend/src/components/molecules/WalletOption.tsx
+++ b/govtool/frontend/src/components/molecules/WalletOption.tsx
@@ -23,7 +23,7 @@ export const WalletOptionButton: FC<WalletOption> = ({
   cip95Available,
   pathToNavigate,
 }) => {
-  const { pathname, hash } = useLocation();
+  const { pathname, hash, state } = useLocation();
   const { enable, isEnableLoading } = useCardano();
   const {
     palette: { lightBlue },
@@ -38,6 +38,7 @@ export const WalletOptionButton: FC<WalletOption> = ({
         pathToNavigate ?? pathname === "/"
           ? "/dashboard"
           : `connected${pathname}${hash}`,
+        { state },
       );
       return;
     }


### PR DESCRIPTION
## List of changes

- fix blank screen on GAs voting when wallet is not initially connected

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1313)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
