### PR TITLE
[#1842] fix invisible modal content on ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ changes.
 ### Fixed
 
 - Delete duplicate text on DRep registration form [Issue 1847](https://github.com/IntersectMBO/govtool/issues/1847)
+- Fix modal content invisible on ios [Issue 1842](https://github.com/IntersectMBO/govtool/issues/1842)
 
 ### Changed
 

--- a/govtool/frontend/src/components/atoms/modal/ModalWrapper.tsx
+++ b/govtool/frontend/src/components/atoms/modal/ModalWrapper.tsx
@@ -17,7 +17,7 @@ interface Props {
 export const BaseWrapper = styled("div")<Pick<Props, "variant">>`
   box-shadow: 1px 2px 11px 0px #00123d5e;
   max-height: 90vh;
-  position: absolute;
+  position: fixed;
   top: 50%;
   left: 50%;
   display: flex;


### PR DESCRIPTION
## List of changes

- Fix invisible modal content on ios

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1842)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
