### PR TITLE
Test-infra: Expose storybook deployment publicly

### DIFF
--- a/tests/test-infrastructure/docker-compose-govtool.yml
+++ b/tests/test-infrastructure/docker-compose-govtool.yml
@@ -79,6 +79,8 @@ services:
         NPMRC_TOKEN: ${NPMRC_TOKEN}
     environment:
       VIRTUAL_HOST: https://storybook-${BASE_DOMAIN}
+    networks:
+      - frontend
     deploy:
       restart_policy:
         delay: "30s"


### PR DESCRIPTION
## List of changes

- On test stack compose file, add storybook service to frontend network

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/660)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
