### PR TITLE
[#1442] Add redirect to dashboard cards after connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ changes.
 - Add redirect to the connected DRep Directory page if a connected user enters a non-connected DRep Directory url [Issue 1117](https://github.com/IntersectMBO/govtool/issues/1117)
 - Add PDF_API_URL to the frontend config [Issue 1575](https://github.com/IntersectMBO/govtool/issues/1575)
 - Provide DB-Sync Postgres envs to the backend config
+- Add redirects to cards on Home after user connects  [Issue 1442](https://github.com/IntersectMBO/govtool/issues/1442)
 
 ### Fixed
 

--- a/govtool/frontend/src/components/organisms/HomeCards.tsx
+++ b/govtool/frontend/src/components/organisms/HomeCards.tsx
@@ -15,9 +15,17 @@ export const HomeCards = () => {
   const { screenWidth } = useScreenDimension();
   const { t } = useTranslation();
 
-  const openWalletModal = useCallback(() => {
-    openModal({ type: "chooseWallet" });
-  }, [openModal]);
+  const openWalletModal = useCallback(
+    (pathToNavigate: string) => {
+      openModal({
+        type: "chooseWallet",
+        state: {
+          pathToNavigate,
+        },
+      });
+    },
+    [openModal],
+  );
 
   const onClickLearnMoreAboutDelegation = () =>
     openInNewTab(
@@ -97,7 +105,7 @@ export const HomeCards = () => {
         dataTestIdFirstButton="register-connect-wallet-button"
         dataTestIdSecondButton="register-learn-more-button"
         description={t("home.cards.registerAsDRep.description")}
-        firstButtonAction={openWalletModal}
+        firstButtonAction={() => openWalletModal(PATHS.registerAsdRep)}
         firstButtonLabel={t("home.cards.registerAsDRep.firstButtonLabel")}
         imageHeight={80}
         imageURL={IMAGES.govActionRegisterImage}
@@ -107,12 +115,12 @@ export const HomeCards = () => {
         title={t("home.cards.registerAsDRep.title")}
       />
       {/* REGISTER AS DREP CARD END */}
-      {/* REGISTER AS SOLE VOTER CARD */}
+      {/* REGISTER AS DIRECT VOTER CARD */}
       <ActionCard
         dataTestIdFirstButton="register-as-sole-voter-button"
         dataTestIdSecondButton="lear-more-about-sole-voter-button"
         description={t("home.cards.registerAsDirectVoter.description")}
-        firstButtonAction={openWalletModal}
+        firstButtonAction={() => openWalletModal(PATHS.registerAsDirectVoter)}
         firstButtonLabel={t(
           "home.cards.registerAsDirectVoter.firstButtonLabel",
         )}
@@ -123,7 +131,7 @@ export const HomeCards = () => {
         secondButtonLabel={t("learnMore")}
         title={t("home.cards.registerAsDirectVoter.title")}
       />
-      {/* REGISTER AS SOLE VOTER CARD END */}
+      {/* REGISTER AS DIRECT VOTER CARD END */}
       {/* GOV ACTIONS CARD */}
       <ActionCard
         dataTestIdFirstButton="move-to-governance-actions-button"
@@ -140,7 +148,7 @@ export const HomeCards = () => {
       <ActionCard
         dataTestIdFirstButton="propose-a-governance-action-button"
         description={t("home.cards.proposeAGovernanceAction.description")}
-        firstButtonAction={openWalletModal}
+        firstButtonAction={() => openWalletModal(PATHS.createGovernanceAction)}
         firstButtonLabel={t(
           "home.cards.proposeAGovernanceAction.firstButtonLabel",
         )}


### PR DESCRIPTION
## List of changes

- Add redirect to dashboard cards after user successfully connects

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1442)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
