### PR TITLE
Enable and Display dRep Voting for All Governance Actions in Testing

### DIFF
--- a/tests/govtool-frontend/playwright/lib/helpers/featureFlag.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/featureFlag.ts
@@ -18,11 +18,7 @@ export const areDRepVoteTotalsDisplayed = async (proposal: IProposal) => {
     );
   }
 
-  return ![
-    GovernanceActionType.NoConfidence,
-    GovernanceActionType.NewCommittee,
-    GovernanceActionType.UpdatetotheConstitution,
-  ].includes(proposal.type as GovernanceActionType);
+  return true;
 };
 
 export const areSPOVoteTotalsDisplayed = async (proposal: IProposal) => {

--- a/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
@@ -1,9 +1,6 @@
 import removeAllSpaces from "@helpers/removeAllSpaces";
 import { Locator, Page, expect } from "@playwright/test";
-import {
-  GovernanceActionType,
-  IProposal,
-} from "@types";
+import { GovernanceActionType, IProposal } from "@types";
 import environments from "lib/constants/environments";
 import GovernanceActionDetailsPage from "./governanceActionDetailsPage";
 import { getEnumKeyByValue } from "@helpers/enum";
@@ -48,20 +45,6 @@ export default class GovernanceActionsPage {
       .first()
       .click();
     return new GovernanceActionDetailsPage(this.page);
-  }
-
-  async viewFirstDRepVoteEnabledGovernanceAction(): Promise<GovernanceActionDetailsPage> {
-    for (const governanceAction of Object.keys(
-      GovernanceActionType
-    )) {
-      const result = await this.viewFirstProposalByGovernanceAction(
-        governanceAction as GovernanceActionType
-      );
-      if (result) {
-        return result;
-      }
-    }
-    return null;
   }
 
   async viewFirstProposalByGovernanceAction(

--- a/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
@@ -1,7 +1,6 @@
 import removeAllSpaces from "@helpers/removeAllSpaces";
 import { Locator, Page, expect } from "@playwright/test";
 import {
-  FullGovernanceDRepVoteActionsType,
   GovernanceActionType,
   IProposal,
 } from "@types";
@@ -53,7 +52,7 @@ export default class GovernanceActionsPage {
 
   async viewFirstDRepVoteEnabledGovernanceAction(): Promise<GovernanceActionDetailsPage> {
     for (const governanceAction of Object.keys(
-      FullGovernanceDRepVoteActionsType
+      GovernanceActionType
     )) {
       const result = await this.viewFirstProposalByGovernanceAction(
         governanceAction as GovernanceActionType

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
@@ -14,11 +14,7 @@ import { createNewPageWithWallet } from "@helpers/page";
 import GovernanceActionsPage from "@pages/governanceActionsPage";
 import { Page, expect } from "@playwright/test";
 import { invalid as mockInvalid, valid as mockValid } from "@mock/index";
-import {
-  FullGovernanceDRepVoteActionsType,
-  GovernanceActionType,
-  IProposal,
-} from "@types";
+import { GovernanceActionType, IProposal } from "@types";
 import walletManager from "lib/walletManager";
 import GovernanceActionDetailsPage from "@pages/governanceActionDetailsPage";
 import { correctVoteAdaFormat } from "@helpers/adaFormat";
@@ -146,7 +142,7 @@ test.describe("Check vote count", () => {
   }) => {
     const voteWhiteListOption = (await isBootStrapingPhase())
       ? { InfoAction: "InfoAction" }
-      : FullGovernanceDRepVoteActionsType;
+      : GovernanceActionType;
     const responsesPromise = Object.keys(voteWhiteListOption).map((filterKey) =>
       page.waitForResponse((response) =>
         response.url().includes(`&type[]=${voteWhiteListOption[filterKey]}`)

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
@@ -63,7 +63,7 @@ test.describe("Logged in DRep", () => {
         ? await govActionsPage.viewFirstProposalByGovernanceAction(
             GovernanceActionType.InfoAction
           )
-        : await govActionsPage.viewFirstDRepVoteEnabledGovernanceAction();
+        : await govActionsPage.viewFirstProposal();
 
       await govActionDetailsPage.contextBtn.click();
       await govActionDetailsPage.contextInput.fill(faker.lorem.sentence(200));

--- a/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
@@ -45,7 +45,7 @@ test.describe("Proposal checks", () => {
       ? await govActionsPage.viewFirstProposalByGovernanceAction(
           GovernanceActionType.InfoAction
         )
-      : await govActionsPage.viewFirstDRepVoteEnabledGovernanceAction();
+      : await govActionsPage.viewFirstProposal();
   });
 
   test("5A. Should show relevant details about governance action as DRep", async () => {
@@ -157,7 +157,7 @@ test.describe("Perform voting", () => {
       ? await govActionsPage.viewFirstProposalByGovernanceAction(
           GovernanceActionType.InfoAction
         )
-      : await govActionsPage.viewFirstDRepVoteEnabledGovernanceAction();
+      : await govActionsPage.viewFirstProposal();
   });
 
   test("5E. Should re-vote with new data on a already voted governance action", async ({}, testInfo) => {


### PR DESCRIPTION
## List of changes

**Note: This PR is ready to be merged once [Issue #2527](https://github.com/IntersectMBO/govtool/issues/2527) is resolved.**

- Removed unnecessary "view first dRep vote enabled" function
- Enabled vote display for all governance actions in full governance.  
- Removed restrictions and ensured all governance actions are checked for dRep-dependent tests.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2527)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
