### PR TITLE
fix(#1131): change link to view governance action docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ changes.
 
 - Change link to propose a governace action docs [Issue 1132](https://github.com/IntersectMBO/govtool/issues/1132)
 - Change link to docs regarding DReps [Issue 1130](https://github.com/IntersectMBO/govtool/issues/1130)
+- Change link to view governance actions docs [Issue 1131](https://github.com/IntersectMBO/govtool/issues/1131)
 
 ## [sancho-v1.0.11](https://github.com/IntersectMBO/govtool/releases/tag/sancho-v1.0.11) 2024-07-30
 

--- a/govtool/frontend/src/components/organisms/DashboardCards/ListGovActionsDashboardCard.tsx
+++ b/govtool/frontend/src/components/organisms/DashboardCards/ListGovActionsDashboardCard.tsx
@@ -23,7 +23,7 @@ export const ListGovActionsDashboardCards = () => {
           dataTestId: "learn-more-governance-actions-button",
           onClick: () =>
             openInNewTab(
-              "https://docs.sanchogov.tools/how-to-use-the-govtool/using-govtool/governance-actions-view-and-vote",
+              "https://docs.sanchogov.tools/how-to-use-the-govtool/using-govtool/governance-actions",
             ),
           variant: "outlined",
         },


### PR DESCRIPTION
## List of changes

- change link to view governance action docs

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1131)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
