### PR TITLE
[#1117] redirect to private drep directory url 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ changes.
 
 ### Added
 
+- Add redirect to the connected DRep Directory page if a connected user enters a non-connected DRep Directory url [Issue 1117](https://github.com/IntersectMBO/govtool/issues/1117)
 - Add PDF_API_URL to the frontend config [Issue 1575](https://github.com/IntersectMBO/govtool/issues/1575)
 
 ### Fixed

--- a/govtool/frontend/src/App.tsx
+++ b/govtool/frontend/src/App.tsx
@@ -37,6 +37,7 @@ import {
   WALLET_LS_KEY,
   removeItemFromLocalStorage,
 } from "@utils";
+import { PublicRoute } from "./pages/PublicRoute";
 
 export default () => {
   const { isProposalDiscussionForumEnabled } = useFeatureFlag();
@@ -131,7 +132,13 @@ export default () => {
             />
           </Route>
         </Route>
-        <Route element={<DRepDirectory />}>
+        <Route
+          element={
+            <PublicRoute>
+              <DRepDirectory />
+            </PublicRoute>
+          }
+        >
           <Route
             path={PATHS.dRepDirectory}
             element={<DRepDirectoryContent />}

--- a/govtool/frontend/src/pages/CreateGovernanceAction.tsx
+++ b/govtool/frontend/src/pages/CreateGovernanceAction.tsx
@@ -37,7 +37,7 @@ export const CreateGovernanceAction = () => {
   });
 
   useEffect(() => {
-    if (checkIsWalletConnected()) {
+    if (!checkIsWalletConnected()) {
       navigate(PATHS.home);
     }
   }, []);

--- a/govtool/frontend/src/pages/DRepDirectory.tsx
+++ b/govtool/frontend/src/pages/DRepDirectory.tsx
@@ -10,9 +10,7 @@ import { checkIsWalletConnected } from "@utils";
 export const DRepDirectory = () => {
   const { t } = useTranslation();
 
-  const isConnected = !checkIsWalletConnected();
-
-  if (isConnected) {
+  if (checkIsWalletConnected()) {
     return (
       <PagePaddingBox
         sx={{ display: "flex", flex: 1, flexDirection: "column", py: 2 }}

--- a/govtool/frontend/src/pages/Dashboard.tsx
+++ b/govtool/frontend/src/pages/Dashboard.tsx
@@ -33,7 +33,7 @@ export const Dashboard = () => {
   }, [pathname, divRef]);
 
   useEffect(() => {
-    if (checkIsWalletConnected()) {
+    if (!checkIsWalletConnected()) {
       if (window.location.pathname === PATHS.dashboard) {
         navigate(PATHS.home);
       } else {

--- a/govtool/frontend/src/pages/EditDRepMetadata.tsx
+++ b/govtool/frontend/src/pages/EditDRepMetadata.tsx
@@ -56,7 +56,7 @@ export const EditDRepMetadata = () => {
     });
 
   useEffect(() => {
-    if (checkIsWalletConnected()) {
+    if (!checkIsWalletConnected()) {
       navigate(PATHS.home);
       return;
     }

--- a/govtool/frontend/src/pages/PublicRoute.tsx
+++ b/govtool/frontend/src/pages/PublicRoute.tsx
@@ -1,0 +1,17 @@
+import { FC, ReactNode } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import { checkIsWalletConnected } from "../utils";
+
+export const PublicRoute: FC<{ children: ReactNode }> = ({ children }) => {
+  // checkIsWalletConnected returns true if wallet is NOT connected
+  const isConnected = !checkIsWalletConnected();
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  if (isConnected && !pathname.startsWith("/connected")) {
+    navigate(`/connected${pathname}`);
+  }
+
+  return children;
+};

--- a/govtool/frontend/src/pages/PublicRoute.tsx
+++ b/govtool/frontend/src/pages/PublicRoute.tsx
@@ -4,12 +4,10 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { checkIsWalletConnected } from "../utils";
 
 export const PublicRoute: FC<{ children: ReactNode }> = ({ children }) => {
-  // checkIsWalletConnected returns true if wallet is NOT connected
-  const isConnected = !checkIsWalletConnected();
   const navigate = useNavigate();
   const { pathname } = useLocation();
 
-  if (isConnected && !pathname.startsWith("/connected")) {
+  if (checkIsWalletConnected() && !pathname.startsWith("/connected")) {
     navigate(`/connected${pathname}`);
   }
 

--- a/govtool/frontend/src/pages/RegisterAsDirectVoter.tsx
+++ b/govtool/frontend/src/pages/RegisterAsDirectVoter.tsx
@@ -94,7 +94,7 @@ export const RegisterAsDirectVoter = () => {
   );
 
   useEffect(() => {
-    if (checkIsWalletConnected()) {
+    if (!checkIsWalletConnected()) {
       navigate(PATHS.home);
     }
   }, []);

--- a/govtool/frontend/src/pages/RegisterAsdRep.tsx
+++ b/govtool/frontend/src/pages/RegisterAsdRep.tsx
@@ -55,7 +55,7 @@ export const RegisterAsdRep = () => {
     });
 
   useEffect(() => {
-    if (checkIsWalletConnected()) {
+    if (!checkIsWalletConnected()) {
       navigate(PATHS.home);
     }
   }, []);

--- a/govtool/frontend/src/pages/RetireAsDirectVoter.tsx
+++ b/govtool/frontend/src/pages/RetireAsDirectVoter.tsx
@@ -81,7 +81,7 @@ export const RetireAsDirectVoter = () => {
   );
 
   useEffect(() => {
-    if (checkIsWalletConnected()) {
+    if (!checkIsWalletConnected()) {
       navigate(PATHS.home);
     }
   }, []);

--- a/govtool/frontend/src/pages/RetireAsDrep.tsx
+++ b/govtool/frontend/src/pages/RetireAsDrep.tsx
@@ -15,7 +15,7 @@ export const RetireAsDrep = () => {
   const { isMobile } = useScreenDimension();
 
   useEffect(() => {
-    if (checkIsWalletConnected()) {
+    if (!checkIsWalletConnected()) {
       navigate(PATHS.home);
     }
   }, []);

--- a/govtool/frontend/src/utils/checkIsWalletConnected.ts
+++ b/govtool/frontend/src/utils/checkIsWalletConnected.ts
@@ -1,5 +1,6 @@
 import { WALLET_LS_KEY, getItemFromLocalStorage } from "@/utils/localStorage";
 
-export const checkIsWalletConnected = () =>
-  !getItemFromLocalStorage(`${WALLET_LS_KEY}_stake_key`) ||
-  !getItemFromLocalStorage(`${WALLET_LS_KEY}_name`);
+export const checkIsWalletConnected = () => !!(
+  getItemFromLocalStorage(`${WALLET_LS_KEY}_stake_key`) &&
+  getItemFromLocalStorage(`${WALLET_LS_KEY}_name`)
+);

--- a/govtool/frontend/src/utils/tests/checkIsWalletConnected.test.ts
+++ b/govtool/frontend/src/utils/tests/checkIsWalletConnected.test.ts
@@ -6,20 +6,20 @@ import {
 } from "@/utils/localStorage";
 
 describe("checkIsWalletConnected function", () => {
-  it("returns false when wallet information is present in local storage", () => {
+  it("returns true when wallet information is present in local storage", () => {
     setItemToLocalStorage(`${WALLET_LS_KEY}_name`, "Nami");
     setItemToLocalStorage(`${WALLET_LS_KEY}_stake_key`, "teststakekey");
     const isConnected = checkIsWalletConnected();
 
-    expect(isConnected).toBe(false);
+    expect(isConnected).toBe(true);
   });
 
-  it("returns true when wallet information is missing in local storage", () => {
+  it("returns false when wallet information is missing in local storage", () => {
     removeItemFromLocalStorage(`${WALLET_LS_KEY}_name`);
     removeItemFromLocalStorage(`${WALLET_LS_KEY}_stake_key`);
 
     const isConnected = checkIsWalletConnected();
 
-    expect(isConnected).toBe(true);
+    expect(isConnected).toBe(false);
   });
 });


### PR DESCRIPTION
## List of changes

- Add redirect to the connected DRep Directory page if a connected user enters a non-connected DRep Directory url

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1117)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
