### PR TITLE
[#1877] fix: incorrect documentation link on proposal learn more button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ changes.
 
 ### Fixed
 
--
+- Fix incorrect documentation link for "Learn More" button on proposal [Issue 1877](https://github.com/IntersectMBO/govtool/issues/1877)
 
 ### Changed
 

--- a/govtool/frontend/src/components/organisms/DashboardCards/ProposeGovActionDashboardCard.tsx
+++ b/govtool/frontend/src/components/organisms/DashboardCards/ProposeGovActionDashboardCard.tsx
@@ -54,7 +54,7 @@ export const ProposeGovActionDashboardCard = ({
           dataTestId: "propose-gov-action-learn-more-button",
           onClick: () =>
             openInNewTab(
-              "https://docs.gov.tools/using-govtool/govtool-functions/governance-actions/view-governance-actions/propose-a-governance-action",
+              "https://docs.gov.tools/using-govtool/govtool-functions/governance-actions/propose-a-governance-action",
             ),
         },
       ]}


### PR DESCRIPTION
## List of changes

- Fix incorrect documentation link on proposal learn more button

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1877)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
