### PR TITLE
[#1940] add doNotList as accepted key on DRep registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ changes.
 ### Fixed
 
 - Make testIds for link and identity references in drep form unique [Issue 1928](https://github.com/IntersectMBO/govtool/issues/1928)
+- Fix saving the Do Not List checkbox value on DRep registration [Issue 1940](https://github.com/IntersectMBO/govtool/issues/1940)
 
 ### Changed
 

--- a/govtool/frontend/src/hooks/forms/useRegisterAsdRepForm.tsx
+++ b/govtool/frontend/src/hooks/forms/useRegisterAsdRepForm.tsx
@@ -106,6 +106,7 @@ export const useRegisterAsdRepForm = (
         "qualifications",
         "paymentAddress",
         "references",
+        "doNotList",
       ],
       standardReference: CIP_119,
     });


### PR DESCRIPTION
## List of changes

- Fix saving the Do Not List checkbox value on DRep registration

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1940)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
