### PR TITLE
[#1945] 💡 Bump DBSync versions to 13.5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ changes.
 
 ### Changed
 
+- Bump cardano-db-sync 13.5.0.2 [Issue 1945](https://github.com/IntersectMBO/govtool/issues/1945)
 -
 
 ### Removed

--- a/scripts/govtool/Makefile
+++ b/scripts/govtool/Makefile
@@ -12,7 +12,7 @@ include config.mk
 
 # image tags
 cardano_node_image_tag := 9.1.1
-cardano_db_sync_image_tag := 13.5.0.1
+cardano_db_sync_image_tag := 13.5.0.2
 
 .PHONY: all
 all: deploy-stack notify

--- a/scripts/govtool/custom-cardano-db-sync.Dockerfile
+++ b/scripts/govtool/custom-cardano-db-sync.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/intersectmbo/cardano-db-sync:13.5.0.1
+FROM ghcr.io/intersectmbo/cardano-db-sync:13.5.0.2
 
 COPY custom-cardano-db-sync.entrypoint.sh /usr/local/bin/custom-cardano-db-sync.entrypoint.sh
 RUN chmod +x /usr/local/bin/custom-cardano-db-sync.entrypoint.sh

--- a/scripts/govtool/docker-compose.node+dbsync.yml
+++ b/scripts/govtool/docker-compose.node+dbsync.yml
@@ -65,7 +65,7 @@ services:
       retries: 10
 
   cardano-db-sync:
-    image: ghcr.io/intersectmbo/cardano-db-sync:13.5.0.1
+    image: ghcr.io/intersectmbo/cardano-db-sync:13.5.0.2
     environment:
       - NETWORK=sanchonet
       - POSTGRES_HOST=postgres


### PR DESCRIPTION
The purpose of these changes is to upgrade the Cardano DB Sync version from 13.5.0.1 to 13.5.0.2 across various parts of the project. This upgrade is a proactive step to align with the latest node hotfix 9.1.1, ensuring that the app remains healthy and performs optimally after the hotfix is applied. The updates have been specifically made to address Issue 1945, underscoring the project's commitment to staying current with the latest version enhancements and bug fixes.

The outcome of these changes involves modifications to several files including `CHANGELOG.md`, `scripts/govtool/Makefile`, `scripts/govtool/custom-cardano-db-sync.Dockerfile`, and `scripts/govtool/docker-compose.node+dbsync.yml`. These changes ensure compatibility with the new features and fixes in version 13.5.0.2, enhancing the overall performance and stability of the project. By keeping dependencies up-to-date, we are securing a more robust and reliable application infrastructure.
