### PR TITLE
chore(#1463): Fix CSP issue blocking Sentry requests in Traefik config

### DIFF
--- a/govtool/frontend/src/context/usersnapContext.tsx
+++ b/govtool/frontend/src/context/usersnapContext.tsx
@@ -73,10 +73,14 @@ export const UsersnapProvider = ({
   }, [usersnapApi]);
 
   useEffect(() => {
-    loadSpace(API_KEY).then((api) => {
-      api.init(initParams);
-      setUsersnapApi(api);
-    });
+    loadSpace(API_KEY)
+      .then((api) => {
+        api.init(initParams);
+        setUsersnapApi(api);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
   }, [initParams]);
 
   const value = useMemo(() => ({ openFeedbackWindow }), [openFeedbackWindow]);

--- a/govtool/frontend/vite.config.ts
+++ b/govtool/frontend/vite.config.ts
@@ -10,19 +10,6 @@ import react from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 const viteConfig = defineViteConfig({
   plugins: [
-    {
-      name: "jsx-in-js-transformer",
-      async transform(code, id) {
-        if (!id.match(/.*\.js$/)) return null;
-
-        // Use the exposed transform from vite, instead of directly
-        // transforming with esbuild
-        return transformWithEsbuild(code, id, {
-          loader: "jsx",
-          jsx: "automatic",
-        });
-      },
-    },
     react(),
   ],
   cacheDir: ".vite",

--- a/govtool/frontend/vite.config.ts
+++ b/govtool/frontend/vite.config.ts
@@ -10,6 +10,19 @@ import react from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 const viteConfig = defineViteConfig({
   plugins: [
+    {
+      name: "jsx-in-js-transformer",
+      async transform(code, id) {
+        if (!id.match(/.*\.js$/)) return null;
+
+        // Use the exposed transform from vite, instead of directly
+        // transforming with esbuild
+        return transformWithEsbuild(code, id, {
+          loader: "jsx",
+          jsx: "automatic",
+        });
+      },
+    },
     react(),
   ],
   cacheDir: ".vite",

--- a/scripts/govtool/config/templates/docker-compose.yml.tpl
+++ b/scripts/govtool/config/templates/docker-compose.yml.tpl
@@ -273,7 +273,7 @@ services:
     logging: *logging
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.frontend-csp.headers.contentSecurityPolicy=default-src 'self'; img-src *.usersnap.com https://www.googletagmanager.com 'self' data:; script-src *.usersnap.com 'self' https://www.googletagmanager.com https://browser.sentry-cdn.com; style-src *.usersnap.com *.googleapis.com 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src *.usersnap.com https://s3.eu-central-1.amazonaws.com/upload.usersnap.com 'self' *.ingest.sentry.io *.google-analytics.com *.api.pdf.gov.tools; font-src *.usersnap.com *.gstatic.com 'self' https://fonts.gstatic.com data:; worker-src blob:" 
+      - "traefik.http.middlewares.frontend-csp.headers.contentSecurityPolicy=default-src 'self'; img-src *.usersnap.com https://www.googletagmanager.com 'self' data:; script-src *.usersnap.com 'self' https://www.googletagmanager.com https://browser.sentry-cdn.com; style-src *.usersnap.com *.googleapis.com 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src *.usersnap.com https://s3.eu-central-1.amazonaws.com/upload.usersnap.com 'self' *.sentry.io *.google-analytics.com *.api.pdf.gov.tools; font-src *.usersnap.com *.gstatic.com 'self' https://fonts.gstatic.com data:; worker-src blob:"
       - "traefik.http.routers.to-frontend.rule=Host(`<DOMAIN>`)"
       - "traefik.http.routers.to-frontend.entrypoints=websecure"
       - "traefik.http.routers.to-frontend.tls.certresolver=myresolver"


### PR DESCRIPTION
The Content Security Policy (CSP) was updated to resolve the issue that was blocking Sentry requests. Previously, the `connect-src` directive did allow requests from ingest.us.sentry.io, which resulted in an error which prevented users from submitting feedback.

## List of changes

- Change sentry domain in connect-src CSP to be broader

## Checklist

- [1463](https://github.com/IntersectMBO/govtool/issues/1463)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
