### PR TITLE
fix: incorrect org labelling for action

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:
-          project-url: https://github.com/users/IntersectMBO/projects/30
+          project-url: https://github.com/orgs/IntersectMBO/projects/30
           github-token: ${{ secrets.ADD_ISSUE_TO_PROJECT_PAT }}
 
   add-to-community-backlog-project:
@@ -20,5 +20,5 @@ jobs:
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:
-          project-url: https://github.com/users/IntersectMBO/projects/34
+          project-url: https://github.com/orgs/IntersectMBO/projects/34
           github-token: ${{ secrets.ADD_ISSUE_TO_PROJECT_PAT }}


### PR DESCRIPTION
## List of changes

- fix: incorrect org labelling for action

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
