### PR TITLE
fix(#1871): make payment address validation optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ changes.
 - Fix voting on info actions in bootstrapping phase [Issue 1876](https://github.com/IntersectMBO/govtool/issues/1876)
 - Fix missing DRep name whitespace validation [Issue 1873](https://github.com/IntersectMBO/govtool/issues/1873)
 - Fix displaying wrongly formatted Governance Action ID [Issue 1866](https://github.com/IntersectMBO/govtool/issues/1866k)
+- Make payment address optional in DRep registration and edit form [Issue 1871](https://github.com/IntersectMBO/govtool/issues/1871)
 
 ### Changed
 

--- a/govtool/frontend/src/hooks/forms/useEditDRepInfoForm.ts
+++ b/govtool/frontend/src/hooks/forms/useEditDRepInfoForm.ts
@@ -68,7 +68,6 @@ export const useEditDRepInfoForm = (
     handleSubmit,
     formState: { errors, isValid },
     register,
-    resetField,
     reset,
     watch,
   } = useFormContext<EditDRepInfoValues>();
@@ -91,7 +90,14 @@ export const useEditDRepInfoForm = (
   const generateMetadata = useCallback(async () => {
     const body = generateMetadataBody({
       data: getValues(),
-      acceptedKeys: ["givenName", "objectives", "motivations", "qualifications", "paymentAddress", "references"],
+      acceptedKeys: [
+        "givenName",
+        "objectives",
+        "motivations",
+        "qualifications",
+        "paymentAddress",
+        "references",
+      ],
       standardReference: CIP_119,
     });
 
@@ -204,7 +210,6 @@ export const useEditDRepInfoForm = (
     onClickDownloadJson,
     register,
     editDRepInfo: handleSubmit(onSubmit),
-    resetField,
     watch,
     reset,
   };

--- a/govtool/frontend/src/hooks/forms/useRegisterAsdRepForm.tsx
+++ b/govtool/frontend/src/hooks/forms/useRegisterAsdRepForm.tsx
@@ -81,7 +81,6 @@ export const useRegisterAsdRepForm = (
     handleSubmit,
     formState: { errors, isValid },
     register,
-    resetField,
     watch,
   } = useFormContext<RegisterAsDRepValues>();
 
@@ -250,7 +249,6 @@ export const useRegisterAsdRepForm = (
     onClickDownloadJson,
     register,
     registerAsDrep: handleSubmit(onSubmit),
-    resetField,
     watch,
   };
 };

--- a/govtool/frontend/src/utils/isValidFormat.ts
+++ b/govtool/frontend/src/utils/isValidFormat.ts
@@ -39,8 +39,11 @@ export async function isRewardAddress(address: string) {
   }
 }
 
-export async function isReceivingAddress(address: string) {
+export async function isReceivingAddress(address?: string) {
   try {
+    if (!address) {
+      return true;
+    }
     const receivingAddress = Address.from_bech32(address);
     return receivingAddress
       ? true


### PR DESCRIPTION
## List of changes

- make payment address validation optional

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1871)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
