### PR TITLE
Assert CIP129 and govActionId on governance action details page

### DIFF
--- a/tests/govtool-frontend/playwright/lib/helpers/cborEncodeDecode.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/cborEncodeDecode.ts
@@ -1,7 +1,0 @@
-import { Decoder, Encoder } from "cbor-x";
-
-export const cborxEncoder = new Encoder({
-  mapsAsObjects: false,
-  useRecords: false,
-});
-export const cborxDecoder = new Decoder({ mapsAsObjects: false });

--- a/tests/govtool-frontend/playwright/lib/helpers/computeTxHash.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/computeTxHash.ts
@@ -1,5 +1,5 @@
 import { blake2bHex } from "blakejs";
-import { cborxDecoder, cborxEncoder } from "./cborEncodeDecode";
+import { cborxDecoder, cborxEncoder } from "./encodeDecode";
 
 export default function computeTxHash(tx: string) {
   let decodedTx = cborxDecoder.decode(Buffer.from(tx, "hex"));

--- a/tests/govtool-frontend/playwright/lib/helpers/encodeDecode.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/encodeDecode.ts
@@ -1,0 +1,22 @@
+import { bech32 } from "bech32";
+import { Decoder, Encoder } from "cbor-x";
+
+export const cborxEncoder = new Encoder({
+  mapsAsObjects: false,
+  useRecords: false,
+});
+export const cborxDecoder = new Decoder({ mapsAsObjects: false });
+
+export const encodeCIP129Identifier = ({
+  txID,
+  index,
+  bech32Prefix,
+}: {
+  txID: string;
+  index?: string;
+  bech32Prefix: string;
+}) => {
+  const govActionBytes = Buffer.from(index ? txID + index : txID, "hex");
+  const words = bech32.toWords(govActionBytes);
+  return bech32.encode(bech32Prefix, words);
+};

--- a/tests/govtool-frontend/playwright/lib/services/kuberService.ts
+++ b/tests/govtool-frontend/playwright/lib/services/kuberService.ts
@@ -9,7 +9,7 @@ import * as blake from "blakejs";
 import environments from "lib/constants/environments";
 import { LockInterceptor, LockInterceptorInfo } from "lib/lockInterceptor";
 import fetch, { BodyInit, RequestInit } from "node-fetch";
-import { cborxDecoder, cborxEncoder } from "../helpers/cborEncodeDecode";
+import { cborxDecoder, cborxEncoder } from "../helpers/encodeDecode";
 import { Logger } from "@helpers/logger";
 
 type CertificateType = "registerstake" | "registerdrep" | "deregisterdrep";


### PR DESCRIPTION
## List of changes

- Rename file cborEncodeDecode to encodeDecode
- Add function to encode CIP129 Identifier
- Add assertion of CIP129 govActionId and default govActionId on govAction details page

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
