### PR TITLE
Enable proposal auth setup

### DIFF
--- a/tests/govtool-frontend/playwright/lib/pages/proposalDiscussionPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/proposalDiscussionPage.ts
@@ -2,9 +2,9 @@ import { faker } from "@faker-js/faker";
 import { generateWalletAddress } from "@helpers/cardano";
 import { extractProposalIdFromUrl } from "@helpers/string";
 import { Page } from "@playwright/test";
-import { ProposalCreateRequest } from "@services/proposalDiscussion/types";
 import environments from "lib/constants/environments";
 import ProposalDiscussionDetailsPage from "./proposalDiscussionDetailsPage";
+import {ProposalCreateRequest} from "@types";
 
 export default class ProposalDiscussionPage {
   // Buttons
@@ -24,6 +24,9 @@ export default class ProposalDiscussionPage {
   readonly showLessBtn = this.page.getByRole("button", { name: "Show less" });
   readonly infoRadio = this.page.getByLabel("Info");
   readonly treasuryRadio = this.page.getByLabel("Treasury");
+  readonly verifyIdentityBtn = this.page.getByRole("button", {
+    name: "Verify your identity",
+  });
 
   constructor(private readonly page: Page) {}
 

--- a/tests/govtool-frontend/playwright/lib/types.ts
+++ b/tests/govtool-frontend/playwright/lib/types.ts
@@ -122,3 +122,21 @@ export type CommentResponse = {
     subcommens_number: number;
   };
 };
+
+
+export type ProposalLink = {
+  prop_link: string;
+  prop_link_text: string;
+};
+
+export type ProposalCreateRequest = {
+  proposal_links: Array<ProposalLink>;
+  gov_action_type_id: number;
+  prop_name: string;
+  prop_abstract: string;
+  prop_motivation: string;
+  prop_rationale: string;
+  prop_receiving_address?: string;
+  prop_amount?: string;
+  is_draft: boolean;
+};

--- a/tests/govtool-frontend/playwright/tests/auth.setup.ts
+++ b/tests/govtool-frontend/playwright/tests/auth.setup.ts
@@ -128,20 +128,20 @@ setup("Create AdaHolder 06 auth", async ({ page, context }) => {
   await context.storageState({ path: adaHolder06AuthFile });
 });
 
-/**
- * TODO: Uncomment this
- * This has been commented to temporarily disable pdf-tests
- */
-// setup("Create Proposal 01 auth", async ({ page, context }) => {
-//   await importWallet(page, proposal01Wallet);
+setup("Create Proposal 01 auth", async ({ page, context }) => {
+  await importWallet(page, proposal01Wallet);
 
-//   const loginPage = new LoginPage(page);
-//   await loginPage.login();
-//   await loginPage.isLoggedIn();
+  const loginPage = new LoginPage(page);
+  await loginPage.login();
+  await loginPage.isLoggedIn();
 
-//   const proposalDiscussionPage = new ProposalDiscussionPage(page);
-//   await proposalDiscussionPage.goto();
-//   await proposalDiscussionPage.setUsername(faker.internet.userName());
+  const proposalDiscussionPage = new ProposalDiscussionPage(page);
+  await proposalDiscussionPage.goto();
+  await proposalDiscussionPage.verifyIdentityBtn.click();
 
-//   await context.storageState({ path: proposal01AuthFile });
-// });
+  await proposalDiscussionPage.setUsername(
+      faker.internet.userName().toLowerCase()
+  );
+
+  await context.storageState({ path: proposal01AuthFile });
+});


### PR DESCRIPTION
## List of changes

- Enabled setup for proposal auth
- Add type for proposal-create-request

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
