### PR TITLE
[#1093] return 0 drep voting power instead of throwing 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ changes.
 
 ### Fixed
 
+- drep/get-voting-power no longer throws 500 for non-existing dreps. Instead it returns 0 [Issue 1093](https://github.com/IntersectMBO/govtool/issues/1093)
 - proposal/list no longer throws 500 error when proposal's url is incorrect [Issue 1073](https://github.com/IntersectMBO/govtool/issues/1073)
 - drep/list sql fix (now the drep type is correct) [Issue 957](https://github.com/IntersectMBO/govtool/issues/957)
 - drep/list sql fix (now the latest tx date is correct) [Issue 826](https://github.com/IntersectMBO/govtool/issues/826)

--- a/govtool/backend/src/VVA/DRep.hs
+++ b/govtool/backend/src/VVA/DRep.hs
@@ -46,10 +46,12 @@ getVotingPower ::
   Text ->
   m Integer
 getVotingPower drepId = withPool $ \conn -> do
-  [SQL.Only votingPower] <-
+  result <-
     liftIO
       (SQL.query @_ @(SQL.Only Scientific) conn getVotingPowerSql $ SQL.Only drepId)
-  return $ floor votingPower
+  case result of
+    [SQL.Only votingPower] -> return $ floor votingPower
+    [] -> return 0
 
 listDRepsSql :: SQL.Query
 listDRepsSql = sqlFrom $(embedFile "sql/list-dreps.sql")


### PR DESCRIPTION
## List of changes

Fix 
- drep/get-voting-power no longer throws error 500 for non-existent dreps

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1093)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
