### PR TITLE
[#1847] delete duplicate text on DRep registration form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ changes.
 
 ### Fixed
 
--
+- Delete duplicate text on DRep registration form [Issue 1847](https://github.com/IntersectMBO/govtool/issues/1847)
 
 ### Changed
 

--- a/govtool/frontend/src/components/organisms/RegisterAsDRepSteps/RegisterAsDRepForm.tsx
+++ b/govtool/frontend/src/components/organisms/RegisterAsDRepSteps/RegisterAsDRepForm.tsx
@@ -97,15 +97,6 @@ export const RegisterAsDRepForm = ({
       />
       <Spacer y={isMobile ? 5 : 6} />
       <Box textAlign="center">
-        <InfoText label={t("registration.optional")} />
-        <Typography sx={{ mt: 0.5, mb: isMobile ? 3 : 4 }} variant="headline4">
-          {t("registration.aboutYou")}
-        </Typography>
-        <Typography fontWeight={400} sx={{ mb: 4 }} variant="body1">
-          {t("registration.aboutYouDescription")}
-        </Typography>
-      </Box>
-      <Box textAlign="center">
         <InfoText label={t("editMetadata.optional")} />
         <Typography sx={{ mt: 0.5, mb: isMobile ? 3 : 4 }} variant="headline4">
           {t("editMetadata.aboutYou")}


### PR DESCRIPTION
## List of changes

- Delete duplicate text on DRep registration form

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1847)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
