### PR TITLE
[#1925] query time from vote tx instead of gov action tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ changes.
 ### Fixed
 
 - Fix incorrect documentation link for "Learn More" button on proposal [Issue 1877](https://github.com/IntersectMBO/govtool/issues/1877)
+- Fix getVotes sql to query time from vote tx instead of govAaction tx [Issue 1925](https://github.com/IntersectMBO/govtool/issues/1925)
 
 ### Changed
 

--- a/govtool/backend/sql/get-votes.sql
+++ b/govtool/backend/sql/get-votes.sql
@@ -11,6 +11,6 @@ on gov_action_tx.id = gov_action_proposal.tx_id
 join tx as vote_tx
 on vote_tx.id = voting_procedure.tx_id
 join block
-on block.id = gov_action_tx.block_id
+on block.id = vote_tx.block_id
 where drep_hash.raw = decode(?, 'hex')
 order by voting_procedure.gov_action_proposal_id, voting_procedure.drep_voter, voting_procedure.id desc


### PR DESCRIPTION
## List of changes

- Fix getVotes sql to query time from vote tx instead of govAaction tx

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1925)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
