### PR TITLE
chore: make all the frontend build arguments mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ changes.
 - Change link to propose a governace action docs [Issue 1132](https://github.com/IntersectMBO/govtool/issues/1132)
 - Change link to docs regarding DReps [Issue 1130](https://github.com/IntersectMBO/govtool/issues/1130)
 - Change link to view governance actions docs [Issue 1131](https://github.com/IntersectMBO/govtool/issues/1131)
+- Make all the frontend build arguments mandatory [Issue 1642](https://github.com/IntersectMBO/govtool/issues/1642), [Issue 1643](https://github.com/IntersectMBO/govtool/issues/1643)
 
 ## [sancho-v1.0.11](https://github.com/IntersectMBO/govtool/releases/tag/sancho-v1.0.11) 2024-07-30
 

--- a/govtool/frontend/Dockerfile
+++ b/govtool/frontend/Dockerfile
@@ -10,7 +10,19 @@ ARG VITE_USERSNAP_SPACE_API_KEY
 ARG VITE_IS_PROPOSAL_DISCUSSION_FORUM_ENABLED='true'
 ARG VITE_PDF_API_URL
 
+# Ensure all required build arguments are set
+RUN \
+  : "${VITE_APP_ENV:?Build argument VITE_APP_ENV is not set}" && \
+  : "${VITE_BASE_URL:?Build argument VITE_BASE_URL is not set}" && \
+  : "${VITE_GTM_ID:?Build argument VITE_GTM_ID is not set}" && \
+  : "${VITE_NETWORK_FLAG:?Build argument VITE_NETWORK_FLAG is not set}" && \
+  : "${VITE_SENTRY_DSN:?Build argument VITE_SENTRY_DSN is not set}" && \
+  : "${NPMRC_TOKEN:?Build argument NPMRC_TOKEN is not set}" && \
+  : "${VITE_USERSNAP_SPACE_API_KEY:?Build argument VITE_USERSNAP_SPACE_API_KEY is not set}" && \
+  : "${VITE_IS_PROPOSAL_DISCUSSION_FORUM_ENABLED:?Build argument VITE_IS_PROPOSAL_DISCUSSION_FORUM_ENABLED is not set}"
+
 ENV NODE_OPTIONS=--max_old_space_size=8192
+
 WORKDIR /src
 
 # Set npm configuration settings using environment variables


### PR DESCRIPTION
## List of changes

- make all the frontend build arguments mandatory

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1642)
- [related issue](https://github.com/IntersectMBO/govtool/issues/1643)

 (Still the Envs have to be set on the infrastructure)
 
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
