### PR TITLE
Bugfix/delegation-test

### DIFF
--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
@@ -48,10 +48,15 @@ test.describe("Delegate to others", () => {
 
     // Verify dRepId in dRep directory
     await expect(
-      page.getByTestId(`${dRepId}-delegate-button')`)
+      page.getByTestId(`${dRepId}-delegate-button`)
     ).not.toBeVisible();
 
-    await expect(page.getByTestId(`${dRepId}-copy-id-button`)).toHaveCount(1, {
+    await expect(page.getByTestId(`${dRepId}-delegated-card`)).toBeVisible();
+    await expect(
+      page
+        .getByTestId(`${dRepId}-delegated-card`)
+        .getByTestId(`${dRepId}-copy-id-button`)
+    ).toHaveCount(1, {
       timeout: 20_000,
     });
 

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
@@ -104,16 +104,28 @@ test.describe("Change delegation", () => {
     const dRepDirectoryPage = new DRepDirectoryPage(page);
     await dRepDirectoryPage.goto();
     await dRepDirectoryPage.delegateToDRep(dRepIdFirst);
-    await expect(page.getByTestId(`${dRepIdFirst}-copy-id-button`)).toHaveText(
-      dRepIdFirst,
-      { timeout: 20_000 }
-    ); // verify delegation
 
+    // verify delegation
+    await expect(
+      page.getByTestId(`${dRepIdFirst}-delegated-card`)
+    ).toBeVisible();
+
+    await expect(
+      page
+        .getByTestId(`${dRepIdFirst}-delegated-card`)
+        .getByTestId(`${dRepIdFirst}-copy-id-button`)
+    ).toHaveText(dRepIdFirst, { timeout: 20_000 });
+
+    // verify delegation
     await dRepDirectoryPage.delegateToDRep(dRepIdSecond);
-    await expect(page.getByTestId(`${dRepIdSecond}-copy-id-button`)).toHaveText(
-      dRepIdSecond,
-      { timeout: 20_000 }
-    ); // verify delegation
+    await expect(
+      page.getByTestId(`${dRepIdSecond}-delegated-card`)
+    ).toBeVisible();
+    await expect(
+      page
+        .getByTestId(`${dRepIdSecond}-delegated-card`)
+        .getByTestId(`${dRepIdSecond}-copy-id-button`)
+    ).toHaveText(dRepIdSecond, { timeout: 20_000 });
   });
 });
 


### PR DESCRIPTION
## List of changes

- Fix the issue in test 2F, caused by multiple dRep cards being visible in the dRep directory after delegation.
- Correct the testid of assertion for the delegate button in test 2A.
- Update the assertion for the copy ID button on the used delegate card.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
