### PR TITLE
chore: bump node version to 10.1.0-pre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ changes.
 
 ### Changed
 
--
+- Bumped Cardano node version to `10.1.0-pre`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ changes.
 ### Changed
 
 - Bumped Cardano node version to `10.1.0-pre`.
+- Bumped Cardano DB Sync version to `13.6.0.0-pre`.
 
 ### Removed
 

--- a/scripts/govtool/Makefile
+++ b/scripts/govtool/Makefile
@@ -12,7 +12,7 @@ include config.mk
 
 # image tags
 cardano_node_image_tag := 10.1.0-pre
-cardano_db_sync_image_tag := 13.5.0.2
+cardano_db_sync_image_tag := 13.6.0.0-pre
 
 .PHONY: all
 all: deploy-stack notify

--- a/scripts/govtool/Makefile
+++ b/scripts/govtool/Makefile
@@ -11,7 +11,7 @@ include config.mk
 .DEFAULT_GOAL := info
 
 # image tags
-cardano_node_image_tag := 10.0.0-pre
+cardano_node_image_tag := 10.1.0-pre
 cardano_db_sync_image_tag := 13.5.0.2
 
 .PHONY: all

--- a/scripts/govtool/docker-compose.node+dbsync.yml
+++ b/scripts/govtool/docker-compose.node+dbsync.yml
@@ -51,7 +51,7 @@ services:
       retries: 5
 
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:10.0.0-pre
+    image: ghcr.io/intersectmbo/cardano-node:10.1.0-pre
     environment:
       - NETWORK=sanchonet
     volumes:

--- a/scripts/govtool/docker-compose.node+dbsync.yml
+++ b/scripts/govtool/docker-compose.node+dbsync.yml
@@ -65,7 +65,7 @@ services:
       retries: 10
 
   cardano-db-sync:
-    image: ghcr.io/intersectmbo/cardano-db-sync:13.5.0.2
+    image: ghcr.io/intersectmbo/cardano-db-sync:13.6.0.0-pre
     environment:
       - NETWORK=sanchonet
       - POSTGRES_HOST=postgres


### PR DESCRIPTION
## List of changes

- Bump Node version to 10.1.0-pre
- Bump DB-Sync version to 13.6.0.0

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
