### PR TITLE
[#1417] [Sentry] Exception before request could be parsed: Thread killed by timeout manager

### DIFF
--- a/govtool/backend/app/Main.hs
+++ b/govtool/backend/app/Main.hs
@@ -9,9 +9,7 @@
 module Main where
 
 import           Control.Concurrent.QSem                (newQSem)
-import           Control.Exception                      (Exception,
-                                                         SomeException,
-                                                         fromException, throw)
+import           Control.Exception                      (Exception, SomeException, fromException, throw)
 import           Control.Lens.Operators                 ((.~))
 import           Control.Monad
 import           Control.Monad.IO.Class
@@ -25,12 +23,8 @@ import qualified Data.Cache                             as Cache
 import           Data.Function                          ((&))
 import           Data.Has                               (getter)
 import           Data.Monoid                            (mempty)
-import           Data.OpenApi                           (OpenApi,
-                                                         Server (Server),
-                                                         _openApiServers,
-                                                         _serverDescription,
-                                                         _serverUrl,
-                                                         _serverVariables,
+import           Data.OpenApi                           (OpenApi, Server (Server), _openApiServers,
+                                                         _serverDescription, _serverUrl, _serverVariables,
                                                          servers)
 import           Data.Pool                              (createPool)
 import           Data.Proxy
@@ -42,9 +36,10 @@ import qualified Data.Text.IO                           as Text
 import qualified Data.Text.Lazy                         as LazyText
 import qualified Data.Text.Lazy.Encoding                as LazyText
 
-import           Database.PostgreSQL.Simple             (close,
-                                                         connectPostgreSQL)
+import           Database.PostgreSQL.Simple             (close, connectPostgreSQL)
 
+import           Network.HTTP.Client                    hiding (Proxy, Request)
+import           Network.HTTP.Client.TLS
 import           Network.Wai
 import           Network.Wai.Handler.Warp
 import           Network.Wai.Middleware.Cors
@@ -55,16 +50,13 @@ import           Servant
 import           Servant.API.ContentTypes
 import           Servant.OpenApi                        (toOpenApi)
 import qualified Servant.Server                         as Servant
-import           Servant.Swagger.UI                     (SwaggerSchemaUI,
-                                                         swaggerSchemaUIServer)
+import           Servant.Swagger.UI                     (SwaggerSchemaUI, swaggerSchemaUIServer)
 
 import           System.Clock                           (TimeSpec (TimeSpec))
 import           System.IO                              (stderr)
-import           System.Log.Raven                       (initRaven, register,
-                                                         silentFallback)
+import           System.Log.Raven                       (initRaven, register, silentFallback)
 import           System.Log.Raven.Transport.HttpConduit (sendRecord)
-import           System.Log.Raven.Types                 (SentryLevel (Error),
-                                                         SentryRecord (..))
+import           System.Log.Raven.Types                 (SentryLevel (Error), SentryRecord (..))
 import           System.TimeManager                     (TimeoutThread (..))
 
 import           VVA.API
@@ -72,10 +64,8 @@ import           VVA.API.Types
 import           VVA.CommandLine
 import           VVA.Config
 import           VVA.Types                              (AppEnv (..),
-                                                         AppError (CriticalError, NotFoundError, ValidationError, InternalError),
+                                                         AppError (CriticalError, InternalError, NotFoundError, ValidationError),
                                                          CacheEnv (..))
-import Network.HTTP.Client hiding (Proxy, Request)
-import Network.HTTP.Client.TLS
 
 proxyAPI :: Proxy (VVAApi :<|> SwaggerAPI)
 proxyAPI = Proxy
@@ -146,10 +136,10 @@ exceptionHandler vvaConfig mRequest exception = do
   print exception
   let isNotTimeoutThread x = case fromException x of
         Just TimeoutThread -> False
-        _ -> True
+        _                  -> True
       isNotConnectionClosedByPeer x = case fromException x of
         Just ConnectionClosedByPeer -> False
-        _ -> True
+        _                           -> True
   guard . isNotTimeoutThread $ exception
   guard . isNotConnectionClosedByPeer $ exception
   let env = sentryEnv vvaConfig

--- a/govtool/backend/src/VVA/API.hs
+++ b/govtool/backend/src/VVA/API.hs
@@ -8,42 +8,42 @@
 
 module VVA.API where
 
-import Control.Concurrent.QSem (waitQSem, signalQSem)
-import Control.Concurrent.Async (mapConcurrently)
-import           Control.Exception    (throw, throwIO)
-import           Control.Monad.Except (throwError, runExceptT)
+import           Control.Concurrent.Async (mapConcurrently)
+import           Control.Concurrent.QSem  (signalQSem, waitQSem)
+import           Control.Exception        (throw, throwIO)
+import           Control.Monad.Except     (runExceptT, throwError)
 import           Control.Monad.Reader
-import           Data.Aeson           (Result(Error, Success), fromJSON)
-import           Data.Bool            (Bool)
-import           Data.List            (sortOn)
-import qualified Data.Map             as Map
-import           Data.Maybe           (Maybe (Nothing), fromMaybe, catMaybes)
-import           Data.Ord             (Down (..))
-import           Data.Text            hiding (drop, elem, filter, length, map,
-                                       null, take, any)
-import qualified Data.Text            as Text
 
-import           Numeric.Natural      (Natural)
+import           Data.Aeson               (Result (Error, Success), fromJSON)
+import           Data.Bool                (Bool)
+import           Data.List                (sortOn)
+import qualified Data.Map                 as Map
+import           Data.Maybe               (Maybe (Nothing), catMaybes, fromMaybe)
+import           Data.Ord                 (Down (..))
+import           Data.Text                hiding (any, drop, elem, filter, length, map, null, take)
+import qualified Data.Text                as Text
+
+import           Numeric.Natural          (Natural)
 
 import           Servant.API
 import           Servant.Server
 
-import           Text.Read            (readMaybe)
+import           Text.Read                (readMaybe)
 
-import qualified VVA.AdaHolder        as AdaHolder
+import qualified VVA.AdaHolder            as AdaHolder
 import           VVA.API.Types
-import           VVA.Cache            (cacheRequest)
+import           VVA.Cache                (cacheRequest)
 import           VVA.Config
-import qualified VVA.DRep             as DRep
-import qualified VVA.Epoch            as Epoch
-import           VVA.Network          as Network
-import qualified VVA.Proposal         as Proposal
-import qualified VVA.Transaction      as Transaction
-import qualified VVA.Types            as Types
-import           VVA.Types            (App, AppEnv (..),
-                                       AppError (CriticalError, ValidationError, InternalError),
-                                       CacheEnv (..))
-import qualified VVA.Metadata         as Metadata
+import qualified VVA.DRep                 as DRep
+import qualified VVA.Epoch                as Epoch
+import qualified VVA.Metadata             as Metadata
+import           VVA.Network              as Network
+import qualified VVA.Proposal             as Proposal
+import qualified VVA.Transaction          as Transaction
+import qualified VVA.Types                as Types
+import           VVA.Types                (App, AppEnv (..),
+                                           AppError (CriticalError, InternalError, ValidationError),
+                                           CacheEnv (..))
 
 type VVAApi =
          "drep" :> "list"
@@ -230,13 +230,13 @@ proposalToResponse Types.Proposal {..} Types.MetadataValidationResult{..} =
   }
   where
    getTitle p Nothing = p
-   getTitle _ m = Types.proposalMetadataTitle <$> m
+   getTitle _ m       = Types.proposalMetadataTitle <$> m
    getAbstract p Nothing = p
-   getAbstract _ m = Types.proposalMetadataAbstract <$> m
+   getAbstract _ m       = Types.proposalMetadataAbstract <$> m
    getMotivation p Nothing = p
-   getMotivation _ m = Types.proposalMetadataMotivation <$> m
+   getMotivation _ m       = Types.proposalMetadataMotivation <$> m
    getRationale p Nothing = p
-   getRationale _ m = Types.proposalMetadataRationale <$> m
+   getRationale _ m       = Types.proposalMetadataRationale <$> m
    -- TODO: convert aeson references to [Text] from database
    --getReferences p Nothing = p
    getReferences _ = maybe [] Types.proposalMetadataReferences

--- a/govtool/backend/src/VVA/API/Types.hs
+++ b/govtool/backend/src/VVA/API/Types.hs
@@ -46,8 +46,7 @@ import           Database.PostgreSQL.Simple (Connection)
 import           GHC.Exts                   (toList)
 import           GHC.Generics
 
-import           Servant.API                (FromHttpApiData, parseQueryParam,
-                                             parseUrlPiece)
+import           Servant.API                (FromHttpApiData, parseQueryParam, parseUrlPiece)
 
 import           Text.Read                  (readMaybe)
 
@@ -112,26 +111,24 @@ instance ToSchema AnyValue where
         & example
           ?~ toJSON exampleAnyValue
 
-data MetadataValidationStatus
-  = IncorrectFormat
-  | IncorrectJSONLD
-  | IncorrectHash
-  | UrlNotFound
-  deriving (Show, Eq)
+data MetadataValidationStatus = IncorrectFormat | IncorrectJSONLD | IncorrectHash | UrlNotFound deriving
+    ( Eq
+    , Show
+    )
 
 instance ToJSON MetadataValidationStatus where
   toJSON IncorrectFormat = "INCORRECT_FORMTAT"
   toJSON IncorrectJSONLD = "INVALID_JSONLD"
-  toJSON IncorrectHash = "INVALID_HASH"
-  toJSON UrlNotFound = "URL_NOT_FOUND"
+  toJSON IncorrectHash   = "INVALID_HASH"
+  toJSON UrlNotFound     = "URL_NOT_FOUND"
 
 instance FromJSON MetadataValidationStatus where
   parseJSON (String s) = case s of
     "INCORRECT_FORMTAT" -> pure IncorrectFormat
-    "INVALID_JSONLD" -> pure IncorrectJSONLD
-    "INVALID_HASH" -> pure IncorrectHash
-    "URL_NOT_FOUND" -> pure UrlNotFound
-    _ -> fail "Invalid MetadataValidationStatus"
+    "INVALID_JSONLD"    -> pure IncorrectJSONLD
+    "INVALID_HASH"      -> pure IncorrectHash
+    "URL_NOT_FOUND"     -> pure UrlNotFound
+    _                   -> fail "Invalid MetadataValidationStatus"
   parseJSON _ = fail "Invalid MetadataValidationStatus"
 
 instance ToSchema MetadataValidationStatus where
@@ -168,7 +165,7 @@ instance ToSchema InternalMetadataValidationResponse where
 data MetadataValidationResponse
   = MetadataValidationResponse
       { metadataValidationResponseStatus :: Maybe Text
-      , metadataValidationResponseValid :: Bool
+      , metadataValidationResponseValid  :: Bool
       }
   deriving (Generic, Show)
 
@@ -189,7 +186,7 @@ instance ToSchema MetadataValidationResponse where
 
 data MetadataValidationParams
   = MetadataValidationParams
-      { metadataValidationParamsUrl :: Text
+      { metadataValidationParamsUrl  :: Text
       , metadataValidationParamsHash :: HexText
       }
   deriving (Generic, Show)
@@ -302,19 +299,11 @@ instance ToParamSchema GovernanceActionType where
       & enum_ ?~ map toJSON (enumFromTo minBound maxBound :: [GovernanceActionType])
 
 
-data DRepSortMode = VotingPower | RegistrationDate | Status
-   deriving
-    ( Bounded
-    , Enum
-    , Eq
-    , Generic
-    , Read
-    , Show
-    )
+data DRepSortMode = VotingPower | RegistrationDate | Status deriving (Bounded, Enum, Eq, Generic, Read, Show)
 
 instance FromJSON DRepSortMode where
   parseJSON (Aeson.String dRepSortMode) = pure $ fromJust $ readMaybe (Text.unpack dRepSortMode)
-  parseJSON _ = fail ""
+  parseJSON _                           = fail ""
 
 instance ToJSON DRepSortMode where
   toJSON x = Aeson.String $ Text.pack $ show x
@@ -769,7 +758,7 @@ instance ToSchema DRepHash where
           ?~ toJSON exampleDrepHash
 
 
-data DRepStatus = Active | Inactive | Retired deriving (Generic, Show, Eq, Ord, Enum, Bounded, Read)
+data DRepStatus = Active | Inactive | Retired deriving (Bounded, Enum, Eq, Generic, Ord, Read, Show)
 
 -- ToJSON instance for DRepStatus
 instance ToJSON DRepStatus where
@@ -925,9 +914,9 @@ instance ToSchema ListDRepsResponse where
 
 data DelegationResponse
   = DelegationResponse
-      { delegationResponseDRepHash       :: Maybe HexText
-      , delegationResponseDRepView       :: Text
-      , delegationResponseTxHash         :: HexText
+      { delegationResponseDRepHash :: Maybe HexText
+      , delegationResponseDRepView :: Text
+      , delegationResponseTxHash   :: HexText
       }
 deriveJSON (jsonOptions "delegationResponse") ''DelegationResponse
 

--- a/govtool/backend/src/VVA/API/Utils.hs
+++ b/govtool/backend/src/VVA/API/Utils.hs
@@ -1,9 +1,9 @@
 module VVA.API.Utils where
 
-import           Data.Aeson (Options (..), defaultOptions)
-import           Data.Char
+import Data.Aeson (Options (..), defaultOptions)
+import Data.Char
 
-import           Foreign    (pooledMalloc)
+import Foreign    (pooledMalloc)
 
 -- | Apply function to first element in the list.
 applyFirst :: (a -> a) -> [a] -> [a]

--- a/govtool/backend/src/VVA/AdaHolder.hs
+++ b/govtool/backend/src/VVA/AdaHolder.hs
@@ -42,9 +42,9 @@ getCurrentDelegation ::
 getCurrentDelegation stakeKey = withPool $ \conn -> do
   result <- liftIO $ SQL.query conn getCurrentDelegationSql (SQL.Only stakeKey)
   case result of
-    []                    -> return Nothing
+    []                              -> return Nothing
     [(mDRepHash, dRepView, txHash)] -> return $ Just $ Delegation mDRepHash dRepView txHash
-    _                     -> error ("multiple delegations for stake key: " <> unpack stakeKey)
+    _                               -> error ("multiple delegations for stake key: " <> unpack stakeKey)
 
 getVotingPowerSql :: SQL.Query
 getVotingPowerSql = sqlFrom $(embedFile "sql/get-stake-key-voting-power.sql")

--- a/govtool/backend/src/VVA/CommandLine.hs
+++ b/govtool/backend/src/VVA/CommandLine.hs
@@ -4,7 +4,7 @@ module VVA.CommandLine
     , cmdParser
     ) where
 
-import           Options.Applicative
+import Options.Applicative
 
 data Command = StartApp | ShowConfig deriving (Show)
 

--- a/govtool/backend/src/VVA/Config.hs
+++ b/govtool/backend/src/VVA/Config.hs
@@ -21,12 +21,12 @@ module VVA.Config
     , loadVVAConfig
       -- * Data type conversions
     , getDbSyncConnectionString
-    , getServerHost
-    , getServerPort
-    , vvaConfigToText
     , getMetadataValidationEnabled
     , getMetadataValidationHost
     , getMetadataValidationPort
+    , getServerHost
+    , getServerPort
+    , vvaConfigToText
     ) where
 
 import           Conferer
@@ -46,8 +46,7 @@ import           Data.Text.Encoding       (decodeUtf8, encodeUtf8)
 
 import           GHC.Generics
 
-import           VVA.CommandLine          (CommandLineConfig (..),
-                                           clcConfigPath)
+import           VVA.CommandLine          (CommandLineConfig (..), clcConfigPath)
 -- | PostgreSQL database access information.
 data DBConfig
   = DBConfig
@@ -72,23 +71,23 @@ instance DefaultConfig DBConfig where
 data VVAConfigInternal
   = VVAConfigInternal
       { -- | db-sync database access.
-        vVAConfigInternalDbsyncconfig           :: DBConfig
+        vVAConfigInternalDbsyncconfig                            :: DBConfig
         -- | Server port.
-      , vVAConfigInternalPort                   :: Int
+      , vVAConfigInternalPort                                    :: Int
         -- | Server host.
-      , vVAConfigInternalHost                   :: Text
+      , vVAConfigInternalHost                                    :: Text
         -- | Request cache duration
-      , vVaConfigInternalCacheDurationSeconds   :: Int
+      , vVaConfigInternalCacheDurationSeconds                    :: Int
         -- | Sentry DSN
-      , vVAConfigInternalSentrydsn              :: String
+      , vVAConfigInternalSentrydsn                               :: String
         -- | Sentry environment
-      , vVAConfigInternalSentryEnv              :: String
+      , vVAConfigInternalSentryEnv                               :: String
         -- | Metadata validation service enabled
-      , vVAConfigInternalMetadataValidationEnabled :: Bool
+      , vVAConfigInternalMetadataValidationEnabled               :: Bool
         -- | Metadata validation service host
-      , vVAConfigInternalMetadataValidationHost :: Text
+      , vVAConfigInternalMetadataValidationHost                  :: Text
         -- | Metadata validation service port
-      , vVAConfigInternalMetadataValidationPort :: Int
+      , vVAConfigInternalMetadataValidationPort                  :: Int
         -- | Maximum number of concurrent metadata requests
       , vVAConfigInternalMetadataValidationMaxConcurrentRequests :: Int
       }
@@ -113,23 +112,23 @@ instance DefaultConfig VVAConfigInternal where
 data VVAConfig
   = VVAConfig
       { -- | db-sync database credentials.
-        dbSyncConnectionString :: Text
+        dbSyncConnectionString                  :: Text
         -- | Server port.
-      , serverPort             :: Int
+      , serverPort                              :: Int
         -- | Server host.
-      , serverHost             :: Text
+      , serverHost                              :: Text
         -- | Request cache duration
-      , cacheDurationSeconds   :: Int
+      , cacheDurationSeconds                    :: Int
         -- | Sentry DSN
-      , sentryDSN              :: String
+      , sentryDSN                               :: String
         -- | Sentry environment
-      , sentryEnv              :: String
+      , sentryEnv                               :: String
         -- | Metadata validation service enabled
-      , metadataValidationEnabled :: Bool
+      , metadataValidationEnabled               :: Bool
         -- | Metadata validation service host
-      , metadataValidationHost :: Text
+      , metadataValidationHost                  :: Text
         -- | Metadata validation service port
-      , metadataValidationPort :: Int
+      , metadataValidationPort                  :: Int
         -- | Maximum number of concurrent metadata requests
       , metadataValidationMaxConcurrentRequests :: Int
       }

--- a/govtool/backend/src/VVA/DRep.hs
+++ b/govtool/backend/src/VVA/DRep.hs
@@ -71,7 +71,7 @@ listDReps = withPool $ \conn -> do
                                     | d >= 0 && not isActive -> Inactive
     , let latestDeposit' = floor @Scientific latestDeposit :: Integer
     , let drepType | latestDeposit' >= 0 && isNothing url = SoleVoter
-                   | latestDeposit' >= 0 && not (isNothing url) = DRep
+                   | latestDeposit' >= 0 && isJust url = DRep
                    | latestDeposit' < 0 && not latestNonDeregisterVotingAnchorWasNotNull = SoleVoter
                    | latestDeposit' < 0 && latestNonDeregisterVotingAnchorWasNotNull = DRep
                    | Data.Maybe.isJust url = DRep

--- a/govtool/backend/src/VVA/DRep.hs
+++ b/govtool/backend/src/VVA/DRep.hs
@@ -30,10 +30,8 @@ import qualified Database.PostgreSQL.Simple as SQL
 import           VVA.Config
 import           VVA.Pool                   (ConnectionPool, withPool)
 import qualified VVA.Proposal               as Proposal
-import           VVA.Types                  (AppError, DRepInfo (..),
-                                             DRepRegistration (..),
-                                             DRepStatus (..), DRepType (..),
-                                             Proposal (..), Vote (..))
+import           VVA.Types                  (AppError, DRepInfo (..), DRepRegistration (..), DRepStatus (..),
+                                             DRepType (..), Proposal (..), Vote (..))
 
 sqlFrom :: ByteString -> SQL.Query
 sqlFrom bs = fromString $ unpack $ Text.decodeUtf8 bs
@@ -51,7 +49,7 @@ getVotingPower drepId = withPool $ \conn -> do
       (SQL.query @_ @(SQL.Only Scientific) conn getVotingPowerSql $ SQL.Only drepId)
   case result of
     [SQL.Only votingPower] -> return $ floor votingPower
-    [] -> return 0
+    []                     -> return 0
 
 listDRepsSql :: SQL.Query
 listDRepsSql = sqlFrom $(embedFile "sql/list-dreps.sql")

--- a/govtool/backend/src/VVA/Pool.hs
+++ b/govtool/backend/src/VVA/Pool.hs
@@ -2,13 +2,13 @@
 
 module VVA.Pool where
 
-import           Control.Monad.IO.Class     (MonadIO, liftIO)
-import           Control.Monad.Reader       (MonadReader, asks)
+import Control.Monad.IO.Class     (MonadIO, liftIO)
+import Control.Monad.Reader       (MonadReader, asks)
 
-import           Data.Has                   (Has, getter)
-import           Data.Pool                  (Pool, putResource, takeResource)
+import Data.Has                   (Has, getter)
+import Data.Pool                  (Pool, putResource, takeResource)
 
-import           Database.PostgreSQL.Simple (Connection)
+import Database.PostgreSQL.Simple (Connection)
 
 type ConnectionPool = Pool Connection
 

--- a/govtool/backend/src/VVA/Transaction.hs
+++ b/govtool/backend/src/VVA/Transaction.hs
@@ -20,8 +20,7 @@ import qualified Database.PostgreSQL.Simple as SQL
 
 import           VVA.Config
 import           VVA.Pool                   (ConnectionPool, withPool)
-import           VVA.Types                  (AppError (..),
-                                             TransactionStatus (..))
+import           VVA.Types                  (AppError (..), TransactionStatus (..))
 
 sqlFrom :: ByteString -> SQL.Query
 sqlFrom bs = fromString $ unpack $ Text.decodeUtf8 bs

--- a/govtool/backend/src/VVA/Types.hs
+++ b/govtool/backend/src/VVA/Types.hs
@@ -6,6 +6,7 @@
 
 module VVA.Types where
 
+import           Control.Concurrent.QSem
 import           Control.Exception
 import           Control.Monad.Except       (MonadError)
 import           Control.Monad.Fail         (MonadFail)
@@ -21,10 +22,10 @@ import           Data.Time                  (UTCTime)
 
 import           Database.PostgreSQL.Simple (Connection)
 
+import           Network.HTTP.Client        (Manager)
+
 import           VVA.Cache
 import           VVA.Config
-import           Network.HTTP.Client (Manager)
-import           Control.Concurrent.QSem
 
 type App m = (MonadReader AppEnv m, MonadIO m, MonadFail m, MonadError AppError m)
 
@@ -141,47 +142,50 @@ data Proposal
 data TransactionStatus = TransactionConfirmed | TransactionUnconfirmed
 
 
-data ProposalMetadata =
-    ProposalMetadata
-    { proposalMetadataAbstract :: Text
-    , proposalMetadataMotivation :: Text
-    , proposalMetadataRationale :: Text
-    , proposalMetadataTitle :: Text
-    , proposalMetadataReferences :: [Text]
-    } deriving (Show)
+data ProposalMetadata
+  = ProposalMetadata
+      { proposalMetadataAbstract   :: Text
+      , proposalMetadataMotivation :: Text
+      , proposalMetadataRationale  :: Text
+      , proposalMetadataTitle      :: Text
+      , proposalMetadataReferences :: [Text]
+      }
+  deriving (Show)
 
-data DRepMetadata =
-    DRepMetadata
-    { dRepMetadataBio :: Text
-    , dRepMetadataDRepName :: Text
-    , dRepMetadataEmail :: Text
-    , dRepMetadataReferences :: [Text]
-    } deriving (Show)
+data DRepMetadata
+  = DRepMetadata
+      { dRepMetadataBio        :: Text
+      , dRepMetadataDRepName   :: Text
+      , dRepMetadataEmail      :: Text
+      , dRepMetadataReferences :: [Text]
+      }
+  deriving (Show)
 
-data MetadataValidationResult a =
-    MetadataValidationResult
-    { metadataValidationResultValid :: Bool
-    , metadataValidationResultStatus :: Maybe Text
-    , metadataValidationResultMetadata :: Maybe a
-    } deriving (Show)
+data MetadataValidationResult a
+  = MetadataValidationResult
+      { metadataValidationResultValid    :: Bool
+      , metadataValidationResultStatus   :: Maybe Text
+      , metadataValidationResultMetadata :: Maybe a
+      }
+  deriving (Show)
 
 
 
 
 data CacheEnv
   = CacheEnv
-      { proposalListCache                  :: Cache.Cache () [Proposal]
-      , getProposalCache                   :: Cache.Cache (Text, Integer) Proposal
-      , currentEpochCache                  :: Cache.Cache () (Maybe Value)
-      , adaHolderVotingPowerCache          :: Cache.Cache Text Integer
+      { proposalListCache :: Cache.Cache () [Proposal]
+      , getProposalCache :: Cache.Cache (Text, Integer) Proposal
+      , currentEpochCache :: Cache.Cache () (Maybe Value)
+      , adaHolderVotingPowerCache :: Cache.Cache Text Integer
       , adaHolderGetCurrentDelegationCache :: Cache.Cache Text (Maybe Delegation)
-      , dRepGetVotesCache                  :: Cache.Cache Text ([Vote], [Proposal])
-      , dRepInfoCache                      :: Cache.Cache Text DRepInfo
-      , dRepVotingPowerCache               :: Cache.Cache Text Integer
-      , dRepListCache                      :: Cache.Cache () [DRepRegistration]
-      , networkMetricsCache                :: Cache.Cache () NetworkMetrics
-      , proposalMetadataValidationCache            :: Cache.Cache (Text, Text) (MetadataValidationResult ProposalMetadata)
-      , dRepMetadataValidationCache                :: Cache.Cache (Text, Text) (MetadataValidationResult DRepMetadata)
+      , dRepGetVotesCache :: Cache.Cache Text ([Vote], [Proposal])
+      , dRepInfoCache :: Cache.Cache Text DRepInfo
+      , dRepVotingPowerCache :: Cache.Cache Text Integer
+      , dRepListCache :: Cache.Cache () [DRepRegistration]
+      , networkMetricsCache :: Cache.Cache () NetworkMetrics
+      , proposalMetadataValidationCache :: Cache.Cache (Text, Text) (MetadataValidationResult ProposalMetadata)
+      , dRepMetadataValidationCache :: Cache.Cache (Text, Text) (MetadataValidationResult DRepMetadata)
       }
 
 data NetworkMetrics
@@ -206,10 +210,6 @@ data Delegation
       }
 
 
-data MetadataValidationStatus
-  = IncorrectFormat
-  | IncorrectJSONLD
-  | IncorrectHash
-  | UrlNotFound
+data MetadataValidationStatus = IncorrectFormat | IncorrectJSONLD | IncorrectHash | UrlNotFound
 
 

--- a/govtool/backend/vva-be.cabal
+++ b/govtool/backend/vva-be.cabal
@@ -67,6 +67,7 @@ executable vva-be
                     , http-client
                     , http-client-tls
                     , raven-haskell >= 0.1.4.1
+                    , time-manager
 
     hs-source-dirs:   app
     default-language: Haskell2010


### PR DESCRIPTION
The purpose of these changes is to address the issue reported by Sentry, where threads on the Haskell backend are being killed by the timeout manager, resulting in unnecessary error reports. The objective is to improve the exception handling logic so that specific exceptions, such as `TimeoutThread` and `ConnectionClosedByPeer`, are recognized and skipped. This aims to prevent these known exceptions from cluttering error reports, thus ensuring that only actionable errors are brought to attention. The user story highlights the need to investigate and fix these timeouts, and the change is a step toward that goal. The outcome of these changes is a more refined error-handling mechanism within the Haskell backend. By updating the dependencies in the `vva-be.cabal` file to include the `time-manager` package, the backend now has the necessary tools to handle the newly identified exception types. Consequently, the system's actual behavior should now more closely align with the expected behavior, as it will filter out unnecessary exceptions that do not require investigation, leading to more meaningful and actionable error reports in Sentry.
