### PR TITLE
tests/support space on dRep name

### DIFF
--- a/tests/govtool-frontend/playwright/lib/_mock/index.ts
+++ b/tests/govtool-frontend/playwright/lib/_mock/index.ts
@@ -26,11 +26,8 @@ export const invalid = {
   },
 
   name: () => {
-    const choice = faker.number.int({ min: 1, max: 3 });
+    const choice = faker.number.int({ min: 1, max: 2 });
     if (choice === 1) {
-      // space invalid
-      return faker.lorem.word() + " " + faker.lorem.word();
-    } else if (choice === 2) {
       // maximum 80 words invalid
       return faker.lorem.paragraphs().replace(/\s+/g, "");
     }
@@ -97,6 +94,13 @@ export const invalid = {
 };
 
 export const valid = {
+  name: () => {
+    const choice = faker.number.int({ min: 1, max: 2 });
+    if (choice === 1) {
+      return faker.internet.displayName();
+    }
+    return faker.lorem.word() + " " + faker.lorem.word();
+  },
   username: () => {
     let timeStamp = Date.now();
     let username = `${faker.internet.userName().toLowerCase()}_${timeStamp}`;

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
@@ -60,7 +60,7 @@ test.describe("Validation of dRep Registration Form", () => {
 
     for (let i = 0; i < 100; i++) {
       await dRepRegistrationPage.validateForm({
-        name: faker.internet.displayName(),
+        name: mockValid.name(),
         objectives: faker.lorem.paragraph(2),
         motivations: faker.lorem.paragraph(2),
         qualifications: faker.lorem.paragraph(2),

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
@@ -27,7 +27,7 @@ test.describe("Validation of edit dRep Form", () => {
 
     for (let i = 0; i < 100; i++) {
       await editDRepPage.validateForm({
-        name: faker.internet.displayName(),
+        name: mockValid.name(),
         objectives: faker.lorem.paragraph(2),
         motivations: faker.lorem.paragraph(2),
         qualifications: faker.lorem.paragraph(2),


### PR DESCRIPTION
## List of changes

- Update dRep for data validation test to support dRep name with space

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
