### PR TITLE
[#1654] Use consistent link for Learn more button on delegate card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ changes.
 - Change link to propose a governace action docs [Issue 1132](https://github.com/IntersectMBO/govtool/issues/1132)
 - Change link to docs regarding DReps [Issue 1130](https://github.com/IntersectMBO/govtool/issues/1130)
 - Change link to view governance actions docs [Issue 1131](https://github.com/IntersectMBO/govtool/issues/1131)
+- Change link to delegate voting power docs, [Issue 1654](https://github.com/IntersectMBO/govtool/issues/1654)
 - Make all the frontend build arguments mandatory [Issue 1642](https://github.com/IntersectMBO/govtool/issues/1642), [Issue 1643](https://github.com/IntersectMBO/govtool/issues/1643)
 - Breaking! Remove usage of metadata validation service in Haskell Backend
 

--- a/govtool/frontend/src/components/organisms/HomeCards.tsx
+++ b/govtool/frontend/src/components/organisms/HomeCards.tsx
@@ -29,7 +29,7 @@ export const HomeCards = () => {
 
   const onClickLearnMoreAboutDelegation = () =>
     openInNewTab(
-      "https://docs.sanchogov.tools/faqs/ways-to-use-your-voting-power",
+      "https://docs.sanchogov.tools/how-to-use-the-govtool/using-govtool/delegating",
     );
 
   const onClickLearnMoreAboutDRepRegistration = () =>


### PR DESCRIPTION
## List of changes

- Change link to delegate voting power docs

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1654)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
