### PR TITLE
Bugfix/protocol v9 failing test

### DIFF
--- a/tests/govtool-frontend/playwright/lib/_mock/index.ts
+++ b/tests/govtool-frontend/playwright/lib/_mock/index.ts
@@ -114,37 +114,42 @@ export const valid = {
 
     return username;
   },
-  metadata: () => ({
+  metadata: (paymentAddress: string) => ({
     "@context": {
-      "@language": "en-us",
       CIP100:
         "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#",
-      CIPQQQ:
-        "https://github.com/cardano-foundation/CIPs/blob/master/CIP-QQQ/README.md#",
+      CIP119:
+        "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0119/README.md#",
       hashAlgorithm: "CIP100:hashAlgorithm",
       body: {
-        "@id": "CIPQQQ:body",
+        "@id": "CIP119:body",
         "@context": {
           references: {
-            "@id": "CIPQQQ:references",
+            "@id": "CIP119:references",
             "@container": "@set",
             "@context": {
               GovernanceMetadata: "CIP100:GovernanceMetadataReference",
+              Identity: "CIP100:IdentityReference",
+              Link: "CIP100:LinkReference",
               Other: "CIP100:OtherReference",
               label: "CIP100:reference-label",
               uri: "CIP100:reference-uri",
               referenceHash: {
-                "@id": "CIPQQQ:referenceHash",
+                "@id": "CIP119:referenceHash",
                 "@context": {
-                  hashDigest: "CIPQQQ:hashDigest",
+                  hashDigest: "CIP119:hashDigest",
                   hashAlgorithm: "CIP100:hashAlgorithm",
                 },
               },
             },
           },
-          dRepName: "CIPQQQ:dRepName",
-          bio: "CIPQQQ:bio",
-          email: "CIPQQQ:email",
+          paymentAddress: "CIP119:paymentAddress",
+          givenName: "CIP119:givenName",
+          image: "CIP119:image",
+          objectives: "CIP119:objectives",
+          motivations: "CIP119:motivations",
+          qualifications: "CIP119:qualifications",
+          doNotList: "CIP119:doNotList",
         },
       },
       authors: {
@@ -164,28 +169,18 @@ export const valid = {
       },
     },
     authors: [],
-    hashAlgorithm: {
-      "@value": "blake2b-256",
-    },
+    hashAlgorithm: "blake2b-256",
     body: {
-      bio: {
-        "@value": faker.lorem.sentences(),
-      },
-      dRepName: {
-        "@value": faker.person.firstName(),
-      },
-      email: {
-        "@value": faker.internet.email(),
-      },
+      givenName: faker.person.firstName(),
+      motivations: faker.lorem.paragraph(2),
+      objectives: faker.lorem.paragraph(2),
+      paymentAddress: paymentAddress,
+      qualifications: faker.lorem.paragraph(2),
       references: [
         {
           "@type": "Other",
-          label: {
-            "@value": "Label",
-          },
-          uri: {
-            "@value": faker.internet.url(),
-          },
+          label: "Label",
+          uri: faker.internet.url(),
         },
       ],
     },

--- a/tests/govtool-frontend/playwright/lib/constants/docsUrl.ts
+++ b/tests/govtool-frontend/playwright/lib/constants/docsUrl.ts
@@ -1,14 +1,14 @@
 import environments from "./environments";
 
-export const DELEGATION_DOC_URL = `${environments.docsUrl}/how-to-use-the-govtool/using-govtool/delegating`;
-export const REGISTER_DREP_DOC_URL = `${environments.docsUrl}/how-to-use-the-govtool/using-govtool/dreps`;
-export const DIRECT_VOTER_DOC_URL = `${environments.docsUrl}/how-to-use-the-govtool/using-govtool/direct-voting`;
-export const GOVERNANCE_ACTION_DOC_URL = `${environments.docsUrl}/how-to-use-the-govtool/using-govtool/governance-actions`;
-export const PROPOSE_GOVERNANCE_ACTION_DOC_URL = `${environments.docsUrl}/how-to-use-the-govtool/using-govtool/governance-actions/propose-a-governance-action`;
-export const ABSTAIN_VOTE_DOC_URL = `${environments.docsUrl}/how-to-use-the-govtool/using-govtool/delegating/abstain-from-every-vote`;
-export const SIGNAL_NO_CONFIDENCE_VOTE_DOC_URL = `${environments.docsUrl}/how-to-use-the-govtool/using-govtool/delegating/signal-no-confidence-on-every-vote`;
+export const DELEGATION_DOC_URL = `${environments.docsUrl}/using-govtool/govtool-functions/delegating`;
+export const REGISTER_DREP_DOC_URL = `${environments.docsUrl}/using-govtool/govtool-functions/dreps/register-as-a-drep`;
+export const DIRECT_VOTER_DOC_URL = `${environments.docsUrl}/using-govtool/govtool-functions/direct-voting`;
+export const GOVERNANCE_ACTION_DOC_URL = `${environments.docsUrl}/using-govtool/govtool-functions/governance-actions/view-governance-actions`;
+export const PROPOSE_GOVERNANCE_ACTION_DOC_URL = `${environments.docsUrl}/using-govtool/govtool-functions/governance-actions/propose-a-governance-action`;
+export const ABSTAIN_VOTE_DOC_URL = `${environments.docsUrl}/using-govtool/govtool-functions/delegating/abstain-from-every-vote`;
+export const SIGNAL_NO_CONFIDENCE_VOTE_DOC_URL = `${environments.docsUrl}/using-govtool/govtool-functions/delegating/signal-no-confidence-on-every-vote`;
 export const FAQS_DOC_URL = `${environments.docsUrl}/faqs`;
-export const GUIDES_DOC_URL = `${environments.docsUrl}/about/what-is-sanchonet-govtool`;
+export const GUIDES_DOC_URL = `${environments.docsUrl}`;
 export const PRIVACY_POLICY = `${environments.docsUrl}/legal/privacy-policy`;
 export const TERMS_AND_CONDITIONS = `${environments.docsUrl}/legal/terms-and-conditions`;
 export const HELP_DOC_URL = `${environments.docsUrl}/support/get-help-in-discord`;

--- a/tests/govtool-frontend/playwright/lib/forms/dRepForm.ts
+++ b/tests/govtool-frontend/playwright/lib/forms/dRepForm.ts
@@ -115,11 +115,13 @@ export default class DRepForm {
     await expect(this.continueBtn).toBeEnabled();
   }
 
-  async inValidateForm(name: string, email: string, bio: string, link: string) {
-    await this.nameInput.fill(name);
-    await this.emailInput.fill(email);
-    await this.bioInput.fill(bio);
-    await this.linkInput.fill(link);
+  async inValidateForm(dRepInfo: IDRepInfo) {
+    await this.nameInput.fill(dRepInfo.name);
+    await this.objectivesInput.fill(dRepInfo.objectives);
+    await this.motivationsInput.fill(dRepInfo.motivations);
+    await this.qualificationsInput.fill(dRepInfo.qualifications);
+    await this.paymentAddressInput.fill(dRepInfo.paymentAddress);
+    await this.linkInput.fill(dRepInfo.extraContentLinks[0]);
 
     function convertTestIdToText(testId: string) {
       let text = testId.replace("-error", "");
@@ -140,9 +142,19 @@ export default class DRepForm {
 
     expect(nameErrors.length).toEqual(1);
 
-    await expect(this.form.getByTestId(formErrors.email)).toBeVisible();
+    await expect(
+      this.form.getByTestId(formErrors.paymentAddress)
+    ).toBeVisible();
 
-    expect(await this.bioInput.textContent()).not.toEqual(bio);
+    expect(await this.objectivesInput.textContent()).not.toEqual(
+      dRepInfo.objectives
+    );
+    expect(await this.motivationsInput.textContent()).not.toEqual(
+      dRepInfo.qualifications
+    );
+    expect(await this.qualificationsInput.textContent()).not.toEqual(
+      dRepInfo.qualifications
+    );
 
     await expect(this.form.getByTestId(formErrors.link)).toBeVisible();
 

--- a/tests/govtool-frontend/playwright/lib/forms/dRepForm.ts
+++ b/tests/govtool-frontend/playwright/lib/forms/dRepForm.ts
@@ -17,6 +17,8 @@ const formErrors = {
 export default class DRepForm {
   readonly continueBtn = this.form.getByTestId("continue-button");
   readonly addLinkBtn = this.form.getByTestId("add-link-button");
+  readonly registerBtn = this.form.getByTestId("register-button");
+  readonly submitBtn = this.form.getByTestId("submit-button");
   readonly metadataDownloadBtn = this.form.getByTestId(
     "metadata-download-button"
   );
@@ -27,6 +29,10 @@ export default class DRepForm {
   readonly bioInput = this.form.getByTestId("bio-input");
   readonly linkInput = this.form.getByTestId("link-1-input");
   readonly metadataUrlInput = this.form.getByTestId("metadata-url-input");
+  readonly objectivesInput = this.form.getByTestId("objectives-input");
+  readonly motivationsInput = this.form.getByTestId("motivations-input");
+  readonly qualificationsInput = this.form.getByTestId("qualifications-input");
+  readonly paymentAddressInput = this.form.getByTestId("payment-address-input");
 
   constructor(private readonly form: Page) {}
 
@@ -38,12 +44,19 @@ export default class DRepForm {
   async registerWithoutTxConfirmation(dRepInfo: IDRepInfo) {
     await this.nameInput.fill(dRepInfo.name);
 
-    if (dRepInfo.email != null) {
-      await this.emailInput.fill(dRepInfo.email);
+    if (dRepInfo.objectives != null) {
+      await this.objectivesInput.fill(dRepInfo.objectives);
     }
-    if (dRepInfo.bio != null) {
-      await this.bioInput.fill(dRepInfo.bio);
+    if (dRepInfo.motivations != null) {
+      await this.motivationsInput.fill(dRepInfo.motivations);
     }
+    if (dRepInfo.qualifications != null) {
+      await this.qualificationsInput.fill(dRepInfo.qualifications);
+    }
+    if (dRepInfo.paymentAddress != null) {
+      await this.paymentAddressInput.fill(dRepInfo.paymentAddress);
+    }
+
     if (dRepInfo.extraContentLinks != null) {
       for (let i = 0; i < dRepInfo.extraContentLinks.length; i++) {
         if (i > 0) {
@@ -54,7 +67,7 @@ export default class DRepForm {
     }
     await this.continueBtn.click();
     await this.form.getByRole("checkbox").click();
-    await this.continueBtn.click();
+    await this.registerBtn.click();
 
     this.metadataDownloadBtn.click();
     const dRepMetadata = await this.downloadVoteMetadata();
@@ -64,7 +77,7 @@ export default class DRepForm {
     );
 
     await this.metadataUrlInput.fill(url);
-    await this.form.getByTestId("register-button").click();
+    await this.submitBtn.click();
   }
 
   async downloadVoteMetadata() {

--- a/tests/govtool-frontend/playwright/lib/forms/dRepForm.ts
+++ b/tests/govtool-frontend/playwright/lib/forms/dRepForm.ts
@@ -8,7 +8,7 @@ const formErrors = {
   dRepName: [
     "max-80-characters-error",
     "this-field-is-required-error",
-    "nickname-can-not-contain-whitespaces-error",
+    "no-spaces-allowed-error",
   ],
   email: "invalid-email-address-error",
   link: "invalid-url-error",

--- a/tests/govtool-frontend/playwright/lib/forms/dRepForm.ts
+++ b/tests/govtool-frontend/playwright/lib/forms/dRepForm.ts
@@ -12,6 +12,7 @@ const formErrors = {
   ],
   email: "invalid-email-address-error",
   link: "invalid-url-error",
+  paymentAddress: "invalid-payment-address-error",
 };
 
 export default class DRepForm {
@@ -85,21 +86,31 @@ export default class DRepForm {
     return downloadMetadata(download);
   }
 
-  async validateForm(name: string, email: string, bio: string, link: string) {
-    await this.nameInput.fill(name);
-    await this.emailInput.fill(email);
-    await this.bioInput.fill(bio);
-    await this.linkInput.fill(link);
+  async validateForm(dRepInfo: IDRepInfo) {
+    await this.nameInput.fill(dRepInfo.name);
+    await this.objectivesInput.fill(dRepInfo.objectives);
+    await this.motivationsInput.fill(dRepInfo.motivations);
+    await this.qualificationsInput.fill(dRepInfo.qualifications);
+    await this.paymentAddressInput.fill(dRepInfo.paymentAddress);
+    await this.linkInput.fill(dRepInfo.extraContentLinks[0]);
 
     for (const err of formErrors.dRepName) {
       await expect(this.form.getByTestId(err)).toBeHidden();
     }
 
-    await expect(this.form.getByTestId(formErrors.email)).toBeHidden();
+    expect(await this.objectivesInput.textContent()).toEqual(
+      dRepInfo.objectives
+    );
 
-    expect(await this.bioInput.textContent()).toEqual(bio);
+    expect(await this.motivationsInput.textContent()).toEqual(
+      dRepInfo.motivations
+    );
+    expect(await this.qualificationsInput.textContent()).toEqual(
+      dRepInfo.qualifications
+    );
 
     await expect(this.form.getByTestId(formErrors.link)).toBeHidden();
+    await expect(this.form.getByTestId(formErrors.paymentAddress)).toBeHidden();
 
     await expect(this.continueBtn).toBeEnabled();
   }

--- a/tests/govtool-frontend/playwright/lib/helpers/metadata.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/metadata.ts
@@ -5,6 +5,7 @@ import metadataBucketService from "@services/metadataBucketService";
 const blake = require("blakejs");
 
 import * as fs from "fs";
+import { ShelleyWallet } from "./crypto";
 
 export async function downloadMetadata(download: Download): Promise<{
   name: string;
@@ -17,9 +18,10 @@ export async function downloadMetadata(download: Download): Promise<{
   return { name: download.suggestedFilename(), data: jsonData };
 }
 
-function calculateMetadataHash() {
+async function calculateMetadataHash() {
   try {
-    const data = JSON.stringify(mockValid.metadata());
+    const paymentAddress = (await ShelleyWallet.generate()).addressBech32(0);
+    const data = JSON.stringify(mockValid.metadata(paymentAddress));
 
     const buffer = Buffer.from(data, "utf8");
     const hexDigest = blake.blake2bHex(buffer, null, 32);
@@ -32,7 +34,7 @@ function calculateMetadataHash() {
 }
 
 export async function uploadMetadataAndGetJsonHash() {
-  const { hexDigest: dataHash, jsonData } = calculateMetadataHash();
+  const { hexDigest: dataHash, jsonData } = await calculateMetadataHash();
   const url = await metadataBucketService.uploadMetadata(
     faker.person.firstName(),
     jsonData

--- a/tests/govtool-frontend/playwright/lib/helpers/transaction.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/transaction.ts
@@ -71,7 +71,7 @@ export async function waitForTxConfirmation(
         .getByTestId("alert-warning")
         .getByText("Transaction in progress", { exact: false })
     ).toBeVisible({
-      timeout: 10_000,
+      timeout: 16_000,
     });
     const url = (await transactionStatusPromise).url();
     const regex = /\/transaction\/status\/([^\/]+)$/;

--- a/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
@@ -143,7 +143,7 @@ export default class DRepDirectoryPage {
   }
 
   async getAllListedDReps() {
-    await this.page.waitForTimeout(2_000);
+    await this.page.waitForTimeout(5_000); // load until the dRep card load properly
 
     return await this.page
       .getByRole("list")

--- a/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
@@ -47,6 +47,17 @@ export default class GovernanceActionsPage {
     return new GovernanceActionDetailsPage(this.page);
   }
 
+  async viewFirstInfoProposal(): Promise<GovernanceActionDetailsPage> {
+    const treasuryWithdrawFirstCard = this.page
+      .getByTestId("govaction-InfoAction-card")
+      .first();
+    await treasuryWithdrawFirstCard
+      .locator('[data-testid^="govaction-"][data-testid$="-view-detail"]')
+      .first()
+      .click();
+    return new GovernanceActionDetailsPage(this.page);
+  }
+
   async viewVotedProposal(
     proposal: IProposal
   ): Promise<GovernanceActionDetailsPage> {

--- a/tests/govtool-frontend/playwright/lib/types.ts
+++ b/tests/govtool-frontend/playwright/lib/types.ts
@@ -26,10 +26,17 @@ export interface IProposal {
   motivation: string | null;
   rationale: string | null;
   metadata: any;
-  references: any;
-  yesVotes: number;
-  noVotes: number;
-  abstainVotes: number;
+  dRepYesVotes: number;
+  dRepNoVotes: number;
+  dRepAbstainVotes: number;
+  poolYesVotes: number;
+  poolNoVotes: number;
+  poolAbstainVotes: number;
+  ccYesVotes: number;
+  ccNoVotes: number;
+  ccAbstainVotes: number;
+  prevGovActionIndex: null | number;
+  prevGovActionTxHash: null | string;
 }
 
 export type IVote = {

--- a/tests/govtool-frontend/playwright/lib/types.ts
+++ b/tests/govtool-frontend/playwright/lib/types.ts
@@ -47,8 +47,10 @@ export type IVotedProposal = {
 
 export type IDRepInfo = {
   name: string;
-  email?: string;
-  bio?: string;
+  objectives?: string;
+  motivations?: string;
+  qualifications?: string;
+  paymentAddress?: string;
   extraContentLinks?: string[];
 };
 

--- a/tests/govtool-frontend/playwright/package-lock.json
+++ b/tests/govtool-frontend/playwright/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@cardanoapi/cardano-test-wallet": "^2.0.1",
+        "@cardanoapi/cardano-test-wallet": "^2.1.1",
         "@faker-js/faker": "^8.4.1",
         "@noble/curves": "^1.3.0",
         "@noble/ed25519": "^2.0.0",
@@ -87,9 +87,10 @@
       }
     },
     "node_modules/@cardanoapi/cardano-test-wallet": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cardanoapi/cardano-test-wallet/-/cardano-test-wallet-2.0.1.tgz",
-      "integrity": "sha512-WpvFIOYh2d0HTi8ye+b62YtCOQTqsIwLqLabcDt4yoQJWMD5SiDDypd5TA1dU17Y0uAJ/oz4GIupch/PWsur2A=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cardanoapi/cardano-test-wallet/-/cardano-test-wallet-2.1.1.tgz",
+      "integrity": "sha512-K5HISR0GmWiJpZOaWT3PqfP7ez+Ht9+jrW8dSGwEXKfKPnj9g6uqUSnkUbuw3FmPeVRgNcB9EwkwmZzPcg7gZw==",
+      "license": "MIT"
     },
     "node_modules/@cbor-extract/cbor-extract-linux-x64": {
       "version": "2.2.0",
@@ -3347,9 +3348,9 @@
       "dev": true
     },
     "@cardanoapi/cardano-test-wallet": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cardanoapi/cardano-test-wallet/-/cardano-test-wallet-2.0.1.tgz",
-      "integrity": "sha512-WpvFIOYh2d0HTi8ye+b62YtCOQTqsIwLqLabcDt4yoQJWMD5SiDDypd5TA1dU17Y0uAJ/oz4GIupch/PWsur2A=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cardanoapi/cardano-test-wallet/-/cardano-test-wallet-2.1.1.tgz",
+      "integrity": "sha512-K5HISR0GmWiJpZOaWT3PqfP7ez+Ht9+jrW8dSGwEXKfKPnj9g6uqUSnkUbuw3FmPeVRgNcB9EwkwmZzPcg7gZw=="
     },
     "@cbor-extract/cbor-extract-linux-x64": {
       "version": "2.2.0",

--- a/tests/govtool-frontend/playwright/package.json
+++ b/tests/govtool-frontend/playwright/package.json
@@ -28,7 +28,7 @@
     "generate-wallets": "ts-node ./generate_wallets.ts 17"
   },
   "dependencies": {
-    "@cardanoapi/cardano-test-wallet": "^2.0.1",
+    "@cardanoapi/cardano-test-wallet": "^2.1.1",
     "@faker-js/faker": "^8.4.1",
     "@noble/curves": "^1.3.0",
     "@noble/ed25519": "^2.0.0",

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
@@ -73,20 +73,24 @@ test("2N. Should show DRep information on details page", async ({
   await dRepPage.getByTestId("view-drep-details-button").click();
 
   // Verification
-  await expect(dRepPage.getByTestId("copy-drep-id-button").first()).toHaveText(
+  await expect(dRepPage.getByTestId("copy-drep-id-button")).toHaveText(
     wallet.dRepId
   );
-  await expect(dRepPage.getByTestId("copy-drep-id-button").last()).toHaveText(
+  await expect(dRepPage.getByTestId("copy-payment-address-button")).toHaveText(
     paymentAddress
   );
   await expect(dRepPage.getByTestId("Active-pill")).toHaveText("Active");
   await expect(dRepPage.getByTestId("voting-power")).toHaveText("₳ 0");
 
-  await expect(dRepPage.getByText(objectives, { exact: true })).toBeVisible();
-  await expect(dRepPage.getByText(motivations, { exact: true })).toBeVisible();
-  await expect(
-    dRepPage.getByText(qualifications, { exact: true })
-  ).toBeVisible();
+  await expect(dRepPage.getByTestId("objectives-description")).toHaveText(
+    objectives
+  );
+  await expect(dRepPage.getByTestId("motivations-description")).toHaveText(
+    motivations
+  );
+  await expect(dRepPage.getByTestId("qualifications-description")).toHaveText(
+    qualifications
+  );
 
   for (const link of links) {
     await expect(
@@ -143,7 +147,9 @@ test.describe("Insufficient funds", () => {
     await expect(delegateBtn).toBeVisible();
     await page.getByTestId(`${dRep01Wallet.dRepId}-delegate-button`).click();
 
-    await expect(dRepDirectoryPage.delegationErrorModal).toBeVisible();
+    await expect(dRepDirectoryPage.delegationErrorModal).toBeVisible({
+      timeout: 10_000,
+    });
   });
 });
 

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
@@ -53,14 +53,18 @@ test("2N. Should show DRep information on details page", async ({
   await dRepRegistrationPage.goto();
 
   const name = faker.person.firstName();
-  const email = faker.internet.email({ firstName: name });
-  const bio = faker.person.bio();
+  const objectives = faker.lorem.paragraph(2);
+  const motivations = faker.lorem.paragraph(2);
+  const qualifications = faker.lorem.paragraph(2);
+  const paymentAddress = ShelleyWallet.fromJson(wallet).rewardAddressBech32(0);
   const links = [faker.internet.url()];
 
   await dRepRegistrationPage.register({
     name,
-    email,
-    bio,
+    objectives,
+    motivations,
+    qualifications,
+    paymentAddress,
     extraContentLinks: links,
   });
 
@@ -69,13 +73,19 @@ test("2N. Should show DRep information on details page", async ({
   await dRepPage.getByTestId("view-drep-details-button").click();
 
   // Verification
-  await expect(dRepPage.getByTestId("copy-drep-id-button")).toHaveText(
+  await expect(dRepPage.getByTestId("copy-drep-id-button").first()).toHaveText(
     wallet.dRepId
+  );
+  await expect(dRepPage.getByTestId("copy-drep-id-button").last()).toHaveText(
+    paymentAddress
   );
   await expect(dRepPage.getByTestId("Active-pill")).toHaveText("Active");
   await expect(dRepPage.getByTestId("voting-power")).toHaveText("₳ 0");
+
+  await expect(dRepPage.getByText(objectives, { exact: true })).toBeVisible();
+  await expect(dRepPage.getByText(motivations, { exact: true })).toBeVisible();
   await expect(
-    dRepPage.getByTestId(`${email.toLowerCase()}-link`)
+    dRepPage.getByText(qualifications, { exact: true })
   ).toBeVisible();
 
   for (const link of links) {
@@ -83,7 +93,6 @@ test("2N. Should show DRep information on details page", async ({
       dRepPage.getByTestId(`${link.toLowerCase()}-link`)
     ).toBeVisible();
   }
-  await expect(dRepPage.getByText(bio, { exact: true })).toBeVisible();
 });
 
 test("2P. Should enable sharing of DRep details", async ({ page, context }) => {

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
@@ -141,7 +141,7 @@ test.describe("Register DRep state", () => {
     await dRepPage.getByTestId("continue-button").click();
     await expect(
       dRepPage.getByTestId("registration-transaction-submitted-modal")
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 15_000 });
     await dRepPage.getByTestId("confirm-modal-button").click();
     await waitForTxConfirmation(dRepPage);
 
@@ -224,14 +224,16 @@ test.describe("Multiple delegations", () => {
     await dRepDirectoryPage.searchInput.fill(dRep01Wallet.dRepId);
 
     await page.getByTestId(`${dRep01Wallet.dRepId}-delegate-button`).click();
+    await expect(page.getByTestId("alert-warning")).toHaveText(/in progress/i, {
+      timeout: 15_000,
+    });
 
-    await page.waitForTimeout(2_000);
     await dRepDirectoryPage.searchInput.fill(dRep02Wallet.dRepId);
     await page.getByTestId(`${dRep02Wallet.dRepId}-delegate-button`).click();
 
-    await expect(
-      page.getByTestId("transaction-inprogress-modal")
-    ).toBeVisible();
+    await expect(page.getByTestId("transaction-inprogress-modal")).toBeVisible({
+      timeout: 15_000,
+    });
   });
 });
 

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
@@ -162,7 +162,7 @@ test.describe("Register DRep state", () => {
     await dRepPage.getByTestId("continue-button").click();
     await expect(
       dRepPage.getByTestId("registration-transaction-submitted-modal")
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 15_000 });
     await dRepPage.getByTestId("confirm-modal-button").click();
     await waitForTxConfirmation(dRepPage);
     await expect(dRepPage.getByText("You are a Direct Voter")).toBeVisible();

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -169,8 +169,8 @@ test.describe("Temporary DReps", () => {
       .getByTestId("confirm-modal-button")
       .click();
 
-    await expect(
-      dRepPage.locator("span").filter({ hasText: /^In Progress$/ })
-    ).toBeVisible(); // BUG add proper testId for dRep registration card
+    await expect(dRepPage.getByTestId("alert-warning")).toHaveText(
+      /in progress/i
+    );
   });
 });

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -5,13 +5,11 @@ import { faker } from "@faker-js/faker";
 import { test } from "@fixtures/walletExtension";
 import { setAllureEpic } from "@helpers/allure";
 import { ShelleyWallet } from "@helpers/crypto";
-import { downloadMetadata } from "@helpers/metadata";
 import { createNewPageWithWallet } from "@helpers/page";
 import { waitForTxConfirmation } from "@helpers/transaction";
 import DRepRegistrationPage from "@pages/dRepRegistrationPage";
 import GovernanceActionsPage from "@pages/governanceActionsPage";
-import { Download, expect } from "@playwright/test";
-import metadataBucketService from "@services/metadataBucketService";
+import { expect } from "@playwright/test";
 import walletManager from "lib/walletManager";
 
 test.beforeEach(async () => {
@@ -169,7 +167,7 @@ test.describe("Temporary DReps", () => {
       .getByTestId("confirm-modal-button")
       .click();
 
-    await expect(dRepPage.getByTestId("alert-warning")).toHaveText(
+    await expect(dRepPage.getByTestId("d-rep-in-progress")).toHaveText(
       /in progress/i
     );
   });

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -106,7 +106,7 @@ test.describe("Temporary DReps", () => {
 
     await expect(
       dRepPage.getByTestId("retirement-transaction-submitted-modal")
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 15_000 });
   });
 
   test("3K. Verify DRep behavior in retired state", async ({
@@ -129,7 +129,7 @@ test.describe("Temporary DReps", () => {
     await dRepPage.getByTestId("continue-retirement-button").click();
     await expect(
       dRepPage.getByTestId("retirement-transaction-submitted-modal")
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 15_000 });
     dRepPage.getByTestId("confirm-modal-button").click();
 
     await waitForTxConfirmation(dRepPage);

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -31,13 +31,13 @@ test.describe("Logged in DReps", () => {
       page.getByTestId("dRep-id-display-card-dashboard")
     ).toContainText(dRep01Wallet.dRepId);
 
-    await page.goto(`${environments.frontendUrl}/governance_actions`);
-    await page
-      .locator('[data-testid^="govaction-"][data-testid$="-view-detail"]')
-      .first()
-      .click();
+    const governanceActionsPage = new GovernanceActionsPage(page);
 
-    await expect(page.getByTestId("vote-button")).toBeVisible();
+    await governanceActionsPage.goto();
+    const governanceActionDetailsPage =
+      await governanceActionsPage.viewFirstInfoProposal();
+
+    await expect(governanceActionDetailsPage.voteBtn).toBeVisible();
   });
 
   test("3H. Should Update DRep data", async ({ page }, testInfo) => {

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
@@ -142,7 +142,7 @@ test("3F. Should create proper DRep registration request, when registered with d
   await dRepRegistrationPage.registerWithoutTxConfirmation({ name: "Test" });
   await expect(
     page.getByTestId("registration-transaction-error-modal")
-  ).toBeVisible();
+  ).toBeVisible({ timeout: 10_000 });
 });
 
 test("3O. Should reject invalid dRep registration metadata", async ({

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
@@ -110,7 +110,7 @@ test.describe("Validation of dRep Registration Form", () => {
 
     await dRepRegistrationPage.continueBtn.click();
     await page.getByRole("checkbox").click();
-    await dRepRegistrationPage.continueBtn.click();
+    await dRepRegistrationPage.registerBtn.click();
 
     for (let i = 0; i < 100; i++) {
       await dRepRegistrationPage.metadataUrlInput.fill(mockInvalid.url());

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
@@ -69,12 +69,14 @@ test.describe("Validation of dRep Registration Form", () => {
     await dRepRegistrationPage.goto();
 
     for (let i = 0; i < 100; i++) {
-      await dRepRegistrationPage.inValidateForm(
-        mockInvalid.name(),
-        mockInvalid.email(),
-        faker.lorem.paragraph(40),
-        mockInvalid.url()
-      );
+      await dRepRegistrationPage.inValidateForm({
+        name: mockInvalid.name(),
+        objectives: faker.lorem.paragraph(40),
+        motivations: faker.lorem.paragraph(40),
+        qualifications: faker.lorem.paragraph(40),
+        paymentAddress: faker.string.alphanumeric(45),
+        extraContentLinks: [mockInvalid.url()],
+      });
     }
   });
 

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
@@ -2,6 +2,7 @@ import { user01Wallet } from "@constants/staticWallets";
 import { faker } from "@faker-js/faker";
 import { test } from "@fixtures/walletExtension";
 import { setAllureEpic } from "@helpers/allure";
+import { ShelleyWallet } from "@helpers/crypto";
 import { invalid as mockInvalid } from "@mock/index";
 import DRepRegistrationPage from "@pages/dRepRegistrationPage";
 import { expect } from "@playwright/test";
@@ -43,12 +44,14 @@ test.describe("Validation of dRep Registration Form", () => {
     await dRepRegistrationPage.goto();
 
     for (let i = 0; i < 100; i++) {
-      await dRepRegistrationPage.validateForm(
-        faker.internet.displayName(),
-        faker.internet.email(),
-        faker.lorem.paragraph(),
-        faker.internet.url()
-      );
+      await dRepRegistrationPage.validateForm({
+        name: faker.internet.displayName(),
+        objectives: faker.lorem.paragraph(2),
+        motivations: faker.lorem.paragraph(2),
+        qualifications: faker.lorem.paragraph(2),
+        paymentAddress: (await ShelleyWallet.generate()).addressBech32(0),
+        extraContentLinks: [faker.internet.url()],
+      });
     }
 
     for (let i = 0; i < 6; i++) {

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
@@ -27,9 +27,10 @@ test("3D. Verify DRep registration form", async ({ page }) => {
   await dRepRegistrationPage.goto();
 
   await expect(dRepRegistrationPage.nameInput).toBeVisible();
-  await expect(dRepRegistrationPage.emailInput).toBeVisible();
-  await expect(dRepRegistrationPage.bioInput).toBeVisible();
-  await expect(dRepRegistrationPage.linkInput).toBeVisible();
+  await expect(dRepRegistrationPage.objectivesInput).toBeVisible();
+  await expect(dRepRegistrationPage.motivationsInput).toBeVisible();
+  await expect(dRepRegistrationPage.qualificationsInput).toBeVisible();
+  await expect(dRepRegistrationPage.paymentAddressInput).toBeVisible();
   await expect(dRepRegistrationPage.addLinkBtn).toBeVisible();
   await expect(dRepRegistrationPage.continueBtn).toBeVisible();
 });

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
@@ -91,7 +91,7 @@ test.describe("Validation of dRep Registration Form", () => {
 
     await dRepRegistrationPage.continueBtn.click();
     await page.getByRole("checkbox").click();
-    await dRepRegistrationPage.continueBtn.click();
+    await dRepRegistrationPage.registerBtn.click();
 
     for (let i = 0; i < 100; i++) {
       await dRepRegistrationPage.metadataUrlInput.fill(faker.internet.url());
@@ -156,11 +156,11 @@ test("3O. Should reject invalid dRep registration metadata", async ({
 
   await dRepRegistrationPage.continueBtn.click();
   await page.getByRole("checkbox").click();
-  await dRepRegistrationPage.continueBtn.click();
+  await dRepRegistrationPage.registerBtn.click();
 
   const invalidMetadataAnchor = "https://www.google.com";
   await dRepRegistrationPage.metadataUrlInput.fill(invalidMetadataAnchor);
-  await dRepRegistrationPage.registerBtn.click();
+  await dRepRegistrationPage.submitBtn.click();
 
   await expect(dRepRegistrationPage.metadataErrorModal).toHaveText(
     /your external data does not/i

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
@@ -70,7 +70,7 @@ test.describe("Validation of edit dRep Form", () => {
 
     await editDRepPage.continueBtn.click();
     await page.getByRole("checkbox").click();
-    await editDRepPage.continueBtn.click();
+    await editDRepPage.registerBtn.click();
 
     for (let i = 0; i < 100; i++) {
       await editDRepPage.metadataUrlInput.fill(faker.internet.url());
@@ -89,7 +89,7 @@ test.describe("Validation of edit dRep Form", () => {
 
     await editDRepPage.continueBtn.click();
     await page.getByRole("checkbox").click();
-    await editDRepPage.continueBtn.click();
+    await editDRepPage.registerBtn.click();
 
     for (let i = 0; i < 100; i++) {
       await editDRepPage.metadataUrlInput.fill(mockInvalid.url());
@@ -119,11 +119,11 @@ test("3P. Should reject invalid edit dRep metadata", async ({ page }) => {
 
   await editDRepPage.continueBtn.click();
   await page.getByRole("checkbox").click();
-  await editDRepPage.continueBtn.click();
+  await editDRepPage.registerBtn.click();
 
   const invalidMetadataAnchor = "https://www.google.com";
   await editDRepPage.metadataUrlInput.fill(invalidMetadataAnchor);
-  await editDRepPage.continueBtn.click();
+  await editDRepPage.submitBtn.click();
 
   await expect(page.getByTestId("modal")).toHaveText(
     /your external data does not/i

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
@@ -2,6 +2,7 @@ import { dRep02Wallet } from "@constants/staticWallets";
 import { faker } from "@faker-js/faker";
 import { test } from "@fixtures/walletExtension";
 import { setAllureEpic } from "@helpers/allure";
+import { ShelleyWallet } from "@helpers/crypto";
 import { invalid as mockInvalid } from "@mock/index";
 import EditDRepPage from "@pages/editDRepPage";
 import { expect } from "@playwright/test";
@@ -23,12 +24,14 @@ test.describe("Validation of edit dRep Form", () => {
     await page.waitForTimeout(5_000);
 
     for (let i = 0; i < 100; i++) {
-      await editDRepPage.validateForm(
-        faker.internet.displayName(),
-        faker.internet.email(),
-        faker.lorem.paragraph(),
-        faker.internet.url()
-      );
+      await editDRepPage.validateForm({
+        name: faker.internet.displayName(),
+        objectives: faker.lorem.paragraph(2),
+        motivations: faker.lorem.paragraph(2),
+        qualifications: faker.lorem.paragraph(2),
+        paymentAddress: (await ShelleyWallet.generate()).addressBech32(0),
+        extraContentLinks: [faker.internet.url()],
+      });
     }
 
     for (let i = 0; i < 6; i++) {
@@ -50,12 +53,14 @@ test.describe("Validation of edit dRep Form", () => {
     await page.waitForTimeout(3_000); // wait until dRep information load properly
 
     for (let i = 0; i < 100; i++) {
-      await editDRepPage.inValidateForm(
-        mockInvalid.name(),
-        mockInvalid.email(),
-        faker.lorem.paragraph(40),
-        mockInvalid.url()
-      );
+      await editDRepPage.inValidateForm({
+        name: mockInvalid.name(),
+        objectives: faker.lorem.paragraph(40),
+        motivations: faker.lorem.paragraph(40),
+        qualifications: faker.lorem.paragraph(40),
+        paymentAddress: faker.string.alphanumeric(45),
+        extraContentLinks: [mockInvalid.url()],
+      });
     }
   });
 

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
@@ -103,17 +103,56 @@ test.describe("Check vote count", () => {
     await expect(
       page
         .getByText("yes₳")
-        .getByText(`₳ ${lovelaceToAda(proposalToCheck.yesVotes)}`)
+        .first()
+        .getByText(`₳ ${lovelaceToAda(proposalToCheck.dRepYesVotes)}`)
     ).toBeVisible();
     await expect(
       page
         .getByText("abstain₳")
-        .getByText(`₳ ${lovelaceToAda(proposalToCheck.abstainVotes)}`)
+        .first()
+        .getByText(`₳ ${lovelaceToAda(proposalToCheck.dRepAbstainVotes)}`)
     ).toBeVisible();
     await expect(
       page
         .getByText("no₳")
-        .getByText(`₳ ${lovelaceToAda(proposalToCheck.noVotes)}`)
+        .first()
+        .getByText(`₳ ${lovelaceToAda(proposalToCheck.dRepNoVotes)}`)
+    ).toBeVisible();
+    await expect(
+      page
+        .getByText("yes₳")
+        .nth(1)
+        .getByText(`₳ ${lovelaceToAda(proposalToCheck.poolYesVotes)}`)
+    ).toBeVisible();
+    await expect(
+      page
+        .getByText("abstain₳")
+        .nth(1)
+        .getByText(`₳ ${lovelaceToAda(proposalToCheck.poolAbstainVotes)}`)
+    ).toBeVisible();
+    await expect(
+      page
+        .getByText("no₳")
+        .nth(1)
+        .getByText(`₳ ${lovelaceToAda(proposalToCheck.poolNoVotes)}`)
+    ).toBeVisible();
+    await expect(
+      page
+        .getByText("yes₳")
+        .nth(2)
+        .getByText(`₳ ${lovelaceToAda(proposalToCheck.ccYesVotes)}`)
+    ).toBeVisible();
+    await expect(
+      page
+        .getByText("abstain₳")
+        .nth(2)
+        .getByText(`₳ ${lovelaceToAda(proposalToCheck.ccAbstainVotes)}`)
+    ).toBeVisible();
+    await expect(
+      page
+        .getByText("no₳")
+        .nth(2)
+        .getByText(`₳ ${lovelaceToAda(proposalToCheck.ccNoVotes)}`)
     ).toBeVisible();
   });
 });

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.loggedin.spec.ts
@@ -102,7 +102,7 @@ test("4C_2. Should sort Governance Action Type on governance actions page", asyn
 
   await govActionsPage.sortAndValidate(
     SortOption.HighestYesVotes,
-    (p1, p2) => p1.yesVotes >= p2.yesVotes
+    (p1, p2) => p1.dRepYesVotes >= p2.dRepYesVotes
   );
 });
 

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.spec.ts
@@ -56,16 +56,55 @@ test("4K. Should display correct vote counts on governance details page for disc
   await expect(
     page
       .getByText("yes₳")
-      .getByText(`₳ ${lovelaceToAda(proposalToCheck.yesVotes)}`)
+      .first()
+      .getByText(`₳ ${lovelaceToAda(proposalToCheck.dRepYesVotes)}`)
   ).toBeVisible();
   await expect(
     page
       .getByText("abstain₳")
-      .getByText(`₳ ${lovelaceToAda(proposalToCheck.abstainVotes)}`)
+      .first()
+      .getByText(`₳ ${lovelaceToAda(proposalToCheck.dRepAbstainVotes)}`)
   ).toBeVisible();
   await expect(
     page
       .getByText("no₳")
-      .getByText(`₳ ${lovelaceToAda(proposalToCheck.noVotes)}`)
+      .first()
+      .getByText(`₳ ${lovelaceToAda(proposalToCheck.dRepNoVotes)}`)
+  ).toBeVisible();
+  await expect(
+    page
+      .getByText("yes₳")
+      .nth(1)
+      .getByText(`₳ ${lovelaceToAda(proposalToCheck.poolYesVotes)}`)
+  ).toBeVisible();
+  await expect(
+    page
+      .getByText("abstain₳")
+      .nth(1)
+      .getByText(`₳ ${lovelaceToAda(proposalToCheck.poolAbstainVotes)}`)
+  ).toBeVisible();
+  await expect(
+    page
+      .getByText("no₳")
+      .nth(1)
+      .getByText(`₳ ${lovelaceToAda(proposalToCheck.poolNoVotes)}`)
+  ).toBeVisible();
+  await expect(
+    page
+      .getByText("yes₳")
+      .nth(2)
+      .getByText(`₳ ${lovelaceToAda(proposalToCheck.ccYesVotes)}`)
+  ).toBeVisible();
+  await expect(
+    page
+      .getByText("abstain₳")
+      .nth(2)
+      .getByText(`₳ ${lovelaceToAda(proposalToCheck.ccAbstainVotes)}`)
+  ).toBeVisible();
+  await expect(
+    page
+      .getByText("no₳")
+      .nth(2)
+      .getByText(`₳ ${lovelaceToAda(proposalToCheck.ccNoVotes)}`)
   ).toBeVisible();
 });

--- a/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
@@ -228,7 +228,7 @@ test.describe("Check voting power", () => {
     await dRepPage.getByTestId("continue-retirement-button").click();
     await expect(
       dRepPage.getByTestId("retirement-transaction-submitted-modal")
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 15_000 });
     dRepPage.getByTestId("confirm-modal-button").click();
     await waitForTxConfirmation(dRepPage);
 

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.loggedin.spec.ts
@@ -43,30 +43,26 @@ test.describe("Logged in user", () => {
 
     const [registerLearnMorepage] = await Promise.all([
       context.waitForEvent("page"),
-      page.getByTestId("register-learn-more-button").click(),
+      page.getByTestId("d-rep-learn-more-button").click(),
     ]);
     await expect(registerLearnMorepage).toHaveURL(REGISTER_DREP_DOC_URL);
 
     const [directVoterLearnMorepage] = await Promise.all([
       context.waitForEvent("page"),
-      page.getByTestId("learn-more-button").first().click(), // BUG should be unique test id
+      page.getByTestId("direct-voter-learn-more-button").first().click(),
     ]);
     await expect(directVoterLearnMorepage).toHaveURL(DIRECT_VOTER_DOC_URL);
 
     const [GA_LearnMorepage] = await Promise.all([
       context.waitForEvent("page"),
-      page.getByTestId("learn-more-governance-actions-button").click(),
+      page.getByTestId("list-gov-actions-learn-more-button").click(),
     ]);
     await expect(GA_LearnMorepage).toHaveURL(GOVERNANCE_ACTION_DOC_URL);
 
     const [proposed_GA_VoterLearnMorepage] = await Promise.all([
       context.waitForEvent("page"),
-      page
-        .locator("div")
-        .filter({ hasText: /^ProposeLearn more$/ })
-        .getByTestId("learn-more-button")
-        .click(),
-    ]); // BUG should be unique test id
+      page.getByTestId("propose-gov-action-learn-more-button").click(),
+    ]);
     await expect(proposed_GA_VoterLearnMorepage).toHaveURL(
       PROPOSE_GOVERNANCE_ACTION_DOC_URL
     );

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
@@ -69,13 +69,13 @@ test("6D. Should open Sanchonet docs in a new tab when clicking `Learn More` on 
 
   const [registerLearnMorepage] = await Promise.all([
     context.waitForEvent("page"),
-    page.getByTestId("register-learn-more-button").click(),
+    page.getByTestId("d-rep-learn-more-button").click(),
   ]);
   await expect(registerLearnMorepage).toHaveURL(REGISTER_DREP_DOC_URL);
 
   const [directVoterLearnMorepage] = await Promise.all([
     context.waitForEvent("page"),
-    page.getByTestId("lear-more-about-sole-voter-button").click(),
+    page.getByTestId("direct-voter-learn-more-button").click(),
   ]);
   await expect(directVoterLearnMorepage).toHaveURL(DIRECT_VOTER_DOC_URL);
 });
@@ -91,7 +91,7 @@ test("6M. Should navigate between footer links", async ({ page, context }) => {
 
   const [termsAndConditions] = await Promise.all([
     context.waitForEvent("page"),
-    page.getByTestId("term-of-service-footer-link").click(),
+    page.getByTestId("terms-and-conditions-footer-link").click(),
   ]);
   await expect(termsAndConditions).toHaveURL(TERMS_AND_CONDITIONS);
 

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
@@ -136,7 +136,6 @@ test.describe("User Snap", () => {
     ).toBeVisible();
     await expect(page.getByPlaceholder("Your feedback")).toBeVisible();
     await expect(page.getByText("Drag & drop or Browse")).toBeVisible();
-    await expect(page.getByPlaceholder("someone@something.com")).toBeVisible();
     await expect(page.getByLabel("Take screenshot")).toBeVisible();
     await expect(page.getByLabel("Record")).toBeVisible();
     await expect(page.getByRole("button", { name: "Submit" })).toBeVisible();
@@ -155,10 +154,14 @@ test.describe("User Snap", () => {
     await expect(
       page.getByPlaceholder("Example: New navigation")
     ).toBeVisible();
-    await expect(page.getByLabel("Any additional details")).toBeVisible();
+    await expect(
+      page.getByPlaceholder("Example: New navigation")
+    ).toBeVisible();
     await expect(page.getByLabel("Any additional details")).toBeVisible();
     await expect(page.getByText("Drag & drop or Browse")).toBeVisible();
-    await expect(page.getByPlaceholder("someone@something.com")).toBeVisible();
+    await expect(
+      page.getByLabel("Please summarize your idea or")
+    ).toBeVisible();
     await expect(page.getByLabel("Take screenshot")).toBeVisible();
     await expect(page.getByLabel("Record")).toBeVisible();
     await expect(page.getByRole("button", { name: "Submit" })).toBeVisible();
@@ -188,9 +191,6 @@ test.describe("User Snap", () => {
         .getByPlaceholder("Your feedback")
         .fill(faker.lorem.paragraph(2));
       await page.setInputFiles(attachmentInputSelector, [mockAttachmentPath]);
-      await page
-        .getByPlaceholder("someone@something.com")
-        .fill(faker.internet.email());
 
       await page.getByRole("button", { name: "Submit" }).click();
 
@@ -221,9 +221,6 @@ test.describe("User Snap", () => {
         .getByLabel("Any additional details")
         .fill(faker.lorem.paragraph(2));
       await page.setInputFiles(attachmentInputSelector, [mockAttachmentPath]);
-      await page
-        .getByPlaceholder("someone@something.com")
-        .fill(faker.internet.email());
 
       await page.getByRole("button", { name: "Submit" }).click();
 


### PR DESCRIPTION
## List of changes

- Modified the dRep registration/edit test to align with the new registration form fields.
- Modified dRep registration mock metadata to align with the new registration form fields.
- Updated the "Learn More" documentation URL.
- Added CC SPO voting power visibility on the governance action details page visibility test.
- Bumped the Cardano test wallet version to 2.1.1.
- Extended the timeout for the retirement and retired dRep popup model, as it is taking more time to display.
- Fixed the failing Usersnap test.


## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
