### PR TITLE
Feat/dRep-faucet teardown

### DIFF
--- a/tests/govtool-frontend/playwright/lib/constants/environments.ts
+++ b/tests/govtool-frontend/playwright/lib/constants/environments.ts
@@ -17,6 +17,7 @@ const environments = {
       process.env.FAUCET_API_URL ||
       "https://faucet.sanchonet.world.dev.cardano.org",
     apiKey: process.env.FAUCET_API_KEY || "",
+    address: process.env.FAUCET_ADDRESS || "addr_test1vz0ua2vyk7r4vufmpqh5v44awg8xff26hxlwyrt3uc67maqtql3kl",
   },
   kuber: {
     apiUrl: process.env.KUBER_API_URL || "https://kuber-govtool.cardanoapi.io",

--- a/tests/govtool-frontend/playwright/lib/services/kuberService.ts
+++ b/tests/govtool-frontend/playwright/lib/services/kuberService.ts
@@ -248,6 +248,24 @@ const kuberService = {
     return kuber.signAndSubmitTx(req);
   },
 
+  multipleDRepDeRegistration: (wallets: StaticWallet[]) => {
+    const kuber = new Kuber(faucetWallet.address, faucetWallet.payment.private);
+    const req = {
+      certificates: wallets.map((wallet) =>
+        Kuber.generateCert("deregisterdrep", wallet.stake.pkh)
+      ),
+      selections: wallets.map((wallet) => {
+        return {
+          type: "PaymentSigningKeyShelley_ed25519",
+          description: "Stake Signing Key",
+          cborHex: `5820${wallet.stake.private}`,
+        };
+      }),
+      inputs: faucetWallet.address,
+    };
+    return kuber.signAndSubmitTx(req);
+  },
+
   stakeDelegation: (
     addr: string,
     signingKey: string,

--- a/tests/govtool-frontend/playwright/lib/walletManager.ts
+++ b/tests/govtool-frontend/playwright/lib/walletManager.ts
@@ -5,7 +5,12 @@ const path = require("path");
 
 const baseFilePath = path.resolve(__dirname, "./_mock");
 
-export type Purpose = "registerDRep" | "registeredDRep" | "proposalSubmission";
+export type Purpose =
+  | "registerDRep"
+  | "registeredDRep"
+  | "proposalSubmission"
+  | "registerDRepCopy"
+  | "registeredDRepCopy";
 
 /**
  * WalletManager class is responsible for managing a list of temporary wallets.
@@ -52,6 +57,14 @@ class WalletManager {
       )
     );
     return JSON.parse(data);
+  }
+
+  async removeCopyWallet(walletToRemove: StaticWallet, purpose: Purpose) {
+    const currentWallets = await this.readWallets(purpose);
+    const updatedWallets = currentWallets.filter(
+      (wallet) => wallet.address !== walletToRemove.address
+    );
+    await this.writeWallets(updatedWallets, purpose);
   }
 
   async popWallet(purpose: Purpose): Promise<StaticWallet> {

--- a/tests/govtool-frontend/playwright/lib/walletManager.ts
+++ b/tests/govtool-frontend/playwright/lib/walletManager.ts
@@ -42,7 +42,7 @@ class WalletManager {
     );
   }
 
-  private async readWallets(purpose: Purpose): Promise<StaticWallet[]> {
+  async readWallets(purpose: Purpose): Promise<StaticWallet[]> {
     const data: string = await new Promise((resolve, reject) =>
       fs.readFile(
         `${baseFilePath}/${purpose}Wallets.json`,

--- a/tests/govtool-frontend/playwright/playwright.config.ts
+++ b/tests/govtool-frontend/playwright/playwright.config.ts
@@ -92,6 +92,7 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
       testMatch: "**/*.dRep.spec.ts",
       dependencies: environments.ci ? ["auth setup", "dRep setup","wallet bootstrap"] : [],
+      teardown: environments.ci && "cleanup dRep"
     },
     {
       name: "delegation",
@@ -128,6 +129,10 @@ export default defineConfig({
     {
       name: "cleanup delegation",
       testMatch: "delegation.teardown.ts",
+    },
+    {
+      name: "cleanup dRep",
+      testMatch: "dRep.teardown.ts",
     },
     {
       name: "cleanup faucet",

--- a/tests/govtool-frontend/playwright/playwright.config.ts
+++ b/tests/govtool-frontend/playwright/playwright.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
     {
       name: "faucet setup",
       testMatch: "**/faucet.setup.ts",
+      teardown: environments.ci && "cleanup faucet" 
     },
     {
       name: "dRep setup",
@@ -127,6 +128,10 @@ export default defineConfig({
     {
       name: "cleanup delegation",
       testMatch: "delegation.teardown.ts",
+    },
+    {
+      name: "cleanup faucet",
+      testMatch: "faucet.teardown.ts",
     },
   ],
 });

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
@@ -140,6 +140,7 @@ test.describe("Register DRep state", () => {
 
   test.beforeEach(async ({ page, browser }) => {
     wallet = await walletManager.popWallet("registerDRep");
+    await walletManager.removeCopyWallet(wallet, "registerDRepCopy");
 
     const dRepAuth = await createTempDRepAuth(page, wallet);
     dRepPage = await createNewPageWithWallet(browser, {

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -144,6 +144,7 @@ test.describe("Temporary DReps", () => {
     test.slow(); // Due to queue in pop wallets
 
     const wallet = await walletManager.popWallet("registeredDRep");
+    await walletManager.removeCopyWallet(wallet, "registeredDRepCopy");
 
     const tempDRepAuth = await createTempDRepAuth(page, wallet);
     const dRepPage = await createNewPageWithWallet(browser, {
@@ -168,6 +169,7 @@ test.describe("Temporary DReps", () => {
     test.setTimeout(testInfo.timeout + environments.txTimeOut);
 
     const wallet = await walletManager.popWallet("registeredDRep");
+    await walletManager.removeCopyWallet(wallet, "registeredDRepCopy");
 
     const dRepAuth = await createTempDRepAuth(page, wallet);
     const dRepPage = await createNewPageWithWallet(browser, {

--- a/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
@@ -225,6 +225,7 @@ test.describe("Check voting power", () => {
     test.setTimeout(testInfo.timeout + environments.txTimeOut);
 
     const wallet = await walletManager.popWallet("registeredDRep");
+    await walletManager.removeCopyWallet(wallet,"registeredDRepCopy");
 
     const tempDRepAuth = await createTempDRepAuth(page, wallet);
 

--- a/tests/govtool-frontend/playwright/tests/dRep.setup.ts
+++ b/tests/govtool-frontend/playwright/tests/dRep.setup.ts
@@ -97,4 +97,6 @@ setup("Setup temporary DRep wallets", async () => {
   // save to file
   await walletManager.writeWallets(dRepWallets, "registeredDRep");
   await walletManager.writeWallets(registerDRepWallets, "registerDRep");
+  await walletManager.writeWallets(dRepWallets, "registeredDRepCopy");
+  await walletManager.writeWallets(registerDRepWallets, "registerDRepCopy");
 });

--- a/tests/govtool-frontend/playwright/tests/dRep.teardown.ts
+++ b/tests/govtool-frontend/playwright/tests/dRep.teardown.ts
@@ -5,6 +5,7 @@ import { pollTransaction } from "@helpers/transaction";
 import { test as cleanup, expect } from "@playwright/test";
 import kuberService from "@services/kuberService";
 import { StaticWallet } from "@types";
+import walletManager from "lib/walletManager";
 
 cleanup.describe.configure({ timeout: environments.txTimeOut });
 cleanup.beforeEach(async () => {
@@ -12,10 +13,12 @@ cleanup.beforeEach(async () => {
   await setAllureStory("Cleanup");
 });
 
-const registerDRep: StaticWallet[] = require("../lib/_mock/registerDRepCopyWallets.json");
-const registeredDRep: StaticWallet[] = require("../lib/_mock/registeredDRepCopyWallets.json");
-
 cleanup("DRep de-registration", async () => {
+  const registerDRep: StaticWallet[] =
+    await walletManager.readWallets("registerDRepCopy");
+  const registeredDRep: StaticWallet[] =
+    await walletManager.readWallets("registeredDRepCopy");
+
   const registeredDRepWallets = [
     ...dRepWallets,
     ...registerDRep,

--- a/tests/govtool-frontend/playwright/tests/dRep.teardown.ts
+++ b/tests/govtool-frontend/playwright/tests/dRep.teardown.ts
@@ -1,0 +1,37 @@
+import environments from "@constants/environments";
+import { dRepWallets } from "@constants/staticWallets";
+import { setAllureEpic, setAllureStory } from "@helpers/allure";
+import { pollTransaction } from "@helpers/transaction";
+import { test as cleanup, expect } from "@playwright/test";
+import kuberService from "@services/kuberService";
+import { StaticWallet } from "@types";
+
+cleanup.describe.configure({ timeout: environments.txTimeOut });
+cleanup.beforeEach(async () => {
+  await setAllureEpic("Setup");
+  await setAllureStory("Cleanup");
+});
+
+const registerDRep: StaticWallet[] = require("../lib/_mock/registerDRepCopyWallets.json");
+const registeredDRep: StaticWallet[] = require("../lib/_mock/registeredDRepCopyWallets.json");
+
+cleanup("DRep de-registration", async () => {
+  const registeredDRepWallets = [
+    ...dRepWallets,
+    ...registerDRep,
+    ...registeredDRep,
+  ];
+  try {
+    const { txId, lockInfo } = await kuberService.multipleDRepDeRegistration(
+      registeredDRepWallets
+    );
+    await pollTransaction(txId, lockInfo);
+  } catch (err) {
+    console.log(err);
+    if (err.status === 400) {
+      expect(true, "DRep not registered").toBeTruthy();
+    } else {
+      throw Error(err);
+    }
+  }
+});

--- a/tests/govtool-frontend/playwright/tests/faucet.teardown.ts
+++ b/tests/govtool-frontend/playwright/tests/faucet.teardown.ts
@@ -1,0 +1,34 @@
+import environments from "@constants/environments";
+import { faucetWallet } from "@constants/staticWallets";
+import { setAllureEpic, setAllureStory } from "@helpers/allure";
+import { pollTransaction } from "@helpers/transaction";
+import { test as cleanup, expect } from "@playwright/test";
+import kuberService from "@services/kuberService";
+
+cleanup.describe.configure({ timeout: environments.txTimeOut });
+cleanup.beforeEach(async () => {
+  await setAllureEpic("Setup");
+  await setAllureStory("Cleanup");
+});
+
+cleanup("Refund faucet", async () => {
+  try {
+    const faucetRemainingBalance = await kuberService.getBalance(
+      faucetWallet.address
+    );
+  
+    const transferBalance = Math.floor(faucetRemainingBalance) - 3;
+    const { txId, lockInfo } = await kuberService.transferADA(
+      [environments.faucet.address],
+      transferBalance
+    );
+    await pollTransaction(txId, lockInfo);
+  } catch (err) {
+     console.log(err);
+    if (err.status === 400) {
+      expect(true, "Failed to trasfer Ada").toBeTruthy();
+    } else {
+      throw Error(err);
+    }
+  }
+});

--- a/tests/govtool-frontend/playwright/tests/governance-action.setup.ts
+++ b/tests/govtool-frontend/playwright/tests/governance-action.setup.ts
@@ -36,7 +36,7 @@ setup("Setup temporary proposal wallets", async () => {
   ]);
   await pollTransaction(initializeRes.txId, initializeRes.lockInfo);
 
-  // transfer 51_000 ADA for dRep registration
+  // transfer 51_000 ADA for proposal submission
   const amountOutputs = proposalSubmissionsWallets.map((wallet) => {
     return { address: wallet.address, value: `${51_000}A` };
   });


### PR DESCRIPTION
## List of changes

- Add teardown to deregister all registered dReps for the test.  
- Add teardown to refund the remaining balance to the faucet.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
