### PR TITLE
[#1417] silence timeout errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ changes.
 
 ### Fixed
 
+- silenced `Thread killed by timeout manager` sentry log [Issue 1417](https://github.com/IntersectMBO/govtool/issues/1417)
 - backend is now compiled with -threaded [Issue 1148](https://github.com/IntersectMBO/govtool/issues/1148)
 - drep/get-voting-power no longer throws 500 for non-existing dreps. Instead it returns 0 [Issue 1093](https://github.com/IntersectMBO/govtool/issues/1093)
 - proposal/list no longer throws 500 error when proposal's url is incorrect [Issue 1073](https://github.com/IntersectMBO/govtool/issues/1073)

--- a/govtool/backend/app/Main.hs
+++ b/govtool/backend/app/Main.hs
@@ -143,6 +143,7 @@ exceptionHandler :: VVAConfig -> Maybe Request -> SomeException -> IO ()
 exceptionHandler vvaConfig mRequest exception = do
   print mRequest
   print exception
+  guard (show exception /= "Thread killed by timeout manager")
   sentryService <-
     initRaven
       (sentryDSN vvaConfig)


### PR DESCRIPTION
## List of changes

Fix
- silence timeout errors before request could be parsed

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1417)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
