### PR TITLE
fix(#2478): fix double signing of transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ changes.
 - Fix removing a child (link) when is not registed in DOM [Issue 2398](https://github.com/IntersectMBO/govtool/issues/2398)
 - Fix blank screen on DRep delegation when UTXos are missing [Issue 2408](https://github.com/IntersectMBO/govtool/issues/2408)
 - Fix broken guides links [Issue 2417](https://github.com/IntersectMBO/govtool/issues/2417)
+- Fix double signing of transaction [Issue 2478](https://github.com/IntersectMBO/govtool/issues/2478)
 
 ### Changed
 

--- a/govtool/frontend/src/context/wallet.tsx
+++ b/govtool/frontend/src/context/wallet.tsx
@@ -674,12 +674,9 @@ const CardanoProvider = (props: Props) => {
         // Make a full transaction, passing in empty witness set
         const tx = Transaction.new(txBody, transactionWitnessSet);
         // Ask wallet to to provide signature (witnesses) for the transaction
-        let txVkeyWitnesses;
-
-        txVkeyWitnesses = await walletApi.signTx(tx.to_hex(), true);
 
         // Create witness set object using the witnesses provided by the wallet
-        txVkeyWitnesses = TransactionWitnessSet.from_bytes(
+        const txVkeyWitnesses = TransactionWitnessSet.from_bytes(
           Buffer.from(await walletApi.signTx(tx.to_hex(), true), "hex"),
         );
         const vkeys = txVkeyWitnesses.vkeys();


### PR DESCRIPTION
## List of changes

- fix double signing of transaction

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2478)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
