### PR TITLE
fix(#2490): add registration cert when stake key is not registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ changes.
 
 ### Added
 
--
+- Add stake key registration certificate to voting and gov action proposal if not registered [Issue 2490](https://github.com/IntersectMBO/govtool/issues/2490)
 
 ### Fixed
 

--- a/govtool/frontend/src/context/wallet.tsx
+++ b/govtool/frontend/src/context/wallet.tsx
@@ -557,6 +557,14 @@ const CardanoProvider = (props: Props) => {
           }
         }
 
+        // register stake key if it is not registered
+        if (!certBuilder && !registeredStakeKeysListState.length) {
+          const stakeKeyRegCertBuilder = CertificatesBuilder.new();
+          const stakeKeyRegCert = await buildStakeKeyRegCert();
+          stakeKeyRegCertBuilder.add(stakeKeyRegCert);
+          txBuilder.set_certs_builder(stakeKeyRegCertBuilder);
+        }
+
         if (votingBuilder) {
           txBuilder.set_voting_builder(votingBuilder);
         }
@@ -728,6 +736,8 @@ const CardanoProvider = (props: Props) => {
       guardrailScript,
       epochParams?.cost_model?.costs,
       disconnectWallet,
+      registeredStakeKeysListState,
+      stakeKey,
     ],
   );
 


### PR DESCRIPTION
## List of changes

- add registration cert when stake key is not registered

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2490)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
