### PR TITLE
chore(#2411): bump cardano db-sync to 13.6.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ changes.
 
 ### Changed
 
--
+- Bump cardano-db-sync to 13.6.0.4 [Issue 2411](https://github.com/IntersectMBO/govtool/issues/2411)
 
 ### Removed
 

--- a/scripts/govtool/Makefile
+++ b/scripts/govtool/Makefile
@@ -12,7 +12,7 @@ include config.mk
 
 # image tags
 cardano_node_image_tag := 10.1.2
-cardano_db_sync_image_tag := 13.6.0.1
+cardano_db_sync_image_tag := 13.6.0.4
 
 .PHONY: all
 all: deploy-stack notify

--- a/scripts/govtool/docker-compose.node+dbsync.yml
+++ b/scripts/govtool/docker-compose.node+dbsync.yml
@@ -65,7 +65,7 @@ services:
       retries: 10
 
   cardano-db-sync:
-    image: ghcr.io/intersectmbo/cardano-db-sync:13.6.0.1
+    image: ghcr.io/intersectmbo/cardano-db-sync:13.6.0.4
     environment:
       - NETWORK=sanchonet
       - POSTGRES_HOST=postgres


### PR DESCRIPTION
## List of changes

- bump cardano db-sync to 13.6.0.4

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2411)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
