### PR TITLE
Fix: typo  replace proposal to drepInfo

### DIFF
--- a/tests/govtool-backend/test_cases/test_proposal.py
+++ b/tests/govtool-backend/test_cases/test_proposal.py
@@ -9,7 +9,7 @@ def validate_proposal(proposal: Proposal) -> bool:
         assert key in proposal, f"Expected Proposal.{key} to be present"
         assert isinstance(
             proposal[key], Proposal.__annotations__[key]
-        ), f"drepInfo.{key} should be of type {Proposal.__annotations__[key]} got {type(proposal[key])}"
+        ), f"proposal.{key} should be of type {Proposal.__annotations__[key]} got {type(proposal[key])}"
     return True
 
 


### PR DESCRIPTION
## List of changes

- Fix error log when proposal schema validation fails

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
