### PR TITLE
Remove unwanted env and get faucet and blockfrost api keys based on network

### DIFF
--- a/.github/workflows/test_integration_playwright.yml
+++ b/.github/workflows/test_integration_playwright.yml
@@ -55,6 +55,16 @@ jobs:
           chmod +w ./lib/_mock
           npm run generate-wallets
           npm test
+          if [[ "${{ env.NETWORK }}" == "preprod" ]]; then
+            echo "FAUCET_API_KEY=${{ secrets.FAUCET_API_KEY_PREPROD }}" >> $GITHUB_ENV
+            echo "BLOCKFROST_API_KEY=${{ secrets.BLOCKFROST_API_KEY_PREPROD }}" >> $GITHUB_ENV
+          elif [[ "${{ env.NETWORK }}" == "sanchonet" ]]; then
+            echo "FAUCET_API_KEY=${{ secrets.FAUCET_API_KEY_SANCHONET }}" >> $GITHUB_ENV
+            echo "BLOCKFROST_API_KEY=${{ secrets.BLOCKFROST_API_KEY_SANCHONET }}" >> $GITHUB_ENV
+          else
+            echo "FAUCET_API_KEY=${{ secrets.FAUCET_API_KEY_PREVIEW }}" >> $GITHUB_ENV
+            echo "BLOCKFROST_API_KEY=${{ secrets.BLOCKFROST_API_KEY_PREVIEW }}" >> $GITHUB_ENV
+          fi
 
       - name: Upload report
         uses: actions/upload-artifact@v3
@@ -74,9 +84,6 @@ jobs:
       HOST_URL: https://${{inputs.deployment ||  'govtool.cardanoapi.io' }}
       API_URL: https://${{inputs.deployment ||  'govtool.cardanoapi.io' }}/api
       DOCS_URL: ${{ vars.DOCS_URL }}
-      FAUCET_API_URL: ${{ vars.FAUCET_API_URL }}
-      FAUCET_API_KEY: ${{secrets.FAUCET_API_KEY}}
-      KUBER_API_URL: ${{vars.KUBER_API_URL}}
       KUBER_API_KEY: ${{secrets.KUBER_API_KEY}}
       TEST_WORKERS: ${{vars.TEST_WORKERS}}
       CI: ${{vars.CI}}
@@ -85,7 +92,6 @@ jobs:
       CARDANOAPI_METADATA_URL: ${{vars.CARDANOAPI_METADATA_URL}}
       PROPOSAL_FAUCET_PAYMENT_PRIVATE: ${{secrets.PROPOSAL_FAUCET_PAYMENT_PRIVATE}}
       PROPOSAL_FAUCET_STAKE_PRIVATE: ${{secrets.PROPOSAL_FAUCET_STAKE_PRIVATE}}
-      BLOCKFROST_API_KEY: ${{secrets.BLOCKFROST_API_KEY}}
 
   publish-report:
     runs-on: ubuntu-latest

--- a/tests/govtool-frontend/playwright/.env.example
+++ b/tests/govtool-frontend/playwright/.env.example
@@ -10,14 +10,12 @@ PDF_URL=https://dev.api.pdf.gov.tools
 NETWORK_ID=0
 
 # Faucet
-FAUCET_API_URL=https://faucet.sanchonet.world.dev.cardano.org
 FAUCET_API_KEY=
 
 #Blockfrost
 BLOCKFROST_API_KEY=XXXXXXXXXXXXXXXXXXXXXXXX
 
 # Kuber
-KUBER_API_URL=https://sanchonet.kuber.cardanoapi.io
 KUBER_API_KEY=
 
 # Transaction timeout

--- a/tests/govtool-frontend/playwright/lib/constants/environments.ts
+++ b/tests/govtool-frontend/playwright/lib/constants/environments.ts
@@ -16,21 +16,14 @@ const environments = {
   pdfUrl: process.env.PDF_URL || "https://dev.api.pdf.gov.tools",
   networkId: parseInt(process.env.NETWORK_ID) || 0,
   faucet: {
-    apiUrl:
-      process.env.FAUCET_API_URL.replace("sanchonet", NETWORK) ||
-      "https://faucet.sanchonet.world.dev.cardano.org".replace(
-        "sanchonet",
-        NETWORK
-      ),
+    apiUrl:`https://faucet.${NETWORK}.world.dev.cardano.org`,
     apiKey: process.env.FAUCET_API_KEY || "",
     address:
       process.env.FAUCET_ADDRESS ||
       "addr_test1vz0ua2vyk7r4vufmpqh5v44awg8xff26hxlwyrt3uc67maqtql3kl",
   },
   kuber: {
-    apiUrl:
-      process.env.KUBER_API_URL.replace("sanchonet", NETWORK) ||
-      "https://sanchonet.kuber.cardanoapi.io".replace("sanchonet", NETWORK),
+    apiUrl: `https://${NETWORK}.kuber.cardanoapi.io`,
     apiKey: process.env.KUBER_API_KEY || "",
   },
   txTimeOut: parseInt(process.env.TX_TIMEOUT) || 240000,


### PR DESCRIPTION
## List of changes

- Remove unwanted env and get faucet and blockfrost api keys based on network

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
