### PR TITLE
test: update governance action total vote visibility assertion according to the protocol version

### DIFF
--- a/tests/govtool-frontend/playwright/lib/constants/index.ts
+++ b/tests/govtool-frontend/playwright/lib/constants/index.ts
@@ -1,0 +1,12 @@
+export const SECURITY_RELEVANT_PARAMS_MAP: Record<string, string> = {
+    maxBlockBodySize: "max_block_size",
+    maxTxSize: "max_tx_size",
+    maxBlockHeaderSize: "max_bh_size",
+    maxValueSize: "max_val_size",
+    maxBlockExecutionUnits: "max_block_ex_mem",
+    txFeePerByte: "min_fee_a",
+    txFeeFixed: "min_fee_b",
+    utxoCostPerByte: "coins_per_utxo_size",
+    govActionDeposit: "gov_action_deposit",
+    minFeeRefScriptCostPerByte: "min_fee_ref_script_cost_per_byte",
+  };

--- a/tests/govtool-frontend/playwright/lib/constants/index.ts
+++ b/tests/govtool-frontend/playwright/lib/constants/index.ts
@@ -1,12 +1,12 @@
 export const SECURITY_RELEVANT_PARAMS_MAP: Record<string, string> = {
-    maxBlockBodySize: "max_block_size",
-    maxTxSize: "max_tx_size",
-    maxBlockHeaderSize: "max_bh_size",
-    maxValueSize: "max_val_size",
-    maxBlockExecutionUnits: "max_block_ex_mem",
-    txFeePerByte: "min_fee_a",
-    txFeeFixed: "min_fee_b",
-    utxoCostPerByte: "coins_per_utxo_size",
-    govActionDeposit: "gov_action_deposit",
-    minFeeRefScriptCostPerByte: "min_fee_ref_script_cost_per_byte",
-  };
+  maxBlockBodySize: "max_block_size",
+  maxTxSize: "max_tx_size",
+  maxBlockHeaderSize: "max_bh_size",
+  maxValueSize: "max_val_size",
+  maxBlockExecutionUnits: "max_block_ex_mem",
+  txFeePerByte: "min_fee_a",
+  txFeeFixed: "min_fee_b",
+  utxoCostPerByte: "coins_per_utxo_size",
+  govActionDeposit: "gov_action_deposit",
+  minFeeRefScriptCostPerByte: "min_fee_ref_script_cost_per_byte",
+};

--- a/tests/govtool-frontend/playwright/lib/helpers/adaFormat.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/adaFormat.ts
@@ -7,9 +7,8 @@ export const correctVoteAdaFormat = (
   if (lovelace) {
     const ada = lovelace / LOVELACE;
     return ada.toLocaleString(locale, {
-      minimumFractionDigits: 3,
       maximumFractionDigits: 3,
     });
   }
-  return "0,000";
+  return "0";
 };

--- a/tests/govtool-frontend/playwright/lib/helpers/featureFlag.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/featureFlag.ts
@@ -1,0 +1,55 @@
+import { GrovernanceActionType, IProposal } from "@types";
+import { isBootStrapingPhase } from "./cardano";
+import { SECURITY_RELEVANT_PARAMS_MAP } from "@constants/index";
+
+export const areDRepVoteTotalsDisplayed = async (proposal: IProposal) => {
+  const isInBootstrapPhase = await isBootStrapingPhase();
+  const isSecurityGroup = Object.values(SECURITY_RELEVANT_PARAMS_MAP).some(
+    (paramKey) =>
+      proposal.protocolParams?.[
+        paramKey as keyof typeof proposal.protocolParams
+      ] !== null
+  );
+  if (isInBootstrapPhase) {
+    return !(
+      proposal.type === GrovernanceActionType.HardFork ||
+      (proposal.type === GrovernanceActionType.ProtocolParameterChange &&
+        !isSecurityGroup)
+    );
+  }
+
+  return ![
+    GrovernanceActionType.NoConfidence,
+    GrovernanceActionType.NewCommittee,
+    GrovernanceActionType.UpdatetotheConstitution,
+  ].includes(proposal.type as GrovernanceActionType);
+};
+
+export const areSPOVoteTotalsDisplayed = async (proposal: IProposal) => {
+  const isInBootstrapPhase = await isBootStrapingPhase();
+  const isSecurityGroup = Object.values(SECURITY_RELEVANT_PARAMS_MAP).some(
+    (paramKey) =>
+      proposal.protocolParams?.[
+        paramKey as keyof typeof proposal.protocolParams
+      ] !== null
+  );
+  if (isInBootstrapPhase) {
+    return proposal.type !== GrovernanceActionType.ProtocolParameterChange;
+  }
+
+  return !(
+    proposal.type === GrovernanceActionType.UpdatetotheConstitution ||
+    proposal.type === GrovernanceActionType.TreasuryWithdrawal ||
+    (proposal.type === GrovernanceActionType.ProtocolParameterChange &&
+      !isSecurityGroup)
+  );
+};
+
+export const areCCVoteTotalsDisplayed = async (
+  governanceActionType: GrovernanceActionType
+) => {
+  return ![
+    GrovernanceActionType.NoConfidence,
+    GrovernanceActionType.NewCommittee,
+  ].includes(governanceActionType);
+};

--- a/tests/govtool-frontend/playwright/lib/types.ts
+++ b/tests/govtool-frontend/playwright/lib/types.ts
@@ -21,6 +21,7 @@ export interface IProposal {
   createdEpochNo: number;
   url: string;
   metadataHash: string;
+  protocolParams: EpochParams | null;
   title: string | null;
   about: string | null;
   motivation: string | null;
@@ -81,6 +82,13 @@ export enum GrovernanceActionType {
   NoConfidence = "NoConfidence",
   NewCommittee = "NewCommittee",
   UpdatetotheConstitution = "NewConstitution",
+}
+
+export enum FullGovernanceDRepVoteActionsType {
+  ProtocolParameterChange = "ParameterChange",
+  InfoAction = "InfoAction",
+  TreasuryWithdrawal = "TreasuryWithdrawals",
+  HardFork = "HardForkInitiation",
 }
 
 export enum BootstrapGovernanceActionType {
@@ -168,4 +176,62 @@ export type WalletAndAnchorType = {
 export type ProtocolVersionType = {
   major: number;
   minor: number;
+};
+
+export type EpochParams = {
+  block_id: number | null;
+  coins_per_utxo_size: number | null;
+  collateral_percent: number | null;
+  committee_max_term_length: number | null;
+  committee_min_size: number | null;
+  cost_model_id: number | null;
+  decentralisation: number | null;
+  drep_activity: number | null;
+  drep_deposit: number | null;
+  dvt_committee_no_confidence: number | null;
+  dvt_committee_normal: number | null;
+  dvt_hard_fork_initiation: number | null;
+  dvt_motion_no_confidence: number | null;
+  dvt_p_p_economic_group: number | null;
+  dvt_p_p_gov_group: number | null;
+  dvt_p_p_network_group: number | null;
+  dvt_p_p_technical_group: number | null;
+  dvt_treasury_withdrawal: number | null;
+  dvt_update_to_constitution: number | null;
+  epoch_no: number | null;
+  extra_entropy: null;
+  gov_action_deposit: number | null;
+  gov_action_lifetime: number | null;
+  id: number;
+  influence: number | null;
+  key_deposit: number | null;
+  max_bh_size: number | null;
+  max_block_ex_mem: number | null;
+  max_block_ex_steps: number | null;
+  max_block_size: number | null;
+  max_collateral_inputs: number | null;
+  max_epoch: number | null;
+  max_tx_ex_mem: number | null;
+  max_tx_ex_steps: number | null;
+  max_tx_size: number | null;
+  max_val_size: number | null;
+  min_fee_a: number | null;
+  min_fee_b: number | null;
+  min_fee_ref_script_cost_per_byte: number | null;
+  min_pool_cost: number | null;
+  min_utxo_value: number | null;
+  monetary_expand_rate: number | null;
+  nonce: string | null;
+  optimal_pool_count: number | null;
+  pool_deposit: number | null;
+  price_mem: number | null;
+  price_step: number | null;
+  protocol_major: number | null;
+  protocol_minor: number | null;
+  pvt_committee_no_confidence: number | null;
+  pvt_committee_normal: number | null;
+  pvt_hard_fork_initiation: number | null;
+  pvt_motion_no_confidence: number | null;
+  pvtpp_security_group: number | null;
+  treasury_growth_rate: number | null;
 };

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
@@ -180,7 +180,7 @@ test.describe("Check vote count", () => {
         await govActionDetailsPage.showVotesBtn.click();
 
         // check dRep votes
-        if (areDRepVoteTotalsDisplayed(proposalToCheck)) {
+        if (await areDRepVoteTotalsDisplayed(proposalToCheck)) {
           await expect(govActionDetailsPage.dRepYesVotes).toHaveText(
             `₳ ${correctVoteAdaFormat(proposalToCheck.dRepYesVotes)}`
           );
@@ -193,7 +193,7 @@ test.describe("Check vote count", () => {
         }
 
         // check sPos votes
-        if (areSPOVoteTotalsDisplayed(proposalToCheck)) {
+        if (await areSPOVoteTotalsDisplayed(proposalToCheck)) {
           await expect(govActionDetailsPage.sPosYesVotes).toHaveText(
             `₳ ${correctVoteAdaFormat(proposalToCheck.poolYesVotes)}`
           );


### PR DESCRIPTION
## List of changes

- Update governance action total vote visibility assertion according to the protocol version for dRep and wallet disconnect user

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
