### PR TITLE
Update Test IDs and Validate Add Withdrawal Address Button Visibility in Proposal Form

### DIFF
--- a/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
@@ -16,8 +16,8 @@ const formErrors = {
   abstract: "abstract-helper-error",
   motivation: "motivation-helper-error",
   rationale: "rationale-helper-error",
-  receivingAddress: "receiving-address-text-error",
-  amount: "amount-text-error",
+  receivingAddress: "receiving-address-0-text-error",
+  amount: "amount-0-text-error",
   link: "link-0-url-input-error",
 };
 
@@ -39,6 +39,9 @@ export default class ProposalSubmissionPage {
 
   readonly continueBtn = this.page.getByTestId("continue-button");
   readonly addLinkBtn = this.page.getByTestId("add-link-button");
+  readonly addWithdrawalAddressBtn = this.page.getByTestId(
+    "add-withdrawal-link-button"
+  );
   readonly infoBtn = this.page.getByTestId("info-button");
   readonly treasuryBtn = this.page.getByTestId("treasury-button");
   readonly editSubmissionButton = this.page.getByTestId(
@@ -61,9 +64,9 @@ export default class ProposalSubmissionPage {
   readonly motivationInput = this.page.getByTestId("motivation-input");
   readonly rationaleInput = this.page.getByTestId("rationale-input");
   readonly receivingAddressInput = this.page.getByTestId(
-    "receiving-address-input"
+    "receiving-address-0-text-input"
   );
-  readonly amountInput = this.page.getByTestId("amount-input");
+  readonly amountInput = this.page.getByTestId("amount-0-text-input");
   readonly closeDraftSuccessModalBtn = this.page.getByTestId("close-button");
 
   constructor(private readonly page: Page) {}

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
@@ -65,6 +65,19 @@ test.describe("Proposal created logged state", () => {
           await proposalSubmissionPage.validateForm(formFields);
         }
 
+        if (type === ProposalType.treasury) {
+          for (let i = 0; i < 9; i++) {
+            await expect(
+              proposalSubmissionPage.addWithdrawalAddressBtn
+            ).toBeVisible();
+            await proposalSubmissionPage.addWithdrawalAddressBtn.click();
+          }
+        }
+
+        await expect(
+          proposalSubmissionPage.addWithdrawalAddressBtn
+        ).toBeHidden();
+
         for (let i = 0; i < 6; i++) {
           await expect(proposalSubmissionPage.addLinkBtn).toBeVisible();
           await proposalSubmissionPage.addLinkBtn.click();


### PR DESCRIPTION
## List of changes

- Update testId of receiving address and amount Input and error message 
- Add assertion on valid proposal form to test the add withdrawal address button visibility

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
