### PR TITLE
Fix: proposal draft test blocked by verify identity button

### DIFF
--- a/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
@@ -73,6 +73,8 @@ export default class ProposalSubmissionPage {
   async goto() {
     await this.page.goto(`${environments.frontendUrl}/proposal_discussion`);
 
+    await this.page.waitForTimeout(2_000); // wait until page load properly
+
     await this.verifyIdentityBtn.click();
     await this.proposalCreateBtn.click();
 

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
@@ -279,7 +279,8 @@ test.describe("Temporary proposal users", () => {
 
     test.beforeEach(async () => {
       proposalSubmissionPage = new ProposalSubmissionPage(userPage);
-      await proposalSubmissionPage.goto();
+      await proposalSubmissionPage.proposalCreateBtn.click();
+      await proposalSubmissionPage.continueBtn.click();
 
       await proposalSubmissionPage.addLinkBtn.click();
       proposalFormValue =


### PR DESCRIPTION
## List of changes

- Fix test 7C, 7L, 7M, 7N

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
