### PR TITLE
fix(#1873): fix missing DRep name whitespace validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ changes.
 - Fix counting votes by CC committee members and SPOs [Issue 1838](https://github.com/IntersectMBO/govtool/issues/1838)
 - Fix displaying non relevant data in protocol parameter change Governance Action [Issue 1601](https://github.com/IntersectMBO/govtool/issues/1601)
 - Fix voting on info actions in bootstrapping phase [Issue 1876](https://github.com/IntersectMBO/govtool/issues/1876)
+- Fix missing DRep name whitespace validation [Issue 1873](https://github.com/IntersectMBO/govtool/issues/1873)
 
 ### Changed
 

--- a/govtool/frontend/src/consts/dRepActions/fields.ts
+++ b/govtool/frontend/src/consts/dRepActions/fields.ts
@@ -13,6 +13,10 @@ export const Rules = {
         maxLength: 80,
       }),
     },
+    pattern: {
+      value: /^[^\s]+$/,
+      message: i18n.t("registration.fields.validations.noSpaces"),
+    },
   },
   LINK: {
     pattern: {

--- a/govtool/frontend/src/i18n/locales/en.ts
+++ b/govtool/frontend/src/i18n/locales/en.ts
@@ -698,6 +698,7 @@ export const en = {
           maxLength: "Max {{maxLength}} characters",
           required: "This field is required",
           url: "Invalid URL",
+          noSpaces: "No spaces allowed",
         },
       },
     },


### PR DESCRIPTION
## List of changes

-  fix missing DRep name whitespace validation

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1873)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
