### PR TITLE
Fix: gov-action-loader: remove old cardano-cli dependency

### DIFF
--- a/gov-action-loader/backend/Dockerfile
+++ b/gov-action-loader/backend/Dockerfile
@@ -1,13 +1,6 @@
 FROM python:3.10 AS builder
 
 WORKDIR /app
-# Install cardano-cli
-
-RUN  \
-       wget https://github.com/input-output-hk/cardano-node/releases/download/8.5.0-pre/cardano-node-8.5.0-linux.tar.gz \
-    && tar -xvzf cardano-node-8.5.0-linux.tar.gz \
-    &&  mv ./cardano-cli /usr/local/bin/cardano-cli \
-    && rm -rf /code/*
 
 COPY ./requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --upgrade -r ./requirements.txt

--- a/gov-action-loader/backend/app/main.py
+++ b/gov-action-loader/backend/app/main.py
@@ -14,7 +14,7 @@ from app.models import MultipleProposal
 from app.settings import settings
 from app.transaction import (get_base_proposal_for_multiple,
                              get_default_transaction,
-                             get_proposal_data_from_type, get_txid_from_cli,
+                             get_proposal_data_from_type,
                              main_wallet, submit_proposal_tx)
 
 app = FastAPI()
@@ -106,7 +106,7 @@ async def submit_multiple_proposals(
     else:
         raise HTTPException(
             status_code=400,
-            detail="No of proposals greater than 100 not supported yet.",
+            detail="No of proposals greater than "+str(maximum_supported_proposals)+" not supported yet.",
         )
 
 
@@ -134,7 +134,7 @@ async def submit_single_proposal(
     if kuber_response.status_code == 200:
         tx = kuber_response.json()
         tx["type"] = "Witnessed Tx ConwayEra"
-        tx_id = get_txid_from_cli(tx)
+        tx_id = tx['hash']
         return tx | {"txId": tx_id}
     else:
         print(kuber_response.text)

--- a/gov-action-loader/backend/app/transaction.py
+++ b/gov-action-loader/backend/app/transaction.py
@@ -160,38 +160,11 @@ def get_proposal_data_from_type(proposal_type, current_pParams):
 
 
 def filter_updatable_paramKeys(keys):
-    updatable_keys = set(
-        [
-            "maxBlockSize",
-            "maxBBSize",
-            "maxTxSize",
-            "maxBHSize",
-            "keyDeposit",
-            "poolDeposit",
-            "eMax",
-            "nOpt",
-            "a0",
-            "rho",
-            "tau",
-            "minPoolCost",
-            "coinsPerUTxOByte",
-            "costModels",
-            "prices",
-            "maxTxExUnits",
-            "maxBlockExUnits",
-            "maxValSize",
-            "collateralPercentage",
-            "maxCollateralInputs",
-            "poolVotingThresholds",
-            "dRepVotingThresholds",
-            "committeeMinSize",
-            "committeeMaxTermLength",
-            "govActionLifetime",
-            "govActionDeposit",
-            "dRepDeposit",
-            "dRepActivity",
-        ]
-    )
+    updatable_keys = {"maxBlockSize", "maxBBSize", "maxTxSize", "maxBHSize", "keyDeposit", "poolDeposit", "eMax",
+                      "nOpt", "a0", "rho", "tau", "minPoolCost", "coinsPerUTxOByte", "costModels", "prices",
+                      "maxTxExUnits", "maxBlockExUnits", "maxValSize", "collateralPercentage", "maxCollateralInputs",
+                      "poolVotingThresholds", "dRepVotingThresholds", "committeeMinSize", "committeeMaxTermLength",
+                      "govActionLifetime", "govActionDeposit", "dRepDeposit", "dRepActivity"}
     return [x for x in keys if x in updatable_keys]
 
 
@@ -230,15 +203,3 @@ async def submit_proposal_tx(wallet, proposal, proposal_numbers, client):
         "proposals": proposals,
     }
     return await submit_tx(tx, client)
-
-
-def get_txid_from_cli(tx: Dict[str, Any]):
-    try:
-        with open("tx.raw", "w") as file:
-            json.dump(tx, file)
-        tx_id_command = "cardano-cli transaction txid --tx-file tx.raw"
-        tx_id_raw = subprocess.check_output(["bash", "-c", tx_id_command])
-        tx_id = tx_id_raw.decode("utf-8").strip()
-        return tx_id
-    finally:
-        os.remove("tx.raw")


### PR DESCRIPTION
## List of changes

- Remove `cardano-cli` from gov-action-loader backend
- Use tx-hash from kuber's transaction response

## Checklist

- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
