### PR TITLE
[#1538] Chore: Bump DB-Sync to version `sancho-5-1-0`

### DIFF
--- a/.github/workflows/resync-cardano-node-and-db-sync.yml
+++ b/.github/workflows/resync-cardano-node-and-db-sync.yml
@@ -13,10 +13,27 @@ on:
           - "test"
           - "staging"
           - "beta"
+      isProposalDiscussionForumEnabled:
+        description: "Enable proposal discussion forum"
+        required: true
+        type: choice
+        default: "disabled"
+        options:
+          - "enabled"
+          - "disabled"
+      forceRebuildDockerImages:
+        description: "Force rebuild the docker images"
+        required: false
+        type: choice
+        default: "false"
+        options:
+          - "true"
+          - "false"
 
 env:
   ENVIRONMENT: ${{ inputs.environment || 'dev' }}
   CARDANO_NETWORK: "sanchonet"
+  FORCE_REBUILD: ${{inputs.forceRebuildDockerImages == 'true'}}
 
 jobs:
   deploy:
@@ -27,22 +44,27 @@ jobs:
         working-directory: ./scripts/govtool
     env:
       DBSYNC_POSTGRES_DB: "cexplorer"
-      DBSYNC_POSTGRES_USER: "postgres"
       DBSYNC_POSTGRES_PASSWORD: "pSa8JCpQOACMUdGb"
+      DBSYNC_POSTGRES_USER: "postgres"
+      GA_CLIENT_EMAIL: ${{ secrets.GA_CLIENT_EMAIL }}
+      GA_PRIVATE_KEY: ${{ secrets.GA_PRIVATE_KEY }}
       GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
-      GRAFANA_SLACK_RECIPIENT: ${{ secrets.GRAFANA_SLACK_RECIPIENT }}
       GRAFANA_SLACK_OAUTH_TOKEN: ${{ secrets.GRAFANA_SLACK_OAUTH_TOKEN }}
-      DEV_NGINX_BASIC_AUTH: ${{ secrets.DEV_NGINX_BASIC_AUTH }}
-      TEST_NGINX_BASIC_AUTH: ${{ secrets.TEST_NGINX_BASIC_AUTH }}
-      STAGING_NGINX_BASIC_AUTH: ${{ secrets.STAGING_NGINX_BASIC_AUTH }}
-      SENTRY_DSN_BACKEND: ${{ secrets.SENTRY_DSN_BACKEND }}
-      TRAEFIK_LE_EMAIL: "admin+govtool@binarapps.com"
+      GRAFANA_SLACK_RECIPIENT: ${{ secrets.GRAFANA_SLACK_RECIPIENT }}
       GTM_ID: ${{ secrets.GTM_ID }}
       NPMRC_TOKEN: ${{ secrets.NPMRC_TOKEN }}
-      SENTRY_DSN: ${{ secrets.SENTRY_DSN_FRONTEND }}
-      PIPELINE_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
       IP_ADDRESS_BYPASSING_BASIC_AUTH1: ${{ secrets.IP_ADDRESS_BYPASSING_BASIC_AUTH1 }}
       IP_ADDRESS_BYPASSING_BASIC_AUTH2: ${{ secrets.IP_ADDRESS_BYPASSING_BASIC_AUTH2 }}
+      NEXT_PUBLIC_API_URL: "https://participation.sanchogov.tools"
+      NEXT_PUBLIC_GA4_PROPERTY_ID: ${{ secrets.NEXT_PUBLIC_GA4_PROPERTY_ID }}
+      DEV_NGINX_BASIC_AUTH: ${{ secrets.DEV_NGINX_BASIC_AUTH }}
+      PIPELINE_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN_FRONTEND }}
+      SENTRY_DSN_BACKEND: ${{ secrets.SENTRY_DSN_BACKEND }}
+      SENTRY_IGNORE_API_RESOLUTION_ERROR: "1"
+      TRAEFIK_LE_EMAIL: "admin+govtool@binarapps.com"
+      USERSNAP_SPACE_API_KEY: ${{ secrets.USERSNAP_SPACE_API_KEY }}
+      IS_PROPOSAL_DISCUSSION_FORUM_ENABLED: ${{ inputs.isProposalDiscussionForumEnabled == 'enabled' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/scripts/govtool/Makefile
+++ b/scripts/govtool/Makefile
@@ -10,8 +10,8 @@ include config.mk
 .DEFAULT_GOAL := info
 
 # image tags
-cardano_node_image_tag := 8.11.0-sancho
-cardano_db_sync_image_tag := sancho-4-3-0-docker
+cardano_node_image_tag := 9.0.0-sancho
+cardano_db_sync_image_tag := sancho-5.1.0
 
 .PHONY: all
 all: deploy-stack notify

--- a/scripts/govtool/docker-compose.node+dbsync.yml
+++ b/scripts/govtool/docker-compose.node+dbsync.yml
@@ -51,7 +51,7 @@ services:
       retries: 5
 
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:8.11.0-sancho
+    image: ghcr.io/intersectmbo/cardano-node:9.0.0-sancho
     environment:
       - NETWORK=sanchonet
     volumes:
@@ -65,7 +65,7 @@ services:
       retries: 10
 
   cardano-db-sync:
-    image: ghcr.io/intersectmbo/cardano-db-sync:sancho-4-3-0-docker
+    image: ghcr.io/intersectmbo/cardano-db-sync:sancho-5.1.0
     environment:
       - NETWORK=sanchonet
       - POSTGRES_HOST=postgres


### PR DESCRIPTION
The purpose of these changes is to update the versions of the Cardano Node and Cardano DB Sync used in our GovTool application to ensure compatibility with version 9.0.0 of the node and version sancho-5.1.0 of DB Sync. This aligns our development and staging environments with the latest network protocols and includes recent fixes and features. By doing this, we aim to maintain synchronization with the updated Cardano protocol, which is crucial for supporting upcoming governance functionalities on the Preview network.

The outcome of these changes is reflected in two main updates: - The `scripts/govtool/Makefile` was modified to upgrade Cardano Node to version 9.0.0-sancho and Cardano DB Sync to sancho-5.1.0. This ensures our application is compatible with the latest network protocols. - The `docker-compose.node+dbsync.yml` file in the development environment was updated to use `cardano-node:9.0.0-sancho` and `cardano-db-sync:sancho-5.1.0`. This keeps our development environment aligned with the latest features and fixes, necessary for validating stability before deployment to staging and beta environments.

These updates help confirm stability through testing in SanchoNet and PreProd environments, ensure successful deployment in the beta environment, and maintain the application's synchronicity with the latest Cardano protocol.
