### PR TITLE
[#1218] Resolve CSP issue blocking Sentry requests in Traefik configuration

### DIFF
--- a/scripts/govtool/config/templates/docker-compose.yml.tpl
+++ b/scripts/govtool/config/templates/docker-compose.yml.tpl
@@ -273,7 +273,7 @@ services:
     logging: *logging
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.frontend-csp.headers.contentSecurityPolicy=default-src 'self'; img-src *.usersnap.com https://www.googletagmanager.com 'self' data:; script-src *.usersnap.com 'self' https://www.googletagmanager.com https://browser.sentry-cdn.com; style-src *.usersnap.com *.googleapis.com 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src *.usersnap.com https://s3.eu-central-1.amazonaws.com/upload.usersnap.com 'self' o4506155985141760.ingest.sentry.io *.google-analytics.com *.api.pdf.gov.tools; font-src *.usersnap.com *.gstatic.com 'self' https://fonts.gstatic.com data:; worker-src blob:" 
+      - "traefik.http.middlewares.frontend-csp.headers.contentSecurityPolicy=default-src 'self'; img-src *.usersnap.com https://www.googletagmanager.com 'self' data:; script-src *.usersnap.com 'self' https://www.googletagmanager.com https://browser.sentry-cdn.com; style-src *.usersnap.com *.googleapis.com 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src *.usersnap.com https://s3.eu-central-1.amazonaws.com/upload.usersnap.com 'self' *.ingest.sentry.io *.google-analytics.com *.api.pdf.gov.tools; font-src *.usersnap.com *.gstatic.com 'self' https://fonts.gstatic.com data:; worker-src blob:" 
       - "traefik.http.routers.to-frontend.rule=Host(`<DOMAIN>`)"
       - "traefik.http.routers.to-frontend.entrypoints=websecure"
       - "traefik.http.routers.to-frontend.tls.certresolver=myresolver"


### PR DESCRIPTION
The purpose of these changes is to resolve a Content Security Policy (CSP) issue in the Traefik configuration that was blocking Sentry requests. The existing CSP settings did not allow communication with Sentry endpoints, specifically POST requests to the Sentry API, which was hindering error tracking and monitoring. This update addresses the problem by modifying the `connect-src` directive to include permissions for requests to any instance of Sentry under the `*.ingest.sentry.io` domain. By making this adjustment, the system ensures that Sentry can receive error data, aligning with the user story's requirement for effective error monitoring. The outcome of these changes is a functional error logging and monitoring system through Sentry, as the requests are no longer blocked. Testing has confirmed that error data is successfully transmitted to Sentry, enabling continuous evaluation and troubleshooting of the frontend service. Furthermore, the updated CSP has been crafted to uphold security best practices, preventing any compromise in the system's overall security posture. The modifications have been documented to ensure clarity and facilitate future maintenance.
