### PR TITLE
fix(#1624): fix unbound variable in resync cardano node workflow

### DIFF
--- a/.github/workflows/resync-cardano-node-and-db-sync.yml
+++ b/.github/workflows/resync-cardano-node-and-db-sync.yml
@@ -43,9 +43,11 @@ jobs:
       run:
         working-directory: ./scripts/govtool
     env:
-      DBSYNC_POSTGRES_DB: "cexplorer"
-      DBSYNC_POSTGRES_PASSWORD: "pSa8JCpQOACMUdGb"
-      DBSYNC_POSTGRES_USER: "postgres"
+      DBSYNC_POSTGRES_DB: ${{ secrets.DBSYNC_POSTGRES_DB || 'cexplorer' }}
+      DBSYNC_POSTGRES_PASSWORD: ${{ secrets.DBSYNC_POSTGRES_PASSWORD || 'pSa8JCpQOACMUdGb' }}
+      DBSYNC_POSTGRES_USER: ${{ secrets.DBSYNC_POSTGRES_USER || 'postgres' }}
+      DBSYNC_POSTGRES_HOST: ${{ secrets.DBSYNC_POSTGRES_HOST || 'postgres' }}
+      DBSYNC_POSTGRES_PORT: ${{ secrets.DBSYNC_POSTGRES_PORT || '5432' }}
       GA_CLIENT_EMAIL: ${{ secrets.GA_CLIENT_EMAIL }}
       GA_PRIVATE_KEY: ${{ secrets.GA_PRIVATE_KEY }}
       GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ changes.
 
 ### Fixed
 
--
+- Fix unbound variable in the resync cardano node github workflow [Issue 1624](https://github.com/IntersectMBO/govtool/issues/1624)
 
 ### Changed
 


### PR DESCRIPTION
## List of changes

- Fix the following error:
```
sed -e "s|<DBSYNC_POSTGRES_DB>|${DBSYNC_POSTGRES_DB}|" \
	-e "s|<DBSYNC_POSTGRES_USER>|${DBSYNC_POSTGRES_USER}|" \
	-e "s|<DBSYNC_POSTGRES_PASSWORD>|${DBSYNC_POSTGRES_PASSWORD}|" \
	-e "s|<DBSYNC_POSTGRES_HOST>|${DBSYNC_POSTGRES_HOST}|" \
	-e "s|<DBSYNC_POSTGRES_PORT>|${DBSYNC_POSTGRES_PORT}|" \
	-e "s|<SENTRY_DSN>|${SENTRY_DSN_BACKEND}|" \
	-e "s|<SENTRY_ENV>|test|" \
	/home/runner/work/govtool/govtool/scripts/govtool/config/templates/backend-config.json.tpl > /home/runner/work/govtool/govtool/scripts/govtool/config/target/backend-config.json
bash: line 1: DBSYNC_POSTGRES_HOST: unbound variable
make: *** [config.mk:85: /home/runner/work/govtool/govtool/scripts/govtool/config/target/backend-config.json] Error 1
```
## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1624)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
