### PR TITLE
Bugfix/test-2N-3M

### DIFF
--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
@@ -66,11 +66,7 @@ test("2N. Should show DRep information on details page", async ({
 
   await dRepRegistrationPage.confirmBtn.click();
 
-  const dRepDirectory = new DRepDirectoryPage(dRepPage);
-  await dRepDirectory.goto();
-
-  await dRepDirectory.searchInput.fill(wallet.dRepId);
-  await dRepPage.getByTestId(`${wallet.dRepId}-view-details-button`).click();
+  await dRepPage.getByTestId("view-drep-details-button").click();
 
   // Verification
   await expect(dRepPage.getByTestId("copy-drep-id-button")).toHaveText(

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
@@ -19,6 +19,8 @@ test.describe("Validation of edit dRep Form", () => {
     const editDRepPage = new EditDRepPage(page);
     await editDRepPage.goto();
 
+    await editDRepPage.addLinkBtn.click();
+
     for (let i = 0; i < 100; i++) {
       await editDRepPage.validateForm(
         faker.internet.displayName(),
@@ -43,6 +45,8 @@ test.describe("Validation of edit dRep Form", () => {
 
     const editDRepPage = new EditDRepPage(page);
     await editDRepPage.goto();
+
+    await editDRepPage.addLinkBtn.click();
 
     for (let i = 0; i < 100; i++) {
       await editDRepPage.inValidateForm(


### PR DESCRIPTION
## List of changes

- Add "add link" button click event on the test 3M (Validation of edit DRep form)
- Update the DRep information navigation flow on test 2N (Should show DRep information on details page)

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
