### PR TITLE
Ensure Username Uniqueness by Appending Timestamp

### DIFF
--- a/tests/govtool-frontend/playwright/lib/_mock/index.ts
+++ b/tests/govtool-frontend/playwright/lib/_mock/index.ts
@@ -91,7 +91,8 @@ export const invalid = {
 
 export const valid = {
   username: () => {
-    let username = faker.internet.userName().toLowerCase();
+    let timeStamp = Date.now();
+    let username = `${faker.internet.userName().toLowerCase()}_${timeStamp}`;
 
     // Remove any invalid characters
     username = username.replace(/[^a-z0-9._]/g, "");

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.loggedin.spec.ts
@@ -139,9 +139,7 @@ test.describe("Temporary user", () => {
 
   test("6K. Should accept valid username.", async () => {
     for (let i = 0; i < 100; i++) {
-      await userPage
-        .getByTestId("username-input")
-        .fill(mockValid.username().toLowerCase());
+      await userPage.getByTestId("username-input").fill(mockValid.username());
 
       await expect(
         userPage.getByTestId("username-error-text")
@@ -152,9 +150,7 @@ test.describe("Temporary user", () => {
 
   test("6L. Should reject invalid username.", async () => {
     for (let i = 0; i < 100; i++) {
-      await userPage
-        .getByTestId("username-input")
-        .fill(mockInvalid.username().toLowerCase());
+      await userPage.getByTestId("username-input").fill(mockInvalid.username());
 
       await expect(userPage.getByTestId("username-error-text")).toBeVisible();
       await expect(userPage.getByTestId("proceed-button")).toBeDisabled();


### PR DESCRIPTION
## List of changes

- Append a timestamp to a valid username to ensure uniqueness.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
