### PR TITLE
Reject metadata anchor with a limit of 128 words.

### DIFF
--- a/tests/govtool-frontend/playwright/lib/_mock/index.ts
+++ b/tests/govtool-frontend/playwright/lib/_mock/index.ts
@@ -2,8 +2,10 @@ import { faker } from "@faker-js/faker";
 import { generateExactLengthText } from "@helpers/string";
 
 export const invalid = {
-  url: () => {
-    const choice = faker.number.int({ min: 1, max: 2 });
+  url: (isSupportedGreaterThan128Words = true) => {
+    const choice = isSupportedGreaterThan128Words
+      ? 1
+      : faker.number.int({ min: 1, max: 2 });
     if (choice === 1) {
       const invalidSchemes = ["ftp", "unsupported", "unknown-scheme"];
       const invalidCharacters = "<>@!#$%^&*()";

--- a/tests/govtool-frontend/playwright/lib/_mock/index.ts
+++ b/tests/govtool-frontend/playwright/lib/_mock/index.ts
@@ -3,19 +3,24 @@ import { generateExactLengthText } from "@helpers/string";
 
 export const invalid = {
   url: () => {
-    const invalidSchemes = ["ftp", "unsupported", "unknown-scheme"];
-    const invalidCharacters = "<>@!#$%^&*()";
-    const invalidTlds = [".invalid", ".example", ".test"];
+    const choice = faker.number.int({ min: 1, max: 2 });
+    if (choice === 1) {
+      const invalidSchemes = ["ftp", "unsupported", "unknown-scheme"];
+      const invalidCharacters = "<>@!#$%^&*()";
+      const invalidTlds = [".invalid", ".example", ".test"];
 
-    const scheme =
-      invalidSchemes[Math.floor(Math.random() * invalidSchemes.length)];
-    const invalidChar =
-      invalidCharacters[Math.floor(Math.random() * invalidCharacters.length)];
-    const invalidTld =
-      invalidTlds[Math.floor(Math.random() * invalidTlds.length)];
+      const scheme =
+        invalidSchemes[Math.floor(Math.random() * invalidSchemes.length)];
+      const invalidChar =
+        invalidCharacters[Math.floor(Math.random() * invalidCharacters.length)];
+      const invalidTld =
+        invalidTlds[Math.floor(Math.random() * invalidTlds.length)];
 
-    const randomDomain = `example${invalidChar}domain${invalidTld}`;
-    return `${scheme}://${randomDomain}`;
+      const randomDomain = `example${invalidChar}domain${invalidTld}`;
+      return `${scheme}://${randomDomain}`;
+    }
+    // max 128 words invalid
+    return faker.internet.url() + faker.lorem.paragraphs(2).replace(/\s+/g, "");
   },
 
   name: () => {

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
@@ -156,7 +156,7 @@ test.describe("Validation of dRep Registration Form", () => {
     await dRepRegistrationPage.registerBtn.click();
 
     for (let i = 0; i < 100; i++) {
-      const invalidUrl = mockInvalid.url();
+      const invalidUrl = mockInvalid.url(false);
 
       await dRepRegistrationPage.metadataUrlInput.fill(invalidUrl);
       if (invalidUrl.length <= 128) {

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
@@ -156,8 +156,16 @@ test.describe("Validation of dRep Registration Form", () => {
     await dRepRegistrationPage.registerBtn.click();
 
     for (let i = 0; i < 100; i++) {
-      await dRepRegistrationPage.metadataUrlInput.fill(mockInvalid.url());
-      await expect(page.getByTestId("invalid-url-error")).toBeVisible();
+      const invalidUrl = mockInvalid.url();
+
+      await dRepRegistrationPage.metadataUrlInput.fill(invalidUrl);
+      if (invalidUrl.length <= 128) {
+        await expect(page.getByTestId("invalid-url-error")).toBeVisible();
+      } else {
+        await expect(
+          page.getByTestId("url-must-be-less-than-128-bytes-error")
+        ).toBeVisible();
+      }
     }
 
     const sentenceWithoutSpace = faker.lorem

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
@@ -127,8 +127,15 @@ test.describe("Validation of edit dRep Form", () => {
     await editDRepPage.registerBtn.click();
 
     for (let i = 0; i < 100; i++) {
-      await editDRepPage.metadataUrlInput.fill(mockInvalid.url());
-      await expect(page.getByTestId("invalid-url-error")).toBeVisible();
+      const invalidUrl = mockInvalid.url();
+      await editDRepPage.metadataUrlInput.fill(invalidUrl);
+      if (invalidUrl.length <= 128) {
+        await expect(page.getByTestId("invalid-url-error")).toBeVisible();
+      } else {
+        await expect(
+          page.getByTestId("url-must-be-less-than-128-bytes-error")
+        ).toBeVisible();
+      }
     }
 
     const sentenceWithoutSpace = faker.lorem

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
@@ -127,7 +127,7 @@ test.describe("Validation of edit dRep Form", () => {
     await editDRepPage.registerBtn.click();
 
     for (let i = 0; i < 100; i++) {
-      const invalidUrl = mockInvalid.url();
+      const invalidUrl = mockInvalid.url(false);
       await editDRepPage.metadataUrlInput.fill(invalidUrl);
       if (invalidUrl.length <= 128) {
         await expect(page.getByTestId("invalid-url-error")).toBeVisible();

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
@@ -261,7 +261,7 @@ test.describe("Proposal created logged state", () => {
       }) => {
         test.slow(); // Brute-force testing with 100 random data
         for (let i = 0; i < 50; i++) {
-          await proposalSubmissionPage.metadataUrlInput.fill(invalid.url());
+          await proposalSubmissionPage.metadataUrlInput.fill(invalid.url(false));
           await expect(page.getByTestId("url-input-error-text")).toBeVisible();
         }
 


### PR DESCRIPTION
## List of changes

- Add validation to restrict URLs containing more than 128 words, applicable only for unsupported URLs.
- Update validation assertions for invalid metadata anchor to enforce the 128-word limit.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
