### PR TITLE
fix: frontend votes info copy and other minor spelling in copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ changes.
 
 ### Fixed
 
--
+- Incorrect copy on DRep votes + other minor copy spelling mistakes
 
 ### Changed
 

--- a/govtool/frontend/src/i18n/locales/en.ts
+++ b/govtool/frontend/src/i18n/locales/en.ts
@@ -310,11 +310,11 @@ export const en = {
       dRep: {
         description: {
           notVerifiable:
-            "GovTool uses external sources for DRep data, and these sources are maintianed by the DReps themselves. This error means that the data stored by the DRep does not match the data supplied by the DRep when they originally registered",
+            "GovTool uses external sources for DRep data, and these sources are maintained by the DReps themselves. This error means that the data stored by the DRep does not match the data supplied by the DRep when they originally registered",
           dataMissing:
-            "GovTool uses external sources for DRep data, and these sources are maintianed by the DReps themselves. This error means that GovTool cannot locate the data on the URL specified when the DRep was originally registered.",
+            "GovTool uses external sources for DRep data, and these sources are maintained by the DReps themselves. This error means that GovTool cannot locate the data on the URL specified when the DRep was originally registered.",
           incorrectFormat:
-            "GovTool uses external sources for DRep data, and these sources are maintianed by the DReps themselves. This error means that the data stored by the DRep does not match the format defined by the DRep spec.",
+            "GovTool uses external sources for DRep data, and these sources are maintained by the DReps themselves. This error means that the data stored by the DRep does not match the format defined by the DRep spec.",
         },
         message: {
           notVerifiable:
@@ -440,15 +440,15 @@ export const en = {
       voteSubmitted: "Vote submitted",
       voteTransaction: "Vote transaction",
       votes: "Votes:",
-      votesSubmitted: "Votes submitted",
+      votesSubmitted: "DRep votes submitted",
       votesSubmittedOnChain:
-        "Votes submitted on-chain by DReps, SPOs and Constitutional Committee members.",
+        "Votes submitted on-chain by DReps and predefined voting options.",
       youCanProvideContext:
         "You can provide context about your vote. This information will be viewable by other users.",
       youHaventVotedYet:
         "You haven't voted on any Governance Actions yet. Check the 'To vote on' section to vote on Governance Actions.",
       withCategoryNotExist: {
-        partOne: "Governnance actions with category",
+        partOne: "Governance actions with category",
         optional: "and search phrase",
         partTwo: "don't exist.",
       },


### PR DESCRIPTION
## List of changes

- Fixed incorrect copy around vote tallies
- Fixed other minor spelling mistakes in copy

## Checklist

- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
