### PR TITLE
[#1982] hide Delegate button if already delegated to this DRep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ changes.
 ### Fixed
 
 - Fixed terms and conditions link [Issue 1968](https://github.com/IntersectMBO/govtool/issues/1968)
+- Hide Delegate button in DRep list and details if user has already delegated to this DRep [Issue 1982](https://github.com/IntersectMBO/govtool/issues/1982)
 
 ### Changed
 

--- a/govtool/frontend/src/components/organisms/DRepCard.tsx
+++ b/govtool/frontend/src/components/organisms/DRepCard.tsx
@@ -19,6 +19,7 @@ type DRepCardProps = {
   isDelegationLoading?: boolean;
   isInProgress?: boolean;
   isMe?: boolean;
+  isMyDrep?: boolean;
   onDelegate?: () => void;
 };
 
@@ -28,6 +29,7 @@ export const DRepCard = ({
   isDelegationLoading,
   isInProgress,
   isMe,
+  isMyDrep,
   onDelegate,
 }: DRepCardProps) => {
   const navigate = useNavigate();
@@ -209,6 +211,7 @@ export const DRepCard = ({
           {status === "Active" &&
             isConnected &&
             onDelegate &&
+            !isMyDrep &&
             !isInProgress && (
               <Button
                 data-testid={`${view}-delegate-button`}

--- a/govtool/frontend/src/components/organisms/DRepDetailsCard.tsx
+++ b/govtool/frontend/src/components/organisms/DRepDetailsCard.tsx
@@ -13,13 +13,17 @@ import { DRepDetailsCardHeader } from "./DRepDetailsCardHeader";
 type DRepDetailsProps = {
   dRepData: DRepData;
   isConnected: boolean;
-  variant?: "default" | "meAsDRep" | "myDRep" | "myDRepInProgress";
+  isMe?: boolean;
+  isMyDrep?: boolean;
+  isMyDrepInProgress?: boolean;
 };
 
 export const DRepDetailsCard = ({
   dRepData,
   isConnected,
-  variant,
+  isMe,
+  isMyDrep,
+  isMyDrepInProgress,
 }: DRepDetailsProps) => {
   const { pendingTransaction } = useCardano();
   const { t } = useTranslation();
@@ -39,10 +43,6 @@ export const DRepDetailsCard = ({
     view,
     votingPower,
   } = dRepData;
-
-  const isMe = variant === "meAsDRep";
-  const isMyDrep = variant === "myDRep";
-  const isMyDrepInProgress = variant === "myDRepInProgress";
 
   const groupedReferences = references?.reduce<Record<string, Reference[]>>(
     (acc, reference) => {
@@ -85,7 +85,11 @@ export const DRepDetailsCard = ({
           gap: 2,
         }}
       >
-        <DRepDetailsCardHeader dRepData={dRepData} variant={variant} />
+        <DRepDetailsCardHeader
+          dRepData={dRepData}
+          isMe={isMe}
+          isMyDrep={isMyDrep}
+        />
         {/* ERROR MESSAGES */}
         {metadataStatus && (
           <DataMissingInfoBox

--- a/govtool/frontend/src/components/organisms/DRepDetailsCardHeader.tsx
+++ b/govtool/frontend/src/components/organisms/DRepDetailsCardHeader.tsx
@@ -15,12 +15,14 @@ import { DRepData } from "@/models";
 
 type DRepDetailsProps = {
   dRepData: DRepData;
-  variant?: "default" | "meAsDRep" | "myDRep" | "myDRepInProgress";
+  isMe?: boolean;
+  isMyDrep?: boolean;
 };
 
 export const DRepDetailsCardHeader = ({
   dRepData,
-  variant,
+  isMe,
+  isMyDrep,
 }: DRepDetailsProps) => {
   const { stakeKey } = useCardano();
   const { t } = useTranslation();
@@ -36,9 +38,6 @@ export const DRepDetailsCardHeader = ({
       state: dRepData,
     });
   };
-
-  const isMe = variant === "meAsDRep";
-  const isMyDrep = variant === "myDRep";
 
   return (
     <div>
@@ -60,7 +59,9 @@ export const DRepDetailsCardHeader = ({
             color="primary"
             label={
               isMe
-                ? t("dRepDirectory.meAsDRep")
+                ? isMyDrep
+                  ? t("dRepDirectory.myDelegationToYourself")
+                  : t("dRepDirectory.meAsDRep")
                 : t("dRepDirectory.myDRep", {
                     ada: correctDRepDirectoryFormat(myVotingPower),
                   })

--- a/govtool/frontend/src/i18n/locales/en.ts
+++ b/govtool/frontend/src/i18n/locales/en.ts
@@ -267,6 +267,8 @@ export const en = {
       goToDRepDirectory: "Go to DRep Directory",
       meAsDRep: "This DRep ID is connected to your wallet",
       myDelegation: "You have delegated your voting power to:",
+      myDelegationToYourself:
+        "You have delegated your voting power to yourself:",
       myDRep: "You have delegated your voting power to this DRep.",
       listTitle: "Find a DRep",
       noConfidenceDefaultDescription:

--- a/govtool/frontend/src/pages/DRepDetails.tsx
+++ b/govtool/frontend/src/pages/DRepDetails.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { Box, CircularProgress } from "@mui/material";
 
@@ -31,20 +30,6 @@ export const DRepDetails = ({ isConnected = false }: DRepDetailsProps) => {
     searchPhrase: dRepParam,
   });
   const dRep = dRepData?.[0];
-
-  const dRepCardVariant = useMemo(() => {
-    if (!dRep) return "default";
-    if (isSameDRep(dRep, myDRepId)) return "meAsDRep";
-    if (isSameDRep(dRep, currentDelegation?.dRepView)) return "myDRep";
-    if (isSameDRep(dRep, pendingTransaction.delegate?.resourceId))
-      return "myDRepInProgress";
-    return "default";
-  }, [
-    currentDelegation,
-    dRep,
-    myDRepId,
-    pendingTransaction.delegate?.resourceId,
-  ]);
 
   if (isDRepListLoading)
     return (
@@ -99,7 +84,12 @@ export const DRepDetails = ({ isConnected = false }: DRepDetailsProps) => {
       <DRepDetailsCard
         isConnected={isConnected}
         dRepData={dRep}
-        variant={dRepCardVariant}
+        isMe={isSameDRep(dRep, myDRepId)}
+        isMyDrep={isSameDRep(dRep, currentDelegation?.dRepView)}
+        isMyDrepInProgress={isSameDRep(
+          dRep,
+          pendingTransaction.delegate?.resourceId,
+        )}
       />
     </>
   );

--- a/govtool/frontend/src/pages/DRepDirectoryContent.tsx
+++ b/govtool/frontend/src/pages/DRepDirectoryContent.tsx
@@ -217,6 +217,7 @@ export const DRepDirectoryContent: FC<DRepDirectoryContentProps> = ({
                   isDelegating === dRep.view || isDelegating === dRep.drepId
                 }
                 isMe={isSameDRep(dRep, myDRepId)}
+                isMyDrep={isSameDRep(dRep, currentDelegation?.dRepView)}
                 onDelegate={() => delegate(dRep.drepId)}
               />
             </Box>

--- a/govtool/frontend/src/stories/DRepDetailsCard.stories.ts
+++ b/govtool/frontend/src/stories/DRepDetailsCard.stories.ts
@@ -60,38 +60,42 @@ type Story = StoryObj<typeof meta>;
 
 export const MeAsDRep: Story = {
   args: {
-    variant: "meAsDRep",
+    isMe: true,
+    isMyDrep: false,
+  },
+};
+
+export const MeAsDRepDelegatedToMyself: Story = {
+  args: {
+    isMe: true,
+    isMyDrep: true,
   },
 };
 
 export const MyDRep: Story = {
   args: {
-    variant: "myDRep",
+    isMyDrep: true,
   },
 };
 
 export const MyDRepInProgress: Story = {
   args: {
-    variant: "myDRepInProgress",
+    isMyDrepInProgress: true,
   },
 };
 
 export const OtherDRep: Story = {
-  args: {
-    variant: "default",
-  },
+  args: {},
 };
 
 export const UserNotConnected: Story = {
   args: {
     isConnected: false,
-    variant: "default",
   },
 };
 
 export const InvalidData: Story = {
   args: {
-    variant: "default",
     dRepData: {
       ...meta.args.dRepData,
       metadataStatus: MetadataValidationStatus.INCORRECT_FORMAT,


### PR DESCRIPTION
## List of changes

- Hide Delegate button in DRep list and details if user has already delegated to this DRep

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1982)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
