### PR TITLE
Fix failing test 3I 6D and 4H

### DIFF
--- a/tests/govtool-frontend/playwright/lib/helpers/extractExpiryDateFromText.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/extractExpiryDateFromText.ts
@@ -14,13 +14,13 @@ const monthNames = [
 ];
 
 export default function extractExpiryDateFromText(text: string): Date | null {
-  const regex = /(\d{1,2})th ([\w]{3}) (\d{4})/;
+  const regex = /(\d{1,2})(st|nd|rd|th) ([\w]{3}) (\d{4})/;
   const match = text.match(regex);
 
   if (match) {
     const day = parseInt(match[1]);
-    const month = match[2];
-    const year = parseInt(match[3]);
+    const month = match[3];
+    const year = parseInt(match[4]);
 
     return new Date(year, monthNames.indexOf(month), day);
   } else {

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -181,7 +181,7 @@ test.describe("Temporary DReps", () => {
       .click();
 
     await expect(
-      dRepPage.locator("span").filter({ hasText: "In Progress" })
+      dRepPage.locator("span").filter({ hasText: /^In Progress$/ })
     ).toBeVisible(); // BUG add proper testId for dRep registration card
   });
 });

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
@@ -76,12 +76,4 @@ test("6D. Should open Sanchonet docs in a new tab when clicking `Learn More` on 
     page.getByTestId("lear-more-about-sole-voter-button").click(),
   ]);
   await expect(directVoterLearnMorepage).toHaveURL(DIRECT_VOTER_DOC_URL);
-
-  const [proposed_GA_VoterLearnMorepage] = await Promise.all([
-    context.waitForEvent("page"),
-    page.getByRole("button", { name: "Learn more" }).nth(3).click(), // BUG missing test id
-  ]);
-  await expect(proposed_GA_VoterLearnMorepage).toHaveURL(
-    PROPOSE_GOVERNANCE_ACTION_DOC_URL
-  );
 });


### PR DESCRIPTION
## List of changes

- Add `st` , `nd`, `rd` on the date regex of `extractExpiryDateFromText` function.
- Remove the "learn more" assertion on disconnect state as "learn more" for proposing a governance action is no longer on dashboard.
- Add an exact match for "In Progress" on the assertion for dRep registration, as "In Progress" is also taken from "DRep registration in progress"

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
