### PR TITLE
feat(#1600): add support for previous governance action data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ changes.
 - Add support for displaying protocol parameters governance actions [Issue 1601](https://github.com/IntersectMBO/govtool/issues/1601)
 - Add SPO and CC committee total votes to gov actions [Issue 1704](https://github.com/IntersectMBO/govtool/issues/1704)
 - Add support for hard fork initiation governance action details [Issue 1600](https://github.com/IntersectMBO/govtool/issues/1600)
+- Add support for hard fork initiation previous governance action data [Issue 1600](https://github.com/IntersectMBO/govtool/issues/1600)
 
 ### Fixed
 

--- a/govtool/backend/src/VVA/API.hs
+++ b/govtool/backend/src/VVA/API.hs
@@ -208,7 +208,9 @@ proposalToResponse timeZone Types.Proposal {..} =
     proposalResponsePoolAbstainVotes = proposalPoolAbstainVotes,
     proposalResponseCcYesVotes = proposalCcYesVotes,
     proposalResponseCcNoVotes = proposalCcNoVotes,
-    proposalResponseCcAbstainVotes = proposalCcAbstainVotes
+    proposalResponseCcAbstainVotes = proposalCcAbstainVotes,
+    proposalResponsePrevGovActionIndex = proposalPrevGovActionIndex,
+    proposalResponsePrevGovActionTxHash = HexText <$> proposalPrevGovActionTxHash
   }
 
 voteToResponse :: Types.Vote -> VoteParams

--- a/govtool/backend/src/VVA/API/Types.hs
+++ b/govtool/backend/src/VVA/API/Types.hs
@@ -476,31 +476,33 @@ instance ToSchema GovernanceActionReferences where
 
 data ProposalResponse
   = ProposalResponse
-      { proposalResponseId                 :: Text
-      , proposalResponseTxHash             :: HexText
-      , proposalResponseIndex              :: Integer
-      , proposalResponseType               :: GovernanceActionType
-      , proposalResponseDetails            :: Maybe GovernanceActionDetails
-      , proposalResponseExpiryDate         :: Maybe UTCTime
-      , proposalResponseExpiryEpochNo      :: Maybe Integer
-      , proposalResponseCreatedDate        :: UTCTime
-      , proposalResponseCreatedEpochNo     :: Integer
-      , proposalResponseUrl                :: Text
-      , proposalResponseMetadataHash       :: HexText
-      , proposalResponseProtocolParams     :: Maybe ProtocolParams
-      , proposalResponseTitle              :: Maybe Text
-      , proposalResponseAbstract           :: Maybe Text
-      , proposalResponseMotivation         :: Maybe Text
-      , proposalResponseRationale          :: Maybe Text
-      , proposalResponseDRepYesVotes       :: Integer
-      , proposalResponseDRepNoVotes        :: Integer
-      , proposalResponseDRepAbstainVotes   :: Integer
-      , proposalResponsePoolYesVotes       :: Integer
-      , proposalResponsePoolNoVotes        :: Integer
-      , proposalResponsePoolAbstainVotes   :: Integer
-      , proposalResponseCcYesVotes         :: Integer
-      , proposalResponseCcNoVotes          :: Integer
-      , proposalResponseCcAbstainVotes     :: Integer
+      { proposalResponseId                  :: Text
+      , proposalResponseTxHash              :: HexText
+      , proposalResponseIndex               :: Integer
+      , proposalResponseType                :: GovernanceActionType
+      , proposalResponseDetails             :: Maybe GovernanceActionDetails
+      , proposalResponseExpiryDate          :: Maybe UTCTime
+      , proposalResponseExpiryEpochNo       :: Maybe Integer
+      , proposalResponseCreatedDate         :: UTCTime
+      , proposalResponseCreatedEpochNo      :: Integer
+      , proposalResponseUrl                 :: Text
+      , proposalResponseMetadataHash        :: HexText
+      , proposalResponseProtocolParams      :: Maybe ProtocolParams
+      , proposalResponseTitle               :: Maybe Text
+      , proposalResponseAbstract            :: Maybe Text
+      , proposalResponseMotivation          :: Maybe Text
+      , proposalResponseRationale           :: Maybe Text
+      , proposalResponseDRepYesVotes        :: Integer
+      , proposalResponseDRepNoVotes         :: Integer
+      , proposalResponseDRepAbstainVotes    :: Integer
+      , proposalResponsePoolYesVotes        :: Integer
+      , proposalResponsePoolNoVotes         :: Integer
+      , proposalResponsePoolAbstainVotes    :: Integer
+      , proposalResponseCcYesVotes          :: Integer
+      , proposalResponseCcNoVotes           :: Integer
+      , proposalResponseCcAbstainVotes      :: Integer
+      , proposalResponsePrevGovActionIndex  :: Maybe Integer
+      , proposalResponsePrevGovActionTxHash :: Maybe HexText
       }
   deriving (Generic, Show)
 
@@ -531,7 +533,9 @@ exampleProposalResponse = "{ \"id\": \"proposalId123\","
                   <> "\"poolAbstainVotes\": 0,"
                   <> "\"cCYesVotes\": 0,"
                   <> "\"cCNoVotes\": 0,"
-                  <> "\"cCAbstainVotes\": 0}"
+                  <> "\"cCAbstainVotes\": 0,"
+                  <> "\"prevGovActionIndex\": 0,"
+                  <> "\"prevGovActionTxHash\": \"47c14a128cd024f1b990c839d67720825921ad87ed875def42641ddd2169b39c\"}"
 
 instance ToSchema ProposalResponse where
   declareNamedSchema proxy = do

--- a/govtool/backend/src/VVA/Types.hs
+++ b/govtool/backend/src/VVA/Types.hs
@@ -106,31 +106,33 @@ data DRepRegistration
 
 data Proposal
   = Proposal
-      { proposalId                 :: Integer
-      , proposalTxHash             :: Text
-      , proposalIndex              :: Integer
-      , proposalType               :: Text
-      , proposalDetails            :: Maybe Value
-      , proposalExpiryDate         :: Maybe LocalTime
-      , proposalExpiryEpochNo      :: Maybe Integer
-      , proposalCreatedDate        :: LocalTime
-      , proposalCreatedEpochNo     :: Integer
-      , proposalUrl                :: Text
-      , proposalDocHash            :: Text
-      , proposalProtocolParams     :: Maybe Value
-      , proposalTitle              :: Maybe Text
-      , proposalAbstract           :: Maybe Text
-      , proposalMotivation         :: Maybe Text
-      , proposalRationale          :: Maybe Text
-      , proposalDRepYesVotes       :: Integer
-      , proposalDRepNoVotes        :: Integer
-      , proposalDRepAbstainVotes   :: Integer
-      , proposalPoolYesVotes       :: Integer
-      , proposalPoolNoVotes        :: Integer
-      , proposalPoolAbstainVotes   :: Integer
-      , proposalCcYesVotes         :: Integer
-      , proposalCcNoVotes          :: Integer
-      , proposalCcAbstainVotes     :: Integer
+      { proposalId                  :: Integer
+      , proposalTxHash              :: Text
+      , proposalIndex               :: Integer
+      , proposalType                :: Text
+      , proposalDetails             :: Maybe Value
+      , proposalExpiryDate          :: Maybe LocalTime
+      , proposalExpiryEpochNo       :: Maybe Integer
+      , proposalCreatedDate         :: LocalTime
+      , proposalCreatedEpochNo      :: Integer
+      , proposalUrl                 :: Text
+      , proposalDocHash             :: Text
+      , proposalProtocolParams      :: Maybe Value
+      , proposalTitle               :: Maybe Text
+      , proposalAbstract            :: Maybe Text
+      , proposalMotivation          :: Maybe Text
+      , proposalRationale           :: Maybe Text
+      , proposalDRepYesVotes        :: Integer
+      , proposalDRepNoVotes         :: Integer
+      , proposalDRepAbstainVotes    :: Integer
+      , proposalPoolYesVotes        :: Integer
+      , proposalPoolNoVotes         :: Integer
+      , proposalPoolAbstainVotes    :: Integer
+      , proposalCcYesVotes          :: Integer
+      , proposalCcNoVotes           :: Integer
+      , proposalCcAbstainVotes      :: Integer
+      , proposalPrevGovActionIndex  :: Maybe Integer
+      , proposalPrevGovActionTxHash :: Maybe Text
       }
   deriving (Show)
 
@@ -162,6 +164,8 @@ instance FromRow Proposal where
       <*> (floor @Scientific <$> field)
       <*> (floor @Scientific <$> field)
       <*> (floor @Scientific <$> field)
+      <*> field
+      <*> field
       
 data TransactionStatus = TransactionConfirmed | TransactionUnconfirmed
 


### PR DESCRIPTION
## List of changes

- Add support for previous governance action data

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1600)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
