### PR TITLE
fix: use logger import from helper instead of cypress logger

### DIFF
--- a/tests/govtool-frontend/playwright/lib/helpers/transaction.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/transaction.ts
@@ -2,11 +2,11 @@ import environments from "@constants/environments";
 import { Page, expect } from "@playwright/test";
 import kuberService from "@services/kuberService";
 import { LockInterceptor, LockInterceptorInfo } from "lib/lockInterceptor";
-import { Logger } from "../../../cypress/lib/logger/logger";
 import convertBufferToHex from "./convertBufferToHex";
 import { ShelleyWallet } from "./crypto";
 import { uploadMetadataAndGetJsonHash } from "./metadata";
 import { WalletAndAnchorType } from "@types";
+import { Logger } from "@helpers/logger";
 
 /**
  * Polls the transaction status until it's resolved or times out.

--- a/tests/govtool-frontend/playwright/lib/services/kuberService.ts
+++ b/tests/govtool-frontend/playwright/lib/services/kuberService.ts
@@ -10,7 +10,7 @@ import environments from "lib/constants/environments";
 import { LockInterceptor, LockInterceptorInfo } from "lib/lockInterceptor";
 import fetch, { BodyInit, RequestInit } from "node-fetch";
 import { cborxDecoder, cborxEncoder } from "../helpers/cborEncodeDecode";
-import { Logger } from "./../../../cypress/lib/logger/logger";
+import { Logger } from "@helpers/logger";
 
 type CertificateType = "registerstake" | "registerdrep" | "deregisterdrep";
 


### PR DESCRIPTION
## List of changes

- use logger import from playwright helper instead of cypress

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
