### PR TITLE
fix: update network name assertion in test 6T to improve accuracy

### DIFF
--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
@@ -284,5 +284,7 @@ test("6T. Should display proper network name", async ({ page }) => {
   const response = await responsePromise;
   const responseBody = await response.json();
 
-  await expect((await page.getByTestId("system-network-name").innerText()).toLowerCase()).toBe(responseBody["networkName"].toLowerCase())
+  await expect(page.getByTestId("system-network-name")).toHaveText(
+    new RegExp(responseBody["networkName"], "i")
+  );
 });


### PR DESCRIPTION
## List of changes

- Update the assertion of network name test to align with latest update

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
