### PR TITLE
fix: fix backend build providing postgresql@14 in the base Dockerfile

### DIFF
--- a/govtool/backend/Dockerfile.base
+++ b/govtool/backend/Dockerfile.base
@@ -6,5 +6,13 @@
 
 FROM haskell:9.2.7-buster
 WORKDIR /src
+
+RUN apt-get update && \
+    apt-get install -y wget lsb-release && \
+    sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    apt-get update && \
+    apt-get install -y postgresql-14 libpq-dev
+
 COPY . .
 RUN cabal update && cabal configure && cabal install --only-dependencies && rm -rf /src/*


### PR DESCRIPTION
## List of changes

- add postgresql@14 to the backend base dockerfile

## Checklist

- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
