### PR TITLE
feat(#1644): provide network name to network metrics endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ changes.
 
 ### Added
 
--
+- Add network name to GET /network/metrics [Issue 1644](https://github.com/IntersectMBO/govtool/issues/1644)
 
 ### Fixed
 

--- a/govtool/backend/sql/get-network-metrics.sql
+++ b/govtool/backend/sql/get-network-metrics.sql
@@ -71,7 +71,8 @@ SELECT
     total_drep_votes.count,
     total_registered_dreps.count,
     always_abstain_voting_power.amount,
-    always_no_confidence_voting_power.amount
+    always_no_confidence_voting_power.amount,
+    network_name
 FROM
     current_epoch
     CROSS JOIN current_block
@@ -82,3 +83,4 @@ FROM
     CROSS JOIN total_registered_dreps
     CROSS JOIN always_abstain_voting_power
     CROSS JOIN always_no_confidence_voting_power
+    CROSS JOIN meta;

--- a/govtool/backend/src/VVA/API.hs
+++ b/govtool/backend/src/VVA/API.hs
@@ -445,6 +445,7 @@ getNetworkMetrics = do
     , getNetworkMetricsResponseTotalRegisteredDReps = networkMetricsTotalRegisteredDReps
     , getNetworkMetricsResponseAlwaysAbstainVotingPower = networkMetricsAlwaysAbstainVotingPower
     , getNetworkMetricsResponseAlwaysNoConfidenceVotingPower = networkMetricsAlwaysNoConfidenceVotingPower
+    , getNetworkMetricsResponseNetworkName = networkMetricsNetworkName
     }
 
 validateProposalMetadata :: App m => MetadataValidationParams -> m (Types.MetadataValidationResult Types.ProposalMetadata)

--- a/govtool/backend/src/VVA/API/Types.hs
+++ b/govtool/backend/src/VVA/API/Types.hs
@@ -944,6 +944,7 @@ data GetNetworkMetricsResponse
       , getNetworkMetricsResponseTotalRegisteredDReps          :: Integer
       , getNetworkMetricsResponseAlwaysAbstainVotingPower      :: Integer
       , getNetworkMetricsResponseAlwaysNoConfidenceVotingPower :: Integer
+      , getNetworkMetricsResponseNetworkName                   :: Text
       }
 
 deriveJSON (jsonOptions "getNetworkMetricsResponse") ''GetNetworkMetricsResponse
@@ -959,7 +960,8 @@ exampleGetNetworkMetricsResponse =
  <> "\"totalDRepVotes\": 0,"
  <> "\"totalRegisteredDReps\": 0,"
  <> "\"alwaysAbstainVotingPower\": 0,"
- <> "\"alwaysNoConfidenceVotingPower\": 0}"
+ <> "\"alwaysNoConfidenceVotingPower\": 0,"
+ <> "\"networkName\": \"Mainnet\"}"
 
 instance ToSchema GetNetworkMetricsResponse where
     declareNamedSchema _ = pure $ NamedSchema (Just "GetNetworkMetricsResponse") $ mempty

--- a/govtool/backend/src/VVA/Network.hs
+++ b/govtool/backend/src/VVA/Network.hs
@@ -44,6 +44,7 @@ networkMetrics = withPool $ \conn -> do
      , total_registered_dreps
      , always_abstain_voting_power
      , always_no_confidence_voting_power
+     , network_name
      )] -> return $ NetworkMetrics
             current_time
             epoch_no
@@ -55,4 +56,5 @@ networkMetrics = withPool $ \conn -> do
             total_registered_dreps
             always_abstain_voting_power
             always_no_confidence_voting_power
+            network_name
     _ -> throwError $ CriticalError "Could not query the network metrics. This should never happen."

--- a/govtool/backend/src/VVA/Types.hs
+++ b/govtool/backend/src/VVA/Types.hs
@@ -198,6 +198,7 @@ data NetworkMetrics
       , networkMetricsTotalRegisteredDReps          :: Integer
       , networkMetricsAlwaysAbstainVotingPower      :: Integer
       , networkMetricsAlwaysNoConfidenceVotingPower :: Integer
+      , networkMetricsNetworkName                   :: Text
       }
 
 data Delegation


### PR DESCRIPTION
## List of changes

- provide network name to network metrics endpoint

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1644)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
