### PR TITLE
Tweak copy for maintenance page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ changes.
 
 ### Changed
 
--
+- Changed copy on maintenance page to remove reference to a network.
 
 ### Removed
 

--- a/govtool/frontend/maintenance-page/index.html
+++ b/govtool/frontend/maintenance-page/index.html
@@ -153,10 +153,8 @@
       <div>
         <h1 class="heading">GovTool is down</h1>
         <h2 class="text">
-          The Cardano GovTool is currently down for maintenance. Cardano
-          Govtool is connected to Preview testnet, which means that if the
-          network gets upgraded with new features Govtool needs to be updated
-          too. Please try again later.
+          The Cardano GovTool is currently down for maintenance.
+          Please try again later.
         </h2>
         <!-- <a href="" class="status">Status tracker</a> -->
       </div>


### PR DESCRIPTION
## List of changes

- Change copy to remove reference to network on maintenance page

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
