### PR TITLE
fix(#2398): fix unnecessary node remove in metadata actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ changes.
 
 - Fix fetching voting power of newly registerd DRep [Issue 2407](https://github.com/IntersectMBO/govtool/issues/2407)
 - Fix inconsistent voting status [Issue 1713](https://github.com/IntersectMBO/govtool/issues/1713)
+- Fix removing a child (link) when is not registed in DOM [Issue 2398](https://github.com/IntersectMBO/govtool/issues/2398)
 
 ### Changed
 

--- a/govtool/frontend/src/utils/jsonUtils.ts
+++ b/govtool/frontend/src/utils/jsonUtils.ts
@@ -24,8 +24,6 @@ export const downloadJson = (json: NodeObject, fileName?: string) => {
   } else {
     link.click();
   }
-
-  document.body.removeChild(link);
   URL.revokeObjectURL(url);
 };
 
@@ -52,6 +50,5 @@ export const downloadTextFile = (text: string, fileName?: string) => {
     link.click();
   }
 
-  document.body.removeChild(link);
   URL.revokeObjectURL(url);
 };


### PR DESCRIPTION
## List of changes

- fix unnecessary node remove in metadata actions

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2398)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
