### PR TITLE
fix/1389-bug-clearing-name-field-on-edit-drep-form-causes-it-to-reappear-and-adds-extra-link-input

### DIFF
--- a/govtool/frontend/src/components/organisms/EditDRepInfoSteps/EditDRepForm.tsx
+++ b/govtool/frontend/src/components/organisms/EditDRepInfoSteps/EditDRepForm.tsx
@@ -21,15 +21,19 @@ const MAX_NUMBER_OF_LINKS = 7;
 export const EditDRepForm = ({
   onClickCancel,
   setStep,
+  loadUserData,
+  setLoadUserData,
 }: {
   onClickCancel: () => void;
   setStep: Dispatch<SetStateAction<number>>;
+  loadUserData: boolean;
+  setLoadUserData: Dispatch<SetStateAction<boolean>>;
 }) => {
   const { state } = useLocation();
   const { t } = useTranslation();
   const { isMobile } = useScreenDimension();
   const { dRepID } = useCardano();
-  const { control, errors, isError, register, watch, reset, getValues } =
+  const { control, errors, isError, register, watch, reset } =
     useEditDRepInfoForm();
   const {
     append,
@@ -47,7 +51,10 @@ export const EditDRepForm = ({
     { enabled: !state },
   );
 
-  const onClickContinue = () => setStep(2);
+  const onClickContinue = () => {
+    setStep(2);
+    setLoadUserData(false);
+  };
 
   const addLink = useCallback(() => append({ uri: "" }), [append]);
 
@@ -56,25 +63,28 @@ export const EditDRepForm = ({
   const isContinueButtonDisabled = !watch("dRepName") || isError;
 
   useEffect(() => {
-    if (!getValues().dRepName)
+    if (loadUserData) {
       reset(
         state
           ? {
               ...state,
-              references: state.references.map((uri: string) => ({
-                uri,
-              })),
+              references: state.references.length
+                ? state.references.map((uri: string) => ({
+                    uri,
+                  }))
+                : [{ uri: "" }],
             }
           : {
               ...yourselfDRepList?.[0],
-              references: yourselfDRepList?.[0].references.map(
-                (uri: string) => ({
-                  uri,
-                }),
-              ),
+              references: yourselfDRepList?.[0].references.length
+                ? yourselfDRepList?.[0].references.map((uri: string) => ({
+                    uri,
+                  }))
+                : [{ uri: "" }],
             },
       );
-  }, [yourselfDRepList]);
+    }
+  }, [yourselfDRepList?.[0], loadUserData]);
 
   const renderLinks = useCallback(
     () =>

--- a/govtool/frontend/src/hooks/forms/useEditDRepInfoForm.ts
+++ b/govtool/frontend/src/hooks/forms/useEditDRepInfoForm.ts
@@ -77,6 +77,7 @@ export const useEditDRepInfoForm = (
 
   // Navigation
   const backToForm = useCallback(() => {
+    window.scrollTo(0, 0);
     setStep?.(1);
     closeModal();
   }, [setStep]);

--- a/govtool/frontend/src/pages/EditDRepMetadata.tsx
+++ b/govtool/frontend/src/pages/EditDRepMetadata.tsx
@@ -24,6 +24,7 @@ import { checkIsWalletConnected } from "@utils";
 
 export const EditDRepMetadata = () => {
   const [step, setStep] = useState<number>(1);
+  const [loadUserData, setLoadUserData] = useState(true);
   const { isMobile } = useScreenDimension();
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -95,6 +96,8 @@ export const EditDRepMetadata = () => {
               <EditDRepForm
                 onClickCancel={onClickBackToDashboard}
                 setStep={setStep}
+                loadUserData={loadUserData}
+                setLoadUserData={setLoadUserData}
               />
             )}
             {step === 2 && <EditDRepStoreDataInfo setStep={setStep} />}


### PR DESCRIPTION
## List of changes

- Fix edit drep form

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1389)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
