### PR TITLE
chore: bump Cardano node to 10.0.0-pre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ changes.
 
 ### Changed
 
--
+- Bump to use Cardano Node `10.0.0-pre`
 
 ### Removed
 

--- a/scripts/govtool/Makefile
+++ b/scripts/govtool/Makefile
@@ -11,7 +11,7 @@ include config.mk
 .DEFAULT_GOAL := info
 
 # image tags
-cardano_node_image_tag := 9.2.1
+cardano_node_image_tag := 10.0.0-pre
 cardano_db_sync_image_tag := 13.5.0.2
 
 .PHONY: all

--- a/scripts/govtool/docker-compose.node+dbsync.yml
+++ b/scripts/govtool/docker-compose.node+dbsync.yml
@@ -51,7 +51,7 @@ services:
       retries: 5
 
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:9.2.1
+    image: ghcr.io/intersectmbo/cardano-node:10.0.0-pre
     environment:
       - NETWORK=sanchonet
     volumes:


### PR DESCRIPTION
## List of changes

- Change bump to use Node 10.0.0-pre

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
