### PR TITLE
Proposal Draft Input Validation and Content Test Refactor

### DIFF
--- a/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
@@ -70,7 +70,21 @@ export default class ProposalSubmissionPage {
   readonly closeDraftSuccessModalBtn = this.page.getByTestId("close-button");
   readonly linkTextInput = this.page.getByTestId("link-0-text-input");
   readonly linkUrlInput = this.page.getByTestId("link-0-url-input");
-  
+
+  // content
+  readonly governanceActionTypeContent = this.page.getByTestId(
+    "governance-action-type-content"
+  );
+  readonly titleContent = this.page.getByTestId("title-content");
+  readonly abstractContent = this.page.getByTestId("abstract-content");
+  readonly motivationContent = this.page.getByTestId("motivation-content");
+  readonly rationaleContent = this.page.getByTestId("rationale-content");
+  readonly receivingAddressContent = this.page.getByTestId(
+    "receiving-address-0-content"
+  );
+  readonly amountContent = this.page.getByTestId("amount-0-content");
+  readonly linkTextContent = this.page.getByTestId("link-0-text-content");
+  readonly linkUrlContent = this.page.getByTestId("link-0-url-content");
 
   constructor(private readonly page: Page) {}
 

--- a/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
@@ -68,6 +68,9 @@ export default class ProposalSubmissionPage {
   );
   readonly amountInput = this.page.getByTestId("amount-0-text-input");
   readonly closeDraftSuccessModalBtn = this.page.getByTestId("close-button");
+  readonly linkTextInput = this.page.getByTestId("link-0-text-input");
+  readonly linkUrlInput = this.page.getByTestId("link-0-url-input");
+  
 
   constructor(private readonly page: Page) {}
 

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
@@ -330,13 +330,45 @@ test.describe("Info Proposal Draft", () => {
 
     const proposalSubmissionPage = new ProposalSubmissionPage(page);
     const { proposalFormValue } = await proposalSubmissionPage.createDraft(
-      ProposalType.info
+      ProposalType.treasury
     );
     const draftCard = proposalSubmissionPage.getFirstDraft();
     const draftCardAllInnerText = await (await draftCard).allInnerTexts();
 
     expect(draftCardAllInnerText.includes(proposalFormValue.prop_name));
     expect(draftCardAllInnerText.includes(proposalFormValue.prop_abstract));
+
+    (await draftCard)
+      .locator('[data-testid^="draft-"][data-testid$="-start-editing"]')
+      .click();
+
+    await expect(proposalSubmissionPage.governanceActionType).toHaveText(
+      ProposalType.treasury
+    );
+    await expect(proposalSubmissionPage.titleInput).toHaveValue(
+      proposalFormValue.prop_name
+    );
+    await expect(proposalSubmissionPage.abstractInput).toHaveValue(
+      proposalFormValue.prop_abstract
+    );
+    await expect(proposalSubmissionPage.motivationInput).toHaveValue(
+      proposalFormValue.prop_motivation
+    );
+    await expect(proposalSubmissionPage.rationaleInput).toHaveValue(
+      proposalFormValue.prop_rationale
+    );
+    await expect(proposalSubmissionPage.receivingAddressInput).toHaveValue(
+      proposalFormValue.prop_receiving_address
+    );
+    await expect(proposalSubmissionPage.amountInput).toHaveValue(
+      proposalFormValue.prop_amount
+    );
+    await expect(proposalSubmissionPage.linkUrlInput).toHaveValue(
+      proposalFormValue.proposal_links[0].prop_link
+    );
+    await expect(proposalSubmissionPage.linkTextInput).toHaveValue(
+      proposalFormValue.proposal_links[0].prop_link_text
+    );
   });
 
   test("7M_1. Should edit a info proposal draft", async ({ browser }) => {

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
@@ -140,22 +140,22 @@ test.describe("Proposal created logged state", () => {
         await proposalSubmissionPage.submitBtn.click();
 
         await expect(page.getByTestId("submit-as-GA-button")).toBeVisible();
-        await expect(page.getByTestId("title-content")).toHaveText(
+        await expect(proposalSubmissionPage.titleContent).toHaveText(
           proposal.prop_name
         );
         await expect(
-          page.getByTestId("governance-action-type-content")
+          proposalSubmissionPage.governanceActionTypeContent
         ).toHaveText(type);
-        await expect(page.getByTestId("abstract-content")).toHaveText(
+        await expect(proposalSubmissionPage.abstractContent).toHaveText(
           proposal.prop_abstract
         );
-        await expect(page.getByTestId("motivation-content")).toHaveText(
+        await expect(proposalSubmissionPage.motivationContent).toHaveText(
           proposal.prop_motivation
         );
-        await expect(page.getByTestId("rationale-content")).toHaveText(
+        await expect(proposalSubmissionPage.rationaleContent).toHaveText(
           proposal.prop_rationale
         );
-        await expect(page.getByTestId("link-0-text-content")).toHaveText(
+        await expect(proposalSubmissionPage.linkTextContent).toHaveText(
           proposal.proposal_links[0].prop_link_text
         );
       });
@@ -187,28 +187,28 @@ test.describe("Proposal created logged state", () => {
         await proposalSubmissionPage.continueBtn.click();
 
         await expect(
-          page.getByTestId("governance-action-type-content")
+          proposalSubmissionPage.governanceActionTypeContent
         ).toHaveText(type);
-        await expect(page.getByTestId("title-content")).toHaveText(
+        await expect(proposalSubmissionPage.titleContent).toHaveText(
           proposal.prop_name
         );
-        await expect(page.getByTestId("abstract-content")).toHaveText(
+        await expect(proposalSubmissionPage.abstractContent).toHaveText(
           proposal.prop_abstract
         );
-        await expect(page.getByTestId("motivation-content")).toHaveText(
+        await expect(proposalSubmissionPage.motivationContent).toHaveText(
           proposal.prop_motivation
         );
-        await expect(page.getByTestId("rationale-content")).toHaveText(
+        await expect(proposalSubmissionPage.rationaleContent).toHaveText(
           proposal.prop_rationale
         );
-        await expect(page.getByTestId("link-0-text-content")).toHaveText(
+        await expect(proposalSubmissionPage.linkTextContent).toHaveText(
           proposal.proposal_links[0].prop_link_text
         );
         if (type === ProposalType.treasury) {
           await expect(
-            page.getByTestId("receiving-address-content")
+            proposalSubmissionPage.receivingAddressContent
           ).toHaveText(proposal.prop_receiving_address);
-          await expect(page.getByTestId("amount-content")).toHaveText(
+          await expect(proposalSubmissionPage.amountContent).toHaveText(
             proposal.prop_amount
           );
         }
@@ -387,20 +387,20 @@ test.describe("Info Proposal Draft", () => {
     await proposalSubmissionPage.titleInput.fill(newTitle);
     await proposalSubmissionPage.continueBtn.click();
 
-    await expect(page.getByTestId("governance-action-type-content")).toHaveText(
+    await expect(proposalSubmissionPage.governanceActionTypeContent).toHaveText(
       ProposalType.info
     );
-    await expect(page.getByTestId("title-content")).toHaveText(newTitle);
-    await expect(page.getByTestId("abstract-content")).toHaveText(
+    await expect(proposalSubmissionPage.titleContent).toHaveText(newTitle);
+    await expect(proposalSubmissionPage.abstractContent).toHaveText(
       proposalFormValue.prop_abstract
     );
-    await expect(page.getByTestId("motivation-content")).toHaveText(
+    await expect(proposalSubmissionPage.motivationContent).toHaveText(
       proposalFormValue.prop_motivation
     );
-    await expect(page.getByTestId("rationale-content")).toHaveText(
+    await expect(proposalSubmissionPage.rationaleContent).toHaveText(
       proposalFormValue.prop_rationale
     );
-    await expect(page.getByTestId("link-0-text-content")).toHaveText(
+    await expect(proposalSubmissionPage.linkTextContent).toHaveText(
       proposalFormValue.proposal_links[0].prop_link_text
     );
   });
@@ -421,22 +421,22 @@ test.describe("Info Proposal Draft", () => {
     await proposalSubmissionPage.submitBtn.click();
 
     await expect(page.getByTestId("submit-as-GA-button")).toBeVisible();
-    await expect(page.getByTestId("title-content")).toHaveText(
+    await expect(proposalSubmissionPage.titleContent).toHaveText(
       proposalFormValue.prop_name
     );
-    await expect(page.getByTestId("governance-action-type-content")).toHaveText(
+    await expect(proposalSubmissionPage.governanceActionTypeContent).toHaveText(
       ProposalType.info
     );
-    await expect(page.getByTestId("abstract-content")).toHaveText(
+    await expect(proposalSubmissionPage.abstractContent).toHaveText(
       proposalFormValue.prop_abstract
     );
-    await expect(page.getByTestId("motivation-content")).toHaveText(
+    await expect(proposalSubmissionPage.motivationContent).toHaveText(
       proposalFormValue.prop_motivation
     );
-    await expect(page.getByTestId("rationale-content")).toHaveText(
+    await expect(proposalSubmissionPage.rationaleContent).toHaveText(
       proposalFormValue.prop_rationale
     );
-    await expect(page.getByTestId("link-0-text-content")).toHaveText(
+    await expect(proposalSubmissionPage.linkTextContent).toHaveText(
       proposalFormValue.proposal_links[0].prop_link_text
     );
   });
@@ -459,26 +459,26 @@ test.describe("Treasury Proposal Draft", () => {
     await proposalSubmissionPage.titleInput.fill(newTitle);
     await proposalSubmissionPage.continueBtn.click();
 
-    await expect(page.getByTestId("governance-action-type-content")).toHaveText(
+    await expect(proposalSubmissionPage.governanceActionTypeContent).toHaveText(
       ProposalType.treasury
     );
-    await expect(page.getByTestId("title-content")).toHaveText(newTitle);
-    await expect(page.getByTestId("abstract-content")).toHaveText(
+    await expect(proposalSubmissionPage.titleContent).toHaveText(newTitle);
+    await expect(proposalSubmissionPage.abstractContent).toHaveText(
       proposalFormValue.prop_abstract
     );
-    await expect(page.getByTestId("motivation-content")).toHaveText(
+    await expect(proposalSubmissionPage.motivationContent).toHaveText(
       proposalFormValue.prop_motivation
     );
-    await expect(page.getByTestId("rationale-content")).toHaveText(
+    await expect(proposalSubmissionPage.rationaleContent).toHaveText(
       proposalFormValue.prop_rationale
     );
-    await expect(page.getByTestId("receiving-address-content")).toHaveText(
+    await expect(proposalSubmissionPage.receivingAddressContent).toHaveText(
       proposalFormValue.prop_receiving_address
     );
-    await expect(page.getByTestId("amount-content")).toHaveText(
+    await expect(proposalSubmissionPage.amountContent).toHaveText(
       proposalFormValue.prop_amount
     );
-    await expect(page.getByTestId("link-0-text-content")).toHaveText(
+    await expect(proposalSubmissionPage.linkTextContent).toHaveText(
       proposalFormValue.proposal_links[0].prop_link_text
     );
   });


### PR DESCRIPTION
## List of changes

- Add extra assertion on save proposal as a draft (save treasury proposal as a draft and validate the input value field of saved the draft)
- Refactor proposal info content and update test Ids of receiving address content and amount content

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
