### PR TITLE
Bugfix/governance dRep vote dependent test

### DIFF
--- a/tests/govtool-frontend/playwright/lib/helpers/featureFlag.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/featureFlag.ts
@@ -45,7 +45,7 @@ export const areSPOVoteTotalsDisplayed = async (proposal: IProposal) => {
   );
 };
 
-export const areCCVoteTotalsDisplayed = async (
+export const areCCVoteTotalsDisplayed = (
   governanceActionType: GrovernanceActionType
 ) => {
   return ![

--- a/tests/govtool-frontend/playwright/lib/helpers/featureFlag.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/featureFlag.ts
@@ -1,4 +1,4 @@
-import { GrovernanceActionType, IProposal } from "@types";
+import { GovernanceActionType, IProposal } from "@types";
 import { isBootStrapingPhase } from "./cardano";
 import { SECURITY_RELEVANT_PARAMS_MAP } from "@constants/index";
 
@@ -12,17 +12,17 @@ export const areDRepVoteTotalsDisplayed = async (proposal: IProposal) => {
   );
   if (isInBootstrapPhase) {
     return !(
-      proposal.type === GrovernanceActionType.HardFork ||
-      (proposal.type === GrovernanceActionType.ProtocolParameterChange &&
+      proposal.type === GovernanceActionType.HardFork ||
+      (proposal.type === GovernanceActionType.ProtocolParameterChange &&
         !isSecurityGroup)
     );
   }
 
   return ![
-    GrovernanceActionType.NoConfidence,
-    GrovernanceActionType.NewCommittee,
-    GrovernanceActionType.UpdatetotheConstitution,
-  ].includes(proposal.type as GrovernanceActionType);
+    GovernanceActionType.NoConfidence,
+    GovernanceActionType.NewCommittee,
+    GovernanceActionType.UpdatetotheConstitution,
+  ].includes(proposal.type as GovernanceActionType);
 };
 
 export const areSPOVoteTotalsDisplayed = async (proposal: IProposal) => {
@@ -34,22 +34,22 @@ export const areSPOVoteTotalsDisplayed = async (proposal: IProposal) => {
       ] !== null
   );
   if (isInBootstrapPhase) {
-    return proposal.type !== GrovernanceActionType.ProtocolParameterChange;
+    return proposal.type !== GovernanceActionType.ProtocolParameterChange;
   }
 
   return !(
-    proposal.type === GrovernanceActionType.UpdatetotheConstitution ||
-    proposal.type === GrovernanceActionType.TreasuryWithdrawal ||
-    (proposal.type === GrovernanceActionType.ProtocolParameterChange &&
+    proposal.type === GovernanceActionType.UpdatetotheConstitution ||
+    proposal.type === GovernanceActionType.TreasuryWithdrawal ||
+    (proposal.type === GovernanceActionType.ProtocolParameterChange &&
       !isSecurityGroup)
   );
 };
 
 export const areCCVoteTotalsDisplayed = (
-  governanceActionType: GrovernanceActionType
+  governanceActionType: GovernanceActionType
 ) => {
   return ![
-    GrovernanceActionType.NoConfidence,
-    GrovernanceActionType.NewCommittee,
+    GovernanceActionType.NoConfidence,
+    GovernanceActionType.NewCommittee,
   ].includes(governanceActionType);
 };

--- a/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
@@ -2,7 +2,7 @@ import removeAllSpaces from "@helpers/removeAllSpaces";
 import { Locator, Page, expect } from "@playwright/test";
 import {
   FullGovernanceDRepVoteActionsType,
-  GrovernanceActionType,
+  GovernanceActionType,
   IProposal,
 } from "@types";
 import environments from "lib/constants/environments";
@@ -56,7 +56,7 @@ export default class GovernanceActionsPage {
       FullGovernanceDRepVoteActionsType
     )) {
       const result = await this.viewFirstProposalByGovernanceAction(
-        governanceAction as GrovernanceActionType
+        governanceAction as GovernanceActionType
       );
       if (result) {
         return result;
@@ -66,7 +66,7 @@ export default class GovernanceActionsPage {
   }
 
   async viewFirstProposalByGovernanceAction(
-    governanceAction: GrovernanceActionType
+    governanceAction: GovernanceActionType
   ): Promise<GovernanceActionDetailsPage> {
     const proposalCard = this.page
       .getByTestId(`govaction-${governanceAction}-card`)
@@ -139,7 +139,7 @@ export default class GovernanceActionsPage {
   async sortAndValidate(
     sortOption: string,
     validationFn: (p1: IProposal, p2: IProposal) => boolean,
-    filterKeys = Object.keys(GrovernanceActionType)
+    filterKeys = Object.keys(GovernanceActionType)
   ) {
     const responsesPromise = Promise.all(
       filterKeys.map((filterKey) =>
@@ -147,7 +147,7 @@ export default class GovernanceActionsPage {
           response
             .url()
             .includes(
-              `&type[]=${GrovernanceActionType[filterKey]}&sort=${sortOption}`
+              `&type[]=${GovernanceActionType[filterKey]}&sort=${sortOption}`
             )
         )
       )
@@ -183,7 +183,7 @@ export default class GovernanceActionsPage {
     for (let dIdx = 0; dIdx <= proposalsByType.length - 1; dIdx++) {
       const proposals = proposalsByType[0] as IProposal[];
       const filterOptionKey = getEnumKeyByValue(
-        GrovernanceActionType,
+        GovernanceActionType,
         proposals[0].type
       );
 

--- a/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
@@ -1,6 +1,10 @@
 import removeAllSpaces from "@helpers/removeAllSpaces";
 import { Locator, Page, expect } from "@playwright/test";
-import { GrovernanceActionType, IProposal } from "@types";
+import {
+  FullGovernanceDRepVoteActionsType,
+  GrovernanceActionType,
+  IProposal,
+} from "@types";
 import environments from "lib/constants/environments";
 import GovernanceActionDetailsPage from "./governanceActionDetailsPage";
 import { getEnumKeyByValue } from "@helpers/enum";
@@ -45,6 +49,20 @@ export default class GovernanceActionsPage {
       .first()
       .click();
     return new GovernanceActionDetailsPage(this.page);
+  }
+
+  async viewFirstDRepVoteEnabledGovernanceAction(): Promise<GovernanceActionDetailsPage> {
+    for (const governanceAction of Object.keys(
+      FullGovernanceDRepVoteActionsType
+    )) {
+      const result = await this.viewFirstProposalByGovernanceAction(
+        governanceAction as GrovernanceActionType
+      );
+      if (result) {
+        return result;
+      }
+    }
+    return null;
   }
 
   async viewFirstProposalByGovernanceAction(

--- a/tests/govtool-frontend/playwright/lib/types.ts
+++ b/tests/govtool-frontend/playwright/lib/types.ts
@@ -74,7 +74,7 @@ export enum ProposalType {
   treasury = "Treasury",
 }
 
-export enum GrovernanceActionType {
+export enum GovernanceActionType {
   ProtocolParameterChange = "ParameterChange",
   InfoAction = "InfoAction",
   TreasuryWithdrawal = "TreasuryWithdrawals",

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -13,7 +13,7 @@ import GovernanceActionsPage from "@pages/governanceActionsPage";
 import { expect } from "@playwright/test";
 import walletManager from "lib/walletManager";
 import DRepDirectoryPage from "@pages/dRepDirectoryPage";
-import { GrovernanceActionType } from "@types";
+import { GovernanceActionType } from "@types";
 
 test.beforeEach(async () => {
   await setAllureEpic("3. DRep registration");
@@ -37,12 +37,12 @@ test.describe("Logged in DReps", () => {
     const governanceActionsPage = new GovernanceActionsPage(page);
 
     await governanceActionsPage.goto();
-    
+
     await expect(page.getByText(/info action/i).first()).toBeVisible();
 
     const governanceActionDetailsPage =
       await governanceActionsPage.viewFirstProposalByGovernanceAction(
-        GrovernanceActionType.InfoAction
+        GovernanceActionType.InfoAction
       );
 
     await expect(governanceActionDetailsPage.voteBtn).toBeVisible();

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
@@ -57,6 +57,11 @@ test.describe("Logged in DRep", () => {
       const govActionsPage = new GovernanceActionsPage(page);
       await govActionsPage.goto();
 
+      // assert to wait until the loading button is hidden
+      await expect(page.getByTestId("to-vote-tab")).toBeVisible({
+        timeout: 15_000,
+      });
+
       govActionDetailsPage = (await isBootStrapingPhase())
         ? await govActionsPage.viewFirstProposalByGovernanceAction(
             GovernanceActionType.InfoAction

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
@@ -16,7 +16,7 @@ import { invalid as mockInvalid, valid as mockValid } from "@mock/index";
 import {
   BootstrapGovernanceActionType,
   FullGovernanceDRepVoteActionsType,
-  GrovernanceActionType,
+  GovernanceActionType,
   IProposal,
 } from "@types";
 import walletManager from "lib/walletManager";
@@ -59,7 +59,7 @@ test.describe("Logged in DRep", () => {
 
       govActionDetailsPage = (await isBootStrapingPhase())
         ? await govActionsPage.viewFirstProposalByGovernanceAction(
-            GrovernanceActionType.InfoAction
+            GovernanceActionType.InfoAction
           )
         : await govActionsPage.viewFirstDRepVoteEnabledGovernanceAction();
 
@@ -207,9 +207,7 @@ test.describe("Check vote count", () => {
 
         // check ccCommittee votes
         if (
-          areCCVoteTotalsDisplayed(
-            proposalToCheck.type as GrovernanceActionType
-          )
+          areCCVoteTotalsDisplayed(proposalToCheck.type as GovernanceActionType)
         ) {
           await expect(govActionDetailsPage.ccCommitteeYesVotes).toHaveText(
             `${proposalToCheck.ccYesVotes}`

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
@@ -61,7 +61,7 @@ test.describe("Logged in DRep", () => {
         ? await govActionsPage.viewFirstProposalByGovernanceAction(
             GrovernanceActionType.InfoAction
           )
-        : await govActionsPage.viewFirstProposal();
+        : await govActionsPage.viewFirstDRepVoteEnabledGovernanceAction();
 
       await govActionDetailsPage.contextBtn.click();
       await govActionDetailsPage.contextInput.fill(faker.lorem.sentence(200));

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.spec.ts
@@ -9,7 +9,7 @@ import {
 import GovernanceActionDetailsPage from "@pages/governanceActionDetailsPage";
 import GovernanceActionsPage from "@pages/governanceActionsPage";
 import { expect, test } from "@playwright/test";
-import { GrovernanceActionType, IProposal } from "@types";
+import { GovernanceActionType, IProposal } from "@types";
 
 test.beforeEach(async () => {
   await setAllureEpic("4. Proposal visibility");
@@ -39,9 +39,9 @@ test("4K. Should display correct vote counts on governance details page for disc
   page,
   browser,
 }) => {
-  const responsesPromise = Object.keys(GrovernanceActionType).map((filterKey) =>
+  const responsesPromise = Object.keys(GovernanceActionType).map((filterKey) =>
     page.waitForResponse((response) =>
-      response.url().includes(`&type[]=${GrovernanceActionType[filterKey]}`)
+      response.url().includes(`&type[]=${GovernanceActionType[filterKey]}`)
     )
   );
 
@@ -98,7 +98,7 @@ test("4K. Should display correct vote counts on governance details page for disc
 
       // check ccCommittee votes
       if (
-        areCCVoteTotalsDisplayed(proposalToCheck.type as GrovernanceActionType)
+        areCCVoteTotalsDisplayed(proposalToCheck.type as GovernanceActionType)
       ) {
         await expect(govActionDetailsPage.ccCommitteeYesVotes).toHaveText(
           `${proposalToCheck.ccYesVotes}`

--- a/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
@@ -37,7 +37,7 @@ test.describe("Proposal checks", () => {
       ? await govActionsPage.viewFirstProposalByGovernanceAction(
           GrovernanceActionType.InfoAction
         )
-      : await govActionsPage.viewFirstProposal();
+      : await govActionsPage.viewFirstDRepVoteEnabledGovernanceAction();
   });
 
   test("5A. Should show relevant details about governance action as DRep", async () => {
@@ -185,7 +185,7 @@ test.describe("Perform voting", () => {
       ? await govActionsPage.viewFirstProposalByGovernanceAction(
           GrovernanceActionType.InfoAction
         )
-      : await govActionsPage.viewFirstProposal();
+      : await govActionsPage.viewFirstDRepVoteEnabledGovernanceAction();
   });
 
   test("5E. Should re-vote with new data on a already voted governance action", async ({}, testInfo) => {

--- a/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
@@ -32,6 +32,11 @@ test.describe("Proposal checks", () => {
     const govActionsPage = new GovernanceActionsPage(page);
     await govActionsPage.goto();
 
+    // assert to wait until the loading button is hidden
+    await expect(page.getByTestId("to-vote-tab")).toBeVisible({
+      timeout: 15_000,
+    });
+
     currentPage = page;
     govActionDetailsPage = (await isBootStrapingPhase())
       ? await govActionsPage.viewFirstProposalByGovernanceAction(
@@ -181,6 +186,11 @@ test.describe("Perform voting", () => {
     const govActionsPage = new GovernanceActionsPage(dRepPage);
     await govActionsPage.goto();
 
+    // assert to wait until the loading button is hidden
+    await expect(dRepPage.getByTestId("to-vote-tab")).toBeVisible({
+      timeout: 15_000,
+    });
+
     govActionDetailsPage = (await isBootStrapingPhase())
       ? await govActionsPage.viewFirstProposalByGovernanceAction(
           GovernanceActionType.InfoAction
@@ -211,7 +221,7 @@ test.describe("Perform voting", () => {
 
     await expect(
       govActionDetailsPage.currentPage.getByTestId("my-vote").getByText("No")
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 15_000 });
   });
 
   test("5F. Should show notification of casted vote after vote", async ({}, testInfo) => {

--- a/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
@@ -12,7 +12,7 @@ import GovernanceActionDetailsPage from "@pages/governanceActionDetailsPage";
 import GovernanceActionsPage from "@pages/governanceActionsPage";
 import { Page, expect } from "@playwright/test";
 import kuberService from "@services/kuberService";
-import { BootstrapGovernanceActionType, GrovernanceActionType } from "@types";
+import { BootstrapGovernanceActionType, GovernanceActionType } from "@types";
 import walletManager from "lib/walletManager";
 
 const invalidInfinityProposals = require("../../lib/_mock/invalidInfinityProposals.json");
@@ -35,7 +35,7 @@ test.describe("Proposal checks", () => {
     currentPage = page;
     govActionDetailsPage = (await isBootStrapingPhase())
       ? await govActionsPage.viewFirstProposalByGovernanceAction(
-          GrovernanceActionType.InfoAction
+          GovernanceActionType.InfoAction
         )
       : await govActionsPage.viewFirstDRepVoteEnabledGovernanceAction();
   });
@@ -183,7 +183,7 @@ test.describe("Perform voting", () => {
 
     govActionDetailsPage = (await isBootStrapingPhase())
       ? await govActionsPage.viewFirstProposalByGovernanceAction(
-          GrovernanceActionType.InfoAction
+          GovernanceActionType.InfoAction
         )
       : await govActionsPage.viewFirstDRepVoteEnabledGovernanceAction();
   });
@@ -274,7 +274,7 @@ test.describe("Bootstrap phase", () => {
   test("5L. Should restrict dRep votes to Info Governance actions During Bootstrapping Phase", async ({
     browser,
   }) => {
-    const voteBlacklistOptions = Object.keys(GrovernanceActionType).filter(
+    const voteBlacklistOptions = Object.keys(GovernanceActionType).filter(
       (option) => option !== BootstrapGovernanceActionType.InfoAction
     );
 
@@ -311,7 +311,7 @@ test.describe("Bootstrap phase", () => {
 
         const governanceActionDetailsPage =
           await governanceActionsPage.viewFirstProposalByGovernanceAction(
-            voteBlacklistOption as GrovernanceActionType
+            voteBlacklistOption as GovernanceActionType
           );
 
         if (governanceActionDetailsPage) {

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
@@ -9,7 +9,10 @@ import {
 import { faker } from "@faker-js/faker";
 import { test } from "@fixtures/proposal";
 import { setAllureEpic } from "@helpers/allure";
-import { skipIfTreasuryAndBootstrapping, skipIfNotHardFork } from "@helpers/cardano";
+import {
+  skipIfTreasuryAndBootstrapping,
+  skipIfNotHardFork,
+} from "@helpers/cardano";
 import { ShelleyWallet } from "@helpers/crypto";
 import { createNewPageWithWallet } from "@helpers/page";
 import { invalid, valid as mockValid } from "@mock/index";
@@ -261,7 +264,9 @@ test.describe("Proposal created logged state", () => {
       }) => {
         test.slow(); // Brute-force testing with 100 random data
         for (let i = 0; i < 50; i++) {
-          await proposalSubmissionPage.metadataUrlInput.fill(invalid.url(false));
+          await proposalSubmissionPage.metadataUrlInput.fill(
+            invalid.url(false)
+          );
           await expect(page.getByTestId("url-input-error-text")).toBeVisible();
         }
 


### PR DESCRIPTION
## List of changes

- Navigate to first dRep vote eligible governance action instead of any governance action on full governance action to fix dRep vote dependent test
- Parallize the bootstrap dRep vote test and improve the visibility checks for proper assertion
- Fix governance action type typo
- Add "vote-tab" assert to wait until the proposal is not visible

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
