### PR TITLE
Fix test 3A

### DIFF
--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -23,7 +23,7 @@ test.beforeEach(async () => {
 test.describe("Logged in DReps", () => {
   test.use({ storageState: ".auth/dRep01.json", wallet: dRep01Wallet });
 
-  test("3A. Should show dRepId on dashboard after connecting registered dRep Wallet", async ({
+  test("3A. Should show dRepId on dashboard and enable voting on governance actions after connecting registered dRep Wallet", async ({
     page,
   }) => {
     await page.goto("/");
@@ -37,6 +37,9 @@ test.describe("Logged in DReps", () => {
     const governanceActionsPage = new GovernanceActionsPage(page);
 
     await governanceActionsPage.goto();
+    
+    await expect(page.getByText(/info action/i).first()).toBeVisible();
+
     const governanceActionDetailsPage =
       await governanceActionsPage.viewFirstProposalByGovernanceAction(
         GrovernanceActionType.InfoAction


### PR DESCRIPTION
## List of changes

- Add assertion to wait for info governance actions loaded properly before assertion the voting behaviour.
- Update test 3A title to match the test behaviour

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
