### PR TITLE
[#2118] 💡 Bump cardano-node on sanchonet to 9.2.1

### DIFF
--- a/scripts/govtool/Makefile
+++ b/scripts/govtool/Makefile
@@ -11,7 +11,7 @@ include config.mk
 .DEFAULT_GOAL := info
 
 # image tags
-cardano_node_image_tag := 9.1.1
+cardano_node_image_tag := 9.2.1
 cardano_db_sync_image_tag := 13.5.0.2
 
 .PHONY: all

--- a/scripts/govtool/docker-compose.node+dbsync.yml
+++ b/scripts/govtool/docker-compose.node+dbsync.yml
@@ -51,7 +51,7 @@ services:
       retries: 5
 
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:9.1.1
+    image: ghcr.io/intersectmbo/cardano-node:9.2.1
     environment:
       - NETWORK=sanchonet
     volumes:


### PR DESCRIPTION
The purpose of these changes is to update the Cardano Node version on the sanchonet environment as part of the Proposal Pillar. This involves upgrading the cardano-node from version 9.1.1 to the newer version 9.2.1. The update caters to the requirement specified in the user story to ensure that sanchonet is compatible with the latest releases and benefits from any improvements or bug fixes contained within this specific version.

The outcome of these changes is that the Makefile and docker-compose.node+dbsync.yml configurations have been updated to reflect the use of cardano-node version 9.2.1. This brings the sanchonet environment in line with the latest updates, potentially enhancing functionality or performance, and addressing any issues present in the previous version. This alignment is crucial for maintaining robust and up-to-date operations within the sanchonet infrastructure as part of the ongoing development efforts in the Proposal Pillar.
