### PR TITLE
fix(#2332): fix inconsisten display of pending delegation DRep card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ changes.
 - Fix listing voted-on governance actions [Issue 2379](https://github.com/IntersectMBO/govtool/issues/2379)
 - Fix wronly displayed markdown on slider card [Issue 2263](https://github.com/IntersectMBO/govtool/issues/2316)
 - fix ada quantities format to avoid thousands when the total is 0 [Issue 2372](https://github.com/IntersectMBO/govtool/issues/2382)
+- fix inconsistent display of delegated DRep card during delegation [Issue 2332](https://github.com/IntersectMBO/govtool/issues/2332)
 
 ### Changed
 

--- a/govtool/frontend/src/hooks/index.ts
+++ b/govtool/frontend/src/hooks/index.ts
@@ -4,6 +4,7 @@ export * from "./useDebounce";
 export * from "./useDelegateToDrep";
 export * from "./useFetchNextPageDetector";
 export * from "./useOutsideClick";
+export * from "./usePrevious";
 export * from "./useSaveScrollPosition";
 export * from "./useScreenDimension";
 export * from "./useSlider";

--- a/govtool/frontend/src/hooks/usePrevious.test.ts
+++ b/govtool/frontend/src/hooks/usePrevious.test.ts
@@ -1,0 +1,47 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import usePrevious from "./usePrevious";
+
+describe("usePrevious hook", () => {
+  it("should return undefined on the initial render", () => {
+    const { result } = renderHook(() => usePrevious(0));
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it("should return the previous value after the state changes", () => {
+    let value = 0;
+
+    const { result, rerender } = renderHook(() => usePrevious(value));
+
+    expect(result.current).toBeUndefined();
+
+    value = 10;
+    rerender();
+
+    expect(result.current).toBe(0);
+
+    value = 20;
+    rerender();
+
+    expect(result.current).toBe(10);
+  });
+
+  it("should handle non-primitive values like objects", () => {
+    let value = { count: 0 };
+
+    const { result, rerender } = renderHook(() => usePrevious(value));
+
+    expect(result.current).toBeUndefined();
+
+    value = { count: 1 };
+    rerender();
+
+    expect(result.current).toEqual({ count: 0 });
+
+    value = { count: 2 };
+    rerender();
+
+    expect(result.current).toEqual({ count: 1 });
+  });
+});

--- a/govtool/frontend/src/hooks/usePrevious.ts
+++ b/govtool/frontend/src/hooks/usePrevious.ts
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Custom React hook to get the previous value of a prop or state.
+ * @param value The current value to track.
+ * @returns The previous value of the given input.
+ */
+function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T>();
+
+  useEffect(() => {
+    ref.current = value; // Update the ref value to the current value after render
+  }, [value]); // Only run if the value changes
+
+  return ref.current; // Return the previous value (ref.current holds the old value)
+}
+
+export default usePrevious;


### PR DESCRIPTION
## List of changes

- fix inconsistent display of pending delegation DRep card
- add usePrevious hook

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2332)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [x] I have added tests that prove my fix is effective or that my feature works
