### PR TITLE
fix: fix wrong status of past DRep information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ changes.
 ### Fixed
 
 - Fix ada holder voting power calculation
+- Fix wrong statuses on past DRep info
 - Fix listing voted-on governance actions [Issue 2379](https://github.com/IntersectMBO/govtool/issues/2379)
 - Fix wronly displayed markdown on slider card [Issue 2263](https://github.com/IntersectMBO/govtool/issues/2316)
 - fix ada quantities format to avoid thousands when the total is 0 [Issue 2372](https://github.com/IntersectMBO/govtool/issues/2382)

--- a/govtool/backend/sql/get-drep-info.sql
+++ b/govtool/backend/sql/get-drep-info.sql
@@ -87,6 +87,7 @@ WasRegisteredAsDRep AS (
                     CROSS JOIN DRepId
                 WHERE
                     drep_hash.raw = DRepId.raw
+                    AND drep_registration.deposit >= 0
                     AND drep_registration.voting_anchor_id IS NOT NULL)) AS value
 ),
 WasRegisteredAsSoleVoter AS (
@@ -100,6 +101,7 @@ WasRegisteredAsSoleVoter AS (
                     CROSS JOIN DRepId
                 WHERE
                     drep_hash.raw = DRepId.raw
+                    AND drep_registration.deposit >= 0
                     AND drep_registration.voting_anchor_id IS NULL)) AS value
 ),
 CurrentMetadata AS (


### PR DESCRIPTION
## List of changes

- fix wrong status of past DRep information

## Checklist

- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
