### PR TITLE
fix(#1934): make displaying own DRep in DRep directory available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ changes.
 
 ### Changed
 
--
+- Make displaying own DRep in DRep directory available [Issue 1934](https://github.com/IntersectMBO/govtool/issues/1934)
 
 ### Removed
 

--- a/govtool/frontend/src/pages/DRepDirectoryContent.tsx
+++ b/govtool/frontend/src/pages/DRepDirectoryContent.tsx
@@ -208,27 +208,19 @@ export const DRepDirectoryContent: FC<DRepDirectoryContentProps> = ({
           }}
         >
           {dRepList?.length === 0 && <EmptyStateDrepDirectory />}
-          {dRepListToDisplay?.map((dRep) => {
-            if (
-              isSameDRep(dRep, myDrep?.view) ||
-              isSameDRep(dRep, inProgressDelegation)
-            ) {
-              return null;
-            }
-            return (
-              <Box key={dRep.drepId} component="li" sx={{ listStyle: "none" }}>
-                <DRepCard
-                  dRep={dRep}
-                  isConnected={!!isConnected}
-                  isDelegationLoading={
-                    isDelegating === dRep.view || isDelegating === dRep.drepId
-                  }
-                  isMe={isSameDRep(dRep, myDRepId)}
-                  onDelegate={() => delegate(dRep.drepId)}
-                />
-              </Box>
-            );
-          })}
+          {dRepListToDisplay?.map((dRep) => (
+            <Box key={dRep.drepId} component="li" sx={{ listStyle: "none" }}>
+              <DRepCard
+                dRep={dRep}
+                isConnected={!!isConnected}
+                isDelegationLoading={
+                  isDelegating === dRep.view || isDelegating === dRep.drepId
+                }
+                isMe={isSameDRep(dRep, myDRepId)}
+                onDelegate={() => delegate(dRep.drepId)}
+              />
+            </Box>
+          ))}
         </Box>
       </>
       {dRepListHasNextPage && dRepList.length >= 10 && (


### PR DESCRIPTION
## List of changes

- make displaying own DRep in DRep directory available

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1934)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
