### PR TITLE
chore: update dRep form references url and link error testId

### DIFF
--- a/tests/govtool-frontend/playwright/lib/forms/dRepForm.ts
+++ b/tests/govtool-frontend/playwright/lib/forms/dRepForm.ts
@@ -12,7 +12,14 @@ const formErrors = {
   ],
   linkDescription: "max-80-characters-error",
   email: "invalid-email-address-error",
-  link: "invalid-url-error",
+  links: {
+    url:"link-reference-description-1-error",
+    description: "link-reference-description-1-error",
+  },
+  identity: {
+    url: "identity-reference-url-1-error",
+    description: "identity-reference-description-1-error",
+  },
   paymentAddress: "invalid-payment-address-error",
 };
 
@@ -165,7 +172,8 @@ export default class DRepForm {
       dRepInfo.qualifications
     );
 
-    await expect(this.form.getByTestId(formErrors.link)).toBeHidden();
+    await expect(this.form.getByTestId(formErrors.links.url)).toBeHidden();
+    await expect(this.form.getByTestId(formErrors.identity.url)).toBeHidden();
     await expect(this.form.getByTestId(formErrors.paymentAddress)).toBeHidden();
     await expect(this.continueBtn).toBeEnabled();
   }
@@ -190,7 +198,7 @@ export default class DRepForm {
       })
       .all();
 
-    expect(nameErrors.length).toBeGreaterThanOrEqual(1); // BUG duplicate test ids
+    expect(nameErrors.length).toBeGreaterThanOrEqual(1);
 
     await expect(
       this.form.getByTestId(formErrors.paymentAddress)
@@ -206,14 +214,14 @@ export default class DRepForm {
       dRepInfo.qualifications
     );
 
-    await expect(this.form.getByTestId(formErrors.link).first()).toBeVisible(); // BUG duplicate test ids
+    await expect(this.form.getByTestId(formErrors.links.url)).toBeVisible();
     await expect(
-      this.form.getByTestId(formErrors.linkDescription).first()
-    ).toBeVisible(); // BUG duplicate test ids
-    await expect(this.form.getByTestId(formErrors.link).last()).toBeVisible(); // BUG duplicate test ids
+      this.form.getByTestId(formErrors.links.description)
+    ).toBeVisible();
+    await expect(this.form.getByTestId(formErrors.identity.url)).toBeVisible();
     await expect(
-      this.form.getByTestId(formErrors.linkDescription).last()
-    ).toBeVisible(); // BUG duplicate test ids
+      this.form.getByTestId(formErrors.identity.description)
+    ).toBeVisible();
 
     await expect(this.continueBtn).toBeDisabled();
   }


### PR DESCRIPTION
## List of changes

- Update dRep form references url and link error testId

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
