### PR TITLE
test: add ability to search dReps by name

### DIFF
--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
@@ -86,6 +86,10 @@ test("2N. Should show DRep information on details page", async ({
 
   await dRepRegistrationPage.confirmBtn.click();
 
+  // Add an assertion to prevent clicking on "View Your dRep Details".
+  await expect(
+    dRepPage.getByTestId("dRep-id-display-card-dashboard")
+  ).toContainText(wallet.dRepId, { timeout: 10_000 });
   await dRepPage.getByTestId("view-drep-details-button").click();
 
   // Verification

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
@@ -193,12 +193,47 @@ test("2I. Should check validity of DRep Id", async ({ page }) => {
   await expect(dRepDirectory.getDRepCard(invalidDRepId)).not.toBeVisible();
 });
 
-test("2J. Should search by DRep id", async ({ page }) => {
+test("2J. Should search by DRep id and DRep givenname", async ({ page }) => {
+  let dRepGivenName = "test";
+
+  await page.route(
+    "**/drep/list?page=0&pageSize=10&sort=Random",
+    async (route) => {
+      const response = await route.fetch();
+      const json = await response.json();
+      const elements = json["elements"].filter(
+        (element) => element["givenName"] != null
+      );
+      dRepGivenName =
+        elements[Math.floor(Math.random() * elements.length)]["givenName"];
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(json),
+      });
+    }
+  );
+
+  const responsePromise = page.waitForResponse(
+    "**/drep/list?page=0&pageSize=10&sort=Random"
+  );
+
   const dRepDirectory = new DRepDirectoryPage(page);
   await dRepDirectory.goto();
 
+  await responsePromise;
+
+  // search by dRep Id
   await dRepDirectory.searchInput.fill(dRep01Wallet.dRepId);
   await expect(dRepDirectory.getDRepCard(dRep01Wallet.dRepId)).toBeVisible();
+
+  // search by dRep givenname
+  await dRepDirectory.searchInput.fill(dRepGivenName);
+  const searchDRepCards = await dRepDirectory.getAllListedDReps();
+
+  for (const dRepCard of searchDRepCards) {
+    expect((await dRepCard.innerText()).includes(dRepGivenName));
+  }
 });
 
 test("2M. Should access dRep directory page on disconnected state", async ({

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -32,7 +32,7 @@ test.describe("Logged in DReps", () => {
 
     await expect(
       page.getByTestId("dRep-id-display-card-dashboard")
-    ).toContainText(dRep01Wallet.dRepId);
+    ).toContainText(dRep01Wallet.dRepId, { timeout: 10_000 });
 
     const governanceActionsPage = new GovernanceActionsPage(page);
 
@@ -52,6 +52,11 @@ test.describe("Logged in DReps", () => {
     test.setTimeout(testInfo.timeout + environments.txTimeOut);
 
     await page.goto("/");
+
+    // Add an assertion to prevent clicking on "View Your dRep Details".
+    await expect(
+      page.getByTestId("dRep-id-display-card-dashboard")
+    ).toContainText(dRep01Wallet.dRepId, { timeout: 10_000 });
 
     await page.getByTestId("view-drep-details-button").click();
     await page.getByTestId("edit-drep-data-button").click();


### PR DESCRIPTION
## List of changes

- Update test case **2J** to include the ability to search dReps by name.
- Assert that the dRep ID card is displayed before clicking the "View Your dRep Details" button to ensure the button's action reflects its expected behavior.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
