### PR TITLE
chore(#2310): bump cardano node (10.1.2) and cardano-db-sync (13.6.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ changes.
 
 ### Changed
 
-- Bumped Cardano node version to `10.1.0-pre`.
-- Bumped Cardano DB Sync version to `13.6.0.0-pre`.
+- Bumped Cardano node version to `10.1.2`.
+- Bumped Cardano DB Sync version to `13.6.0.1`.
 - Make calculation of a DRep voting power on the backend [Issue 1960](https://github.com/IntersectMBO/govtool/issues/1960)
 
 ### Removed

--- a/scripts/govtool/Makefile
+++ b/scripts/govtool/Makefile
@@ -11,8 +11,8 @@ include config.mk
 .DEFAULT_GOAL := info
 
 # image tags
-cardano_node_image_tag := 10.1.0-pre
-cardano_db_sync_image_tag := 13.6.0.0-pre
+cardano_node_image_tag := 10.1.2
+cardano_db_sync_image_tag := 13.6.0.1
 
 .PHONY: all
 all: deploy-stack notify

--- a/scripts/govtool/docker-compose.node+dbsync.yml
+++ b/scripts/govtool/docker-compose.node+dbsync.yml
@@ -51,7 +51,7 @@ services:
       retries: 5
 
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:10.1.0-pre
+    image: ghcr.io/intersectmbo/cardano-node:10.1.2
     environment:
       - NETWORK=sanchonet
     volumes:
@@ -65,7 +65,7 @@ services:
       retries: 10
 
   cardano-db-sync:
-    image: ghcr.io/intersectmbo/cardano-db-sync:13.6.0.0-pre
+    image: ghcr.io/intersectmbo/cardano-db-sync:13.6.0.1
     environment:
       - NETWORK=sanchonet
       - POSTGRES_HOST=postgres


### PR DESCRIPTION
## List of changes
[SanchoNet]
- Bump cardano-node to v10.1.2
- Bump cardano-db-sync to v13.6.0.1

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2310)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
