### PR TITLE
[#1928] make testIds for references in DRep form unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ changes.
 
 ### Fixed
 
--
+- Make testIds for link and identity references in drep form unique [Issue 1928](https://github.com/IntersectMBO/govtool/issues/1928)
 
 ### Changed
 

--- a/govtool/frontend/src/components/molecules/DRepDataForm.tsx
+++ b/govtool/frontend/src/components/molecules/DRepDataForm.tsx
@@ -232,6 +232,7 @@ const ReferencesSection = ({
             label={t("forms.dRepData.referenceDescription")}
             name={`${fieldName}.${index}.label`}
             helpfulText={t("forms.dRepData.referenceDescriptionHelpfulText")}
+            dataTestId={`${type}-reference-description-${index + 1}-input`}
             rules={Rules.LINK_DESCRIPTION}
           />
           <ControlledField.Input
@@ -250,13 +251,14 @@ const ReferencesSection = ({
             label={t("forms.dRepData.referenceURL")}
             layoutStyles={{ mb: 3 }}
             name={`${fieldName}.${index}.uri`}
+            dataTestId={`${type}-reference-url-${index + 1}-input`}
             rules={Rules.LINK_URL}
           />
         </Fragment>
       ))}
       {references?.length < MAX_NUMBER_OF_LINKS ? (
         <Button
-          data-testid="add-link-button"
+          data-testid={`add-${type}-reference-button`}
           onClick={addLink}
           size="extraLarge"
           variant="text"

--- a/govtool/frontend/src/components/organisms/DRepDetailsCard.tsx
+++ b/govtool/frontend/src/components/organisms/DRepDetailsCard.tsx
@@ -311,6 +311,9 @@ const ReferencesLink = ({ label, uri }: ReferenceItem) => (
       sx={{
         overflow: "hidden",
         textOverflow: "ellipsis",
+        display: "flex",
+        gap: 1,
+        alignItems: "center",
       }}
     >
       <Typography


### PR DESCRIPTION
## List of changes

- Fix duplicate testIds for link and identity references in DRep form

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1928)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
