### PR TITLE
fix(#1349): Change label of Proposal Discussion nav item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ changes.
 - Changed documents to prepare for open source [Issue 737](https://github.com/IntersectMBO/govtool/issues/737)
 - Changed copy on maintenance page [Issue 753](https://github.com/IntersectMBO/govtool/issues/753)
 - Update link to docs [Issue 1246](https://github.com/IntersectMBO/govtool/issues/1246)
+- Change label of Proposal Discussion nav item [Issue 1349](https://github.com/IntersectMBO/govtool/issues/1349)
 
 ### Removed
 

--- a/govtool/frontend/src/i18n/locales/en.ts
+++ b/govtool/frontend/src/i18n/locales/en.ts
@@ -385,7 +385,7 @@ export const en = {
       },
     },
     proposalDiscussion: {
-      title: "Proposal Discussion",
+      title: "Proposals",
       proposeAGovernanceAction: "Propose a Governance Action",
     },
     govActions: {


### PR DESCRIPTION
## List of changes

- Change label of Proposal Discussion nav item

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1349)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
