### PR TITLE
fix(#1732): fix reading property `trim` of nullish label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ changes.
 ### Fixed
 
 - Fix typescript bug leading to runtime error when entering Governance Action details page via direct link [Issue 1801](https://github.com/IntersectMBO/govtool/issues/1801)
+- Fix reading trim of null object [Issue 1733](https://github.com/IntersectMBO/govtool/issues/1733)
 
 ### Changed
 

--- a/govtool/frontend/src/utils/testIdFromLabel.ts
+++ b/govtool/frontend/src/utils/testIdFromLabel.ts
@@ -1,2 +1,2 @@
-export const testIdFromLabel = (label: string) =>
-  label.trim().replace(/ /g, "-").toLocaleLowerCase();
+export const testIdFromLabel = (label?: string) =>
+  label?.trim().replace(/ /g, "-").toLocaleLowerCase();


### PR DESCRIPTION
## List of changes

- fix reading property `trim` of nullish label

The issue originally is caused by an empty `email` in DRep detailed `DRepDetailsInfoItem` component. But email is not supported by CIP-119 property and should be removed within https://github.com/IntersectMBO/govtool/pull/1820

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1732)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
