### PR TITLE
fix(#1876): fix voting on info actions in bootstrapping phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ changes.
 - Fix modal content invisible on ios [Issue 1842](https://github.com/IntersectMBO/govtool/issues/1842)
 - Fix counting votes by CC committee members and SPOs [Issue 1838](https://github.com/IntersectMBO/govtool/issues/1838)
 - Fix displaying non relevant data in protocol parameter change Governance Action [Issue 1601](https://github.com/IntersectMBO/govtool/issues/1601)
+- Fix voting on info actions in bootstrapping phase [Issue 1876](https://github.com/IntersectMBO/govtool/issues/1876)
 
 ### Changed
 

--- a/govtool/frontend/src/context/featureFlag.tsx
+++ b/govtool/frontend/src/context/featureFlag.tsx
@@ -50,7 +50,7 @@ const FeatureFlagProvider = ({ children }: PropsWithChildren) => {
    */
   const isVotingOnGovernanceActionEnabled = useCallback(
     (governanceActionType: GovernanceActionType) =>
-      (epochParams?.protocol_major || 0) >
+      (epochParams?.protocol_major || 0) >=
       govActionVotingEnabledSinceProtocolVersion[governanceActionType],
     [isAppInitializing],
   );


### PR DESCRIPTION
## List of changes

- fix voting on info actions in bootstrapping phase

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1876)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
