### PR TITLE
Use only bootstrap goverance actions to check dRep vote dependent test on bootstrap phase

### DIFF
--- a/tests/govtool-frontend/playwright/lib/types.ts
+++ b/tests/govtool-frontend/playwright/lib/types.ts
@@ -74,6 +74,12 @@ export enum ProposalType {
   treasury = "Treasury",
 }
 
+export enum BootstrapGovernanceActionType {
+  ProtocolParameterChange = "ParameterChange",
+  InfoAction = "InfoAction",
+  HardFork = "HardForkInitiation",
+}
+
 export enum GovernanceActionType {
   ProtocolParameterChange = "ParameterChange",
   InfoAction = "InfoAction",
@@ -91,7 +97,7 @@ export enum FullGovernanceDRepVoteActionsType {
   HardFork = "HardForkInitiation",
 }
 
-export enum BootstrapGovernanceActionType {
+export enum BootstrapDRepVoteEnabledGovernanceActionType {
   InfoAction = "InfoAction",
 }
 

--- a/tests/govtool-frontend/playwright/lib/types.ts
+++ b/tests/govtool-frontend/playwright/lib/types.ts
@@ -97,10 +97,6 @@ export enum FullGovernanceDRepVoteActionsType {
   HardFork = "HardForkInitiation",
 }
 
-export enum BootstrapDRepVoteEnabledGovernanceActionType {
-  InfoAction = "InfoAction",
-}
-
 export type DRepStatus = "Active" | "Inactive" | "Retired";
 
 export type IDRep = {

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
@@ -14,7 +14,7 @@ import GovernanceActionsPage from "@pages/governanceActionsPage";
 import { Page, expect } from "@playwright/test";
 import { invalid as mockInvalid, valid as mockValid } from "@mock/index";
 import {
-  BootstrapGovernanceActionType,
+  BootstrapDRepVoteEnabledGovernanceActionType,
   FullGovernanceDRepVoteActionsType,
   GovernanceActionType,
   IProposal,
@@ -144,7 +144,7 @@ test.describe("Check vote count", () => {
     browser,
   }) => {
     const voteWhiteListOption = (await isBootStrapingPhase())
-      ? BootstrapGovernanceActionType
+      ? BootstrapDRepVoteEnabledGovernanceActionType
       : FullGovernanceDRepVoteActionsType;
     const responsesPromise = Object.keys(voteWhiteListOption).map((filterKey) =>
       page.waitForResponse((response) =>

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
@@ -14,7 +14,6 @@ import GovernanceActionsPage from "@pages/governanceActionsPage";
 import { Page, expect } from "@playwright/test";
 import { invalid as mockInvalid, valid as mockValid } from "@mock/index";
 import {
-  BootstrapDRepVoteEnabledGovernanceActionType,
   FullGovernanceDRepVoteActionsType,
   GovernanceActionType,
   IProposal,
@@ -144,7 +143,7 @@ test.describe("Check vote count", () => {
     browser,
   }) => {
     const voteWhiteListOption = (await isBootStrapingPhase())
-      ? BootstrapDRepVoteEnabledGovernanceActionType
+      ? { InfoAction: "InfoAction" }
       : FullGovernanceDRepVoteActionsType;
     const responsesPromise = Object.keys(voteWhiteListOption).map((filterKey) =>
       page.waitForResponse((response) =>

--- a/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
@@ -12,7 +12,10 @@ import GovernanceActionDetailsPage from "@pages/governanceActionDetailsPage";
 import GovernanceActionsPage from "@pages/governanceActionsPage";
 import { Page, expect } from "@playwright/test";
 import kuberService from "@services/kuberService";
-import { BootstrapGovernanceActionType, GovernanceActionType } from "@types";
+import {
+  BootstrapGovernanceActionType,
+  GovernanceActionType,
+} from "@types";
 import walletManager from "lib/walletManager";
 
 const invalidInfinityProposals = require("../../lib/_mock/invalidInfinityProposals.json");
@@ -284,8 +287,8 @@ test.describe("Bootstrap phase", () => {
   test("5L. Should restrict dRep votes to Info Governance actions During Bootstrapping Phase", async ({
     browser,
   }) => {
-    const voteBlacklistOptions = Object.keys(GovernanceActionType).filter(
-      (option) => option !== BootstrapGovernanceActionType.InfoAction
+    const voteBlacklistOptions = Object.keys(BootstrapGovernanceActionType).filter(
+      (option) => option !== GovernanceActionType.InfoAction
     );
 
     await Promise.all(


### PR DESCRIPTION
## List of changes

- Use only bootstrap goverance actions to check dRep vote dependent test on bootstrap phase

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
