### PR TITLE
backend: allow using metadata directly from db-sync

### DIFF
--- a/govtool/backend/example-config.json
+++ b/govtool/backend/example-config.json
@@ -11,6 +11,7 @@
     "cachedurationseconds": 20,
     "sentrydsn": "https://username:password@senty.host/id",
     "sentryenv": "dev",
+    "metadatavalidationenabled": true,
     "metadatavalidationhost": "localhost",
     "metadatavalidationport": 3001,
     "metadatavalidationmaxconcurrentrequests": 10

--- a/govtool/backend/src/VVA/API.hs
+++ b/govtool/backend/src/VVA/API.hs
@@ -217,18 +217,30 @@ proposalToResponse Types.Proposal {..} Types.MetadataValidationResult{..} =
     proposalResponseCreatedEpochNo = proposalCreatedEpochNo,
     proposalResponseUrl = proposalUrl,
     proposalResponseMetadataHash = HexText proposalDocHash,
-    proposalResponseTitle = Types.proposalMetadataTitle <$> metadata,
-    proposalResponseAbstract = Types.proposalMetadataAbstract <$> metadata,
-    proposalResponseMotivation = Types.proposalMetadataMotivation <$> metadata,
-    proposalResponseRationale = Types.proposalMetadataRationale <$> metadata,
+    proposalResponseTitle = getTitle proposalTitle metadata,
+    proposalResponseAbstract = getAbstract proposalAbstract metadata,
+    proposalResponseMotivation = getMotivation proposalMotivation metadata,
+    proposalResponseRationale = getRationale proposalRationale metadata,
     proposalResponseMetadata = GovernanceActionMetadata <$> proposalMetadata,
-    proposalResponseReferences = maybe [] Types.proposalMetadataReferences metadata,
+    proposalResponseReferences = getReferences proposalReferences metadata,
     proposalResponseYesVotes = proposalYesVotes,
     proposalResponseNoVotes = proposalNoVotes,
     proposalResponseAbstainVotes = proposalAbstainVotes,
     proposalResponseMetadataStatus = metadataValidationResultStatus,
     proposalResponseMetadataValid = metadataValidationResultValid
   }
+  where
+   getTitle p Nothing = p
+   getTitle _ m = Types.proposalMetadataTitle <$> m
+   getAbstract p Nothing = p
+   getAbstract _ m = Types.proposalMetadataAbstract <$> m
+   getMotivation p Nothing = p
+   getMotivation _ m = Types.proposalMetadataMotivation <$> m
+   getRationale p Nothing = p
+   getRationale _ m = Types.proposalMetadataRationale <$> m
+   -- TODO: convert aeson references to [Text] from database
+   --getReferences p Nothing = p
+   getReferences _ m = maybe [] Types.proposalMetadataReferences m
 
 voteToResponse :: Types.Vote -> VoteParams
 voteToResponse Types.Vote {..} =

--- a/govtool/backend/src/VVA/Config.hs
+++ b/govtool/backend/src/VVA/Config.hs
@@ -24,6 +24,7 @@ module VVA.Config
     , getServerHost
     , getServerPort
     , vvaConfigToText
+    , getMetadataValidationEnabled
     , getMetadataValidationHost
     , getMetadataValidationPort
     ) where
@@ -82,6 +83,8 @@ data VVAConfigInternal
       , vVAConfigInternalSentrydsn              :: String
         -- | Sentry environment
       , vVAConfigInternalSentryEnv              :: String
+        -- | Metadata validation service enabled
+      , vVAConfigInternalMetadataValidationEnabled :: Bool
         -- | Metadata validation service host
       , vVAConfigInternalMetadataValidationHost :: Text
         -- | Metadata validation service port
@@ -100,6 +103,7 @@ instance DefaultConfig VVAConfigInternal where
         vVaConfigInternalCacheDurationSeconds = 20,
         vVAConfigInternalSentrydsn = "https://username:password@senty.host/id",
         vVAConfigInternalSentryEnv = "development",
+        vVAConfigInternalMetadataValidationEnabled = True,
         vVAConfigInternalMetadataValidationHost = "localhost",
         vVAConfigInternalMetadataValidationPort = 3001,
         vVAConfigInternalMetadataValidationMaxConcurrentRequests = 10
@@ -120,6 +124,8 @@ data VVAConfig
       , sentryDSN              :: String
         -- | Sentry environment
       , sentryEnv              :: String
+        -- | Metadata validation service enabled
+      , metadataValidationEnabled :: Bool
         -- | Metadata validation service host
       , metadataValidationHost :: Text
         -- | Metadata validation service port
@@ -167,6 +173,7 @@ convertConfig VVAConfigInternal {..} =
       cacheDurationSeconds = vVaConfigInternalCacheDurationSeconds,
       sentryDSN = vVAConfigInternalSentrydsn,
       sentryEnv = vVAConfigInternalSentryEnv,
+      metadataValidationEnabled = vVAConfigInternalMetadataValidationEnabled,
       metadataValidationHost = vVAConfigInternalMetadataValidationHost,
       metadataValidationPort = vVAConfigInternalMetadataValidationPort,
       metadataValidationMaxConcurrentRequests = vVAConfigInternalMetadataValidationMaxConcurrentRequests
@@ -207,6 +214,12 @@ getServerHost ::
   (Has VVAConfig r, MonadReader r m) =>
   m Text
 getServerHost = asks (serverHost . getter)
+
+-- | Access MetadataValidationService enabled
+getMetadataValidationEnabled ::
+  (Has VVAConfig r, MonadReader r m) =>
+  m Bool
+getMetadataValidationEnabled = asks (metadataValidationEnabled . getter)
 
 -- | Access MetadataValidationService host
 getMetadataValidationHost ::

--- a/govtool/backend/src/VVA/Types.hs
+++ b/govtool/backend/src/VVA/Types.hs
@@ -127,8 +127,8 @@ data Proposal
       , proposalUrl            :: Text
       , proposalDocHash        :: Text
       , proposalTitle          :: Maybe Text
-      , proposalAbout          :: Maybe Text
-      , proposalMotivaiton     :: Maybe Text
+      , proposalAbstract       :: Maybe Text
+      , proposalMotivation     :: Maybe Text
       , proposalRationale      :: Maybe Text
       , proposalMetadata       :: Maybe Value
       , proposalReferences     :: Maybe Value


### PR DESCRIPTION
## List of changes

The PR introduces a flag in the configuration to disable metadata validation from querying a server and rather trusts the metadata is valid from db-sync itself.

Usage:

add `"metadatavalidationenabled": false,` to config file

It also fixes some typos in types.hs that weren't used anywhere else in the code.

- Add / Fix / Change / Remove

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
