### PR TITLE
Fix the treasury proposal submission test by using the same wallet's reward address

### DIFF
--- a/tests/govtool-frontend/playwright/lib/fixtures/proposal.ts
+++ b/tests/govtool-frontend/playwright/lib/fixtures/proposal.ts
@@ -22,7 +22,8 @@ export const test = base.extend<TestOptions>({
     const proposalCreationPage = new ProposalSubmissionPage(proposalPage);
     await proposalCreationPage.goto();
 
-    const proposalId = await proposalCreationPage.createProposal();
+    const proposalId =
+      await proposalCreationPage.createProposal(proposal01Wallet);
 
     const proposalDetailsPage = new ProposalDiscussionDetailsPage(proposalPage);
 

--- a/tests/govtool-frontend/playwright/lib/pages/proposalDiscussionPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/proposalDiscussionPage.ts
@@ -76,39 +76,6 @@ export default class ProposalDiscussionPage {
     await this.page.getByTestId("close-button").click();
   }
 
-  async createProposal(): Promise<number> {
-    const receivingAddr = generateWalletAddress();
-    const proposalRequest: ProposalCreateRequest = {
-      proposal_links: [
-        {
-          prop_link: faker.internet.url(),
-          prop_link_text: faker.internet.displayName(),
-        },
-      ],
-      gov_action_type_id: 1,
-      prop_name: faker.company.name(),
-      prop_abstract: faker.lorem.paragraph(2),
-      prop_motivation: faker.lorem.paragraph(2),
-      prop_rationale: faker.lorem.paragraph(2),
-      prop_receiving_address: receivingAddr,
-      prop_amount: faker.number.int({ min: 100, max: 1000 }).toString(),
-      is_draft: false,
-    };
-    await this.proposalCreateBtn.click();
-    await this.continueBtn.click();
-
-    await this.fillForm(proposalRequest);
-
-    await this.continueBtn.click();
-    await this.page.getByTestId("submit-button").click();
-
-    // Wait for redirection to `proposal-discussion-details` page
-    await this.page.waitForTimeout(2_000);
-
-    const currentPageUrl = this.page.url();
-    return extractProposalIdFromUrl(currentPageUrl);
-  }
-
   private async fillForm(data: ProposalCreateRequest) {
     await this.page.getByTestId("governance-action-type").click();
     await this.page.getByTestId("info-button").click();

--- a/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
@@ -9,7 +9,12 @@ import { extractProposalIdFromUrl } from "@helpers/string";
 import { invalid } from "@mock/index";
 import { Download, Locator, Page, expect } from "@playwright/test";
 import metadataBucketService from "@services/metadataBucketService";
-import { ProposalCreateRequest, ProposalLink, ProposalType } from "@types";
+import {
+  ProposalCreateRequest,
+  ProposalLink,
+  ProposalType,
+  StaticWallet,
+} from "@types";
 
 const formErrors = {
   proposalTitle: "title-input-error",
@@ -339,12 +344,11 @@ export default class ProposalSubmissionPage {
   }
 
   async createProposal(
+    wallet: StaticWallet,
     proposalType: ProposalType = ProposalType.treasury
   ): Promise<number> {
     await this.addLinkBtn.click();
-    const receivingAddr = (await ShelleyWallet.generate()).rewardAddressBech32(
-      0
-    );
+    const receivingAddr = ShelleyWallet.fromJson(wallet).rewardAddressBech32(0);
 
     const proposalRequest: ProposalCreateRequest =
       this.generateValidProposalFormFields(

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.ga.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.ga.spec.ts
@@ -38,7 +38,10 @@ Object.values(ProposalType).forEach((proposalType, index) => {
     await proposalSubmissionPage.proposalCreateBtn.click();
     await proposalDiscussionPage.continueBtn.click();
 
-    await proposalSubmissionPage.createProposal(proposalType);
+    await proposalSubmissionPage.createProposal(
+      proposalFaucetWallet,
+      proposalType
+    );
 
     await userPage.getByTestId("submit-as-GA-button").click();
 


### PR DESCRIPTION
## List of changes

- Use wallet stake address while creating proposal instead of random address
- remove unused create proposal function

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
