### PR TITLE
chore: add mainnet govtool domain to bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,11 +34,12 @@ body:
       label: Domain
       description: Which GovTool instance were you connected to?
       options:
+        - gov.tools
+        - preview.gov.tools
         - sanchogov.tools
         - dev-sanchogov.tools
         - test-sanchogov.tools
         - stage-sanchogov.tools
-        - preview.gov.tools
         - Custom setup
     validations:
       required: true


### PR DESCRIPTION
## List of changes

- Add mainnet domain to bug report issue template

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
