### PR TITLE
[#1897] fix unwanted horizontal page scroll on Governance Actions page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ changes.
 
 ### Fixed
 
--
+- Fix unwanted horizontal page scroll on Governance Actions page [Issue 1897](https://github.com/IntersectMBO/govtool/issues/1897)
 
 ### Changed
 

--- a/govtool/frontend/src/components/organisms/GovernanceActionsToVote.tsx
+++ b/govtool/frontend/src/components/organisms/GovernanceActionsToVote.tsx
@@ -27,7 +27,7 @@ export const GovernanceActionsToVote = ({
 }: GovernanceActionsToVoteProps) => {
   const { pendingTransaction } = useCardano();
   const navigate = useNavigate();
-  const { isMobile } = useScreenDimension();
+  const { isMobile, pagePadding } = useScreenDimension();
   const { t } = useTranslation();
 
   return (
@@ -39,7 +39,15 @@ export const GovernanceActionsToVote = ({
       ) : (
         <>
           {proposals?.map((item, index) => (
-            <Box key={item.title} pb={2.5}>
+            <Box
+              key={item.title}
+              sx={{
+                mx: -pagePadding,
+                px: pagePadding,
+                pb: 2.5,
+                overflow: "hidden",
+              }}
+            >
               <Slider
                 data={item.actions.slice(0, 6).map((action) => (
                   <div


### PR DESCRIPTION
## List of changes

- Fix unwanted horizontal page scroll on Governance Actions page

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1897)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
