### PR TITLE
change: to use new type of stake registration certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ changes.
 
 ### Changed
 
--
+- Changed stake key registration to use the newer Conway type of certificate 
 
 ## [sancho-v1.0.12](https://github.com/IntersectMBO/govtool/releases/tag/sancho-v1.0.12) 2024-08-01
 

--- a/govtool/frontend/src/context/wallet.tsx
+++ b/govtool/frontend/src/context/wallet.tsx
@@ -617,7 +617,7 @@ const CardanoProvider = (props: Props) => {
           stakeCred = Credential.from_keyhash(stakeKeyHash);
         } else {
           stakeCred = Credential.from_keyhash(stakeKeyHash);
-          const stakeKeyRegCert = StakeRegistration.new(stakeCred);
+          const stakeKeyRegCert = StakeRegistration.new_with_coin(stakeCred, BigNum.from_str(`${epochParams.key_deposit}`));
           certBuilder.add(Certificate.new_stake_registration(stakeKeyRegCert));
         }
 


### PR DESCRIPTION
Draft because I don't have proper local setup to be able to test properly

#### Motivation

We should use the newer type of stake key registration certificate
because the one we currently are using will be deprecated in a future ledger era.