### PR TITLE
fix(#2044): fix missing validation for url length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ changes.
 
 - Fix mzero parsing error on fetching the /proposal/list [Issue 2446](https://github.com/IntersectMBO/govtool/issues/2446)
 - Fix scaling gov action votes on lower resolutions
+- Fix storing url missing length validation [Issue 2044](https://github.com/IntersectMBO/govtool/issues/2044)
 
 ### Changed
 

--- a/govtool/frontend/src/components/organisms/VoteContext/VoteContextStoringInformation.tsx
+++ b/govtool/frontend/src/components/organisms/VoteContext/VoteContextStoringInformation.tsx
@@ -7,7 +7,7 @@ import { ICONS } from "@consts";
 import { useTranslation, useScreenDimension, useVoteContextForm } from "@hooks";
 import { Step } from "@molecules";
 import { ControlledField, VoteContextWrapper } from "@organisms";
-import { URL_REGEX, openInNewTab } from "@utils";
+import { URL_REGEX, isValidURLLength, openInNewTab } from "@utils";
 import { LINKS } from "@/consts/links";
 
 type VoteContextStoringInformationProps = {
@@ -144,6 +144,7 @@ export const VoteContextStoringInformation = ({
                   value: URL_REGEX,
                   message: t("createGovernanceAction.fields.validations.url"),
                 },
+                validate: isValidURLLength,
               }}
             />
           }


### PR DESCRIPTION
## List of changes

- fix missing validation for url length

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2044)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
