### PR TITLE
[#1600] hide hardfork initiation details outside details tab

### DIFF
--- a/govtool/frontend/src/components/organisms/GovernanceActionDetailsCardData.tsx
+++ b/govtool/frontend/src/components/organisms/GovernanceActionDetailsCardData.tsx
@@ -256,6 +256,7 @@ export const GovernanceActionDetailsCardData = ({
       )}
 
       {details &&
+        type !== GovernanceActionType.HardForkInitiation &&
         Object.keys(details).length !== 0 &&
         Object.entries(details).map(([detailLabel, content]) => (
           <GovernanceActionCardElement
@@ -312,7 +313,7 @@ const HardforkDetailsTabContent = ({
   const { t } = useTranslation();
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3, pb: 3 }}>
       <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
         <Typography variant="body2">
           {t("govActions.hardforkDetails.currentVersion")}


### PR DESCRIPTION
## List of changes

- Fix displaying duplicate hardfork initiation details

## Checklist

- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
