### PR TITLE
[#1924] map references from validation service to format expected by FE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ changes.
 
 - Fix incorrect documentation link for "Learn More" button on proposal [Issue 1877](https://github.com/IntersectMBO/govtool/issues/1877)
 - Fix getVotes sql to query time from vote tx instead of govAaction tx [Issue 1925](https://github.com/IntersectMBO/govtool/issues/1925)
+- Map references from validation service to format expected by FE [Issue 1924](https://github.com/IntersectMBO/govtool/issues/1924)
 
 ### Changed
 

--- a/govtool/frontend/src/models/metadataValidation.ts
+++ b/govtool/frontend/src/models/metadataValidation.ts
@@ -31,6 +31,6 @@ export type ProposalMetadata = {
   abstract?: string;
   motivation?: string;
   rationale?: string;
-  references?: string[];
+  references?: Reference[];
   title?: string;
 };

--- a/govtool/frontend/src/utils/mapDtoToProposal.ts
+++ b/govtool/frontend/src/utils/mapDtoToProposal.ts
@@ -16,7 +16,7 @@ export const mapDtoToProposal = async (
       abstract: validationResponse.metadata?.abstract,
       motivation: validationResponse.metadata?.motivation,
       rationale: validationResponse.metadata?.rationale,
-      references: validationResponse.metadata?.references,
+      references: validationResponse.metadata?.references?.map(({ uri }) => uri),
       metadataStatus: validationResponse.status || null,
       metadataValid: validationResponse.valid,
     };


### PR DESCRIPTION
## List of changes

- Fix runtime error in GA details with links by mapping references from validation service to format expected by FE

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1924)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
