### PR TITLE
fix(#1733): fix accessing drep deposit from possibly empty epoch params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ changes.
 ### Fixed
 
 - Fix typescript bug leading to runtime error when entering Governance Action details page via direct link [Issue 1801](https://github.com/IntersectMBO/govtool/issues/1801)
+- Fix accessing missing epochParams drep_deposit [Issue 1733](https://github.com/IntersectMBO/govtool/issues/1733)
 
 ### Changed
 

--- a/govtool/frontend/src/components/organisms/RegisterAsDRepSteps/RolesAndResponsibilities.tsx
+++ b/govtool/frontend/src/components/organisms/RegisterAsDRepSteps/RolesAndResponsibilities.tsx
@@ -20,7 +20,7 @@ export const RolesAndResponsibilities = ({
   const { t } = useTranslation();
   const { isMobile } = useScreenDimension();
 
-  const deposit = getItemFromLocalStorage(PROTOCOL_PARAMS_KEY);
+  const epochParams = getItemFromLocalStorage(PROTOCOL_PARAMS_KEY);
 
   const onClickContinue = () => setStep(2);
 
@@ -51,7 +51,7 @@ export const RolesAndResponsibilities = ({
             />,
           ]}
           i18nKey="registration.rolesAndResponsibilitiesDescription"
-          values={{ deposit: correctAdaFormat(deposit.drep_deposit) }}
+          values={{ deposit: correctAdaFormat(epochParams?.drep_deposit) }}
         />
       </Typography>
       <CenteredBoxBottomButtons

--- a/govtool/frontend/src/context/wallet.tsx
+++ b/govtool/frontend/src/context/wallet.tsx
@@ -651,14 +651,14 @@ const CardanoProvider = (props: Props) => {
           // Create cert object using one Ada as the deposit
           dRepRegCert = DrepRegistration.new_with_anchor(
             dRepCred,
-            BigNum.from_str(`${epochParams.drep_deposit}`),
+            BigNum.from_str(`${epochParams?.drep_deposit}`),
             anchor,
           );
         } else {
           console.error(t("errors.notUsingAnchor"));
           dRepRegCert = DrepRegistration.new(
             dRepCred,
-            BigNum.from_str(`${epochParams.drep_deposit}`),
+            BigNum.from_str(`${epochParams?.drep_deposit}`),
           );
         }
         return Certificate.new_drep_registration(dRepRegCert);

--- a/govtool/frontend/src/pages/RegisterAsDirectVoter.tsx
+++ b/govtool/frontend/src/pages/RegisterAsDirectVoter.tsx
@@ -131,7 +131,7 @@ export const RegisterAsDirectVoter = () => {
       >
         <Trans
           i18nKey="directVoter.registerDescription"
-          values={{ deposit: correctAdaFormat(epochParams.drep_deposit) }}
+          values={{ deposit: correctAdaFormat(epochParams?.drep_deposit) }}
           components={[
             <Link
               onClick={() => openInNewTab("https://sancho.network/")}


### PR DESCRIPTION
## List of changes

- fix accessing DRep deposit from possibly empty epoch params

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1733)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
