### PR TITLE
[2277] fix: remove unneeded login step on workflow action

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -1,25 +1,24 @@
-name: Add Issue to Projects
+name: Add all issues created to projects
 
 on:
   issues:
     types: [opened]
 
 jobs:
-  add-to-projects:
+  add-to-govtool-all-project:
+    name: Add issue to GovTool all project
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/IntersectMBO/projects/30
+          github-token: ${{ secrets.ADD_ISSUE_TO_PROJECT_PAT }}
 
-      - name: Install GitHub CLI
-        run: sudo apt-get install gh
-
-      - name: Add issue to GovTool Project
-        run: gh project item-add IntersectMBO/30 --content-type Issue --content-id ${{ github.event.issue.node_id }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Add issue to Community Backlog Project
-        run: gh project item-add IntersectMBO/34 --content-type Issue --content-id ${{ github.event.issue.node_id }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  add-to-community-backlog-project:
+    name: Add issue to governance tools community backlog project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/IntersectMBO/projects/34
+          github-token: ${{ secrets.ADD_ISSUE_TO_PROJECT_PAT }}

--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -14,11 +14,6 @@ jobs:
       - name: Install GitHub CLI
         run: sudo apt-get install gh
 
-      - name: Authenticate GitHub CLI with default token
-        run: gh auth login --with-token <<< "$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Add issue to GovTool Project
         run: gh project item-add IntersectMBO/30 --content-type Issue --content-id ${{ github.event.issue.node_id }}
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ changes.
 ### Fixed
 
 - Fix submitting treasury governance action [Issue 1845](https://github.com/IntersectMBO/govtool/issues/1845)
+- Fix failing github action workflow [Issue 2277](https://github.com/IntersectMBO/govtool/issues/2277)
 
 ### Changed
 


### PR DESCRIPTION
## List of changes

- Overhaul action to use github personal access token and premade workflow template

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2277)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
