### PR TITLE
Configure Google tag manager in test stack

### DIFF
--- a/tests/test-infrastructure/docker-compose-govtool.yml
+++ b/tests/test-infrastructure/docker-compose-govtool.yml
@@ -43,6 +43,7 @@ services:
         VITE_SENTRY_DSN: ${SENTRY_DSN_FRONTEND}
         NPMRC_TOKEN: ${NPMRC_TOKEN}
         VITE_IS_PROPOSAL_DISCUSSION_FORUM_ENABLED: "true"
+        GTM_ID: ${GTM_ID}
     environment:
       VIRTUAL_HOST: https://${BASE_DOMAIN}
     networks:

--- a/tests/test-infrastructure/playbook.yml
+++ b/tests/test-infrastructure/playbook.yml
@@ -18,6 +18,7 @@
       args:
         chdir: "/opt/govtool/tests/test-infrastructure"
       environment:
+        GTM_ID: "{{ lookup ('env', 'GTM_ID') }}"
         GOVTOOL_TAG: "{{ lookup('env', 'GOVTOOL_TAG') }}"
         NPMRC_TOKEN: "{{ lookup('env','NPMRC_TOKEN') }}"
         SENTRY_DSN_FRONTEND: "{{ lookup ('env', 'SENTRY_DSN_FRONTEND') }}"


### PR DESCRIPTION
## List of changes

- pass GTM_ID env variable to frontend build.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1335)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
