### PR TITLE
Use valid anchor url, hash and return address in bulk loader

### DIFF
--- a/gov-action-loader/backend/app/transaction.py
+++ b/gov-action-loader/backend/app/transaction.py
@@ -39,8 +39,8 @@ def get_base_proposal():
 def get_base_proposal_for_multiple():
     base_proposal = get_base_proposal()
     base_proposal["anchor"] = {
-        "url": "http://bit.ly/3QFMhii",
-        "dataHash": "1111111111111111111111111111111111111111111111111111111111111112",
+        "url": "https://metadata-govtool.cardanoapi.io/data/gov-action-loader",
+        "dataHash": "bcb2fadedbe928519ff000051d8e78ffcabadba0f92b91334cee3e8786491462",
     }
     base_proposal["deposit"] = default_proposal_deposit_ada * 1000000
     return base_proposal
@@ -69,7 +69,7 @@ def generate_bytes(length):
 
 
 def generate_withdraw(number):
-    stake_addresses = [generate_raw_address() for _ in range(number)]
+    stake_addresses = ["e02fe0d8c1b1c600249e8b9663e18790425e9589ac17cb5ee952d54bee"]
     amounts = [
         random.choice([10000000, 20000000, 30000000, 40000000, 50000000])
         for _ in range(number)

--- a/gov-action-loader/backend/app/transaction.py
+++ b/gov-action-loader/backend/app/transaction.py
@@ -78,7 +78,7 @@ def generate_withdraw(number):
 
 
 def generate_update(number):
-    stake_addresses = [generate_raw_address() for _ in range(number)]
+    stake_addresses = ["e02fe0d8c1b1c600249e8b9663e18790425e9589ac17cb5ee952d54bee"]
     current_epoch = int((int(time.time()) - 1506635071) / (5 * 24 * 60 * 60))
     maximum_epoch = 10000
     epochs = [random.randint(current_epoch + 2, maximum_epoch) for _ in range(number)]


### PR DESCRIPTION
## List of changes

- Change
    - Anchor for bulk gov-actions: 
        - url: https://metadata-govtool.cardanoapi.io/data/gov-action-loader
        - hash: `bcb2fadedbe928519ff000051d8e78ffcabadba0f92b91334cee3e8786491462`
        - This was done so that goveranace actions can be viewed as having correctly formatted data
        - Example: [a003201b997db0777751c1f8f3f1d5ca761248ce5fd683e886a647dca53c2039#0](https://preview.gov.tools/governance_actions/a003201b997db0777751c1f8f3f1d5ca761248ce5fd683e886a647dca53c2039#0)
    - Stake address for update committee and treasury withdrawal
        - change stake address to `e02fe0d8c1b1c600249e8b9663e18790425e9589ac17cb5ee952d54bee`
        - This had to be done since stake addresses were randomly generated and not yet initialized, which was resulting in error while submitting the transaction

## Checklist

- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works