### PR TITLE
Refactor test suite: Automated Testing Strategy for Mainnet with ADA-Free Scenarios

### DIFF
--- a/.github/workflows/test_integration_playwright.yml
+++ b/.github/workflows/test_integration_playwright.yml
@@ -15,6 +15,7 @@ on:
           - "staging.govtool.byron.network"
           - "govtool.cardanoapi.io"
           - "preview.gov.tools"
+          - "gov.tools"
 
   workflow_run:
     workflows: ["Build and deploy GovTool to TEST server"]
@@ -54,18 +55,27 @@ jobs:
           mkdir -p ./lib/_mock
           chmod +w ./lib/_mock
           npm run generate-wallets
-          if [[ "${{ env.NETWORK }}" == "preprod" ]]; then
+
+          # Set network variables based on deployment input and environment
+          if [[ "${{inputs.deployment}}" == "gov.tools" ]]; then
+             export NETWORK='mainnet'
+          else
+             export NETWORK="${{ vars.NETWORK }}"
+          fi
+
+          # Set API keys based on the network
+          if [[ "${{ vars.NETWORK }}" == "preprod" ]]; then
             export FAUCET_API_KEY="${{ secrets.FAUCET_API_KEY_PREPROD }}"
             export BLOCKFROST_API_KEY="${{ secrets.BLOCKFROST_API_KEY_PREPROD }}"
-          elif [[ "${{ env.NETWORK }}" == "sanchonet" ]]; then
+          elif [[ "${{ vars.NETWORK }}" == "sanchonet" ]]; then
             export FAUCET_API_KEY="${{ secrets.FAUCET_API_KEY_SANCHONET }}"
             export BLOCKFROST_API_KEY="${{ secrets.BLOCKFROST_API_KEY_SANCHONET }}"
           else
             export FAUCET_API_KEY="${{ secrets.FAUCET_API_KEY_PREVIEW }}"
             export BLOCKFROST_API_KEY="${{ secrets.BLOCKFROST_API_KEY_PREVIEW }}"
           fi
+
           npm test
-         
 
       - name: Upload report
         uses: actions/upload-artifact@v3
@@ -88,7 +98,6 @@ jobs:
       KUBER_API_KEY: ${{secrets.KUBER_API_KEY}}
       TEST_WORKERS: ${{vars.TEST_WORKERS}}
       CI: ${{vars.CI}}
-      NETWORK: ${{vars.NETWORK}}
       FAUCET_ADDRESS: ${{vars.FAUCET_ADDRESS}}
       CARDANOAPI_METADATA_URL: ${{vars.CARDANOAPI_METADATA_URL}}
       PROPOSAL_FAUCET_PAYMENT_PRIVATE: ${{secrets.PROPOSAL_FAUCET_PAYMENT_PRIVATE}}

--- a/tests/govtool-frontend/playwright/lib/constants/environments.ts
+++ b/tests/govtool-frontend/playwright/lib/constants/environments.ts
@@ -14,9 +14,9 @@ const environments = {
   apiUrl: `${SERVER_HOST_URL}/api`,
   docsUrl: process.env.DOCS_URL || "https://docs.gov.tools/cardano-govtool",
   pdfUrl: process.env.PDF_URL || "https://dev.api.pdf.gov.tools",
-  networkId: parseInt(process.env.NETWORK_ID) || 0,
+  networkId: NETWORK === "mainnet" ? 1 : 0,
   faucet: {
-    apiUrl:`https://faucet.${NETWORK}.world.dev.cardano.org`,
+    apiUrl: `https://faucet.${NETWORK}.world.dev.cardano.org`,
     apiKey: process.env.FAUCET_API_KEY || "",
     address:
       process.env.FAUCET_ADDRESS ||

--- a/tests/govtool-frontend/playwright/lib/fixtures/loadExtension.ts
+++ b/tests/govtool-frontend/playwright/lib/fixtures/loadExtension.ts
@@ -19,6 +19,7 @@ export default async function loadDemosExtension(
   let walletConfig: CardanoTestWalletConfig = {
     enableStakeSigning,
     kuberApiUrl: environments.kuber.apiUrl,
+    networkId: environments.networkId,
     kuberApiKey: environments.kuber.apiKey,
     blockfrostApiKey: environments.blockfrostApiKey,
     blockfrostApiUrl: environments.blockfrostApiUrl,

--- a/tests/govtool-frontend/playwright/lib/helpers/auth.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/auth.ts
@@ -45,7 +45,7 @@ export async function createAuthWithUserName({
 
   const proposalDiscussionPage = new ProposalDiscussionPage(page);
   await proposalDiscussionPage.goto();
-  await proposalDiscussionPage.verifyIdentityBtn.click();
+  await proposalDiscussionPage.verifyIdentityBtn.click({ timeout: 15_000 });
 
   await proposalDiscussionPage.setUsername(mockValid.username());
 

--- a/tests/govtool-frontend/playwright/lib/helpers/cardano.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/cardano.ts
@@ -1,4 +1,5 @@
-import test, { expect } from "@playwright/test";
+import environments from "@constants/environments";
+import test from "@playwright/test";
 import kuberService from "@services/kuberService";
 import { ProposalType, ProtocolParams } from "@types";
 import { allure } from "allure-playwright";
@@ -41,6 +42,15 @@ export async function skipIfNotHardFork() {
   if (currentProtocolVersion < 9) {
     await allure.description(
       "Govtool Features will be available after hardfork."
+    );
+    test.skip();
+  }
+}
+
+export async function skipIfMainnet() {
+  if (environments.networkId === 1) {
+    await allure.description(
+      "Ada spendable features are not available on mainnet."
     );
     test.skip();
   }

--- a/tests/govtool-frontend/playwright/lib/helpers/dRep.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/dRep.ts
@@ -6,7 +6,7 @@ export async function fetchFirstActiveDRepDetails(page: Page) {
   let dRepId: string;
   let dRepDirectoryPage: DRepDirectoryPage;
   await page.route(
-    "**/drep/list?page=0&pageSize=10&sort=Random",
+    "**/drep/list?page=0&pageSize=10&sort=Random&**",
     async (route) => {
       const response = await route.fetch();
       const json = await response.json();
@@ -25,15 +25,15 @@ export async function fetchFirstActiveDRepDetails(page: Page) {
   );
 
   const responsePromise = page.waitForResponse(
-    "**/drep/list?page=0&pageSize=10&sort=Random"
+    "**/drep/list?page=0&pageSize=10&sort=Random&**"
   );
 
   dRepDirectoryPage = new DRepDirectoryPage(page);
   await dRepDirectoryPage.goto();
   await dRepDirectoryPage.filterBtn.click();
   await page.getByTestId("Active-checkbox").click();
-  await dRepDirectoryPage.searchInput.click();
-
   await responsePromise;
+
+  await dRepDirectoryPage.searchInput.click();
   return { dRepGivenName, dRepId, dRepDirectoryPage };
 }

--- a/tests/govtool-frontend/playwright/lib/helpers/dRep.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/dRep.ts
@@ -1,0 +1,39 @@
+import DRepDirectoryPage from "@pages/dRepDirectoryPage";
+import { Page } from "@playwright/test";
+
+export async function fetchFirstActiveDRepDetails(page: Page) {
+  let dRepGivenName: string;
+  let dRepId: string;
+  let dRepDirectoryPage: DRepDirectoryPage;
+  await page.route(
+    "**/drep/list?page=0&pageSize=10&sort=Random",
+    async (route) => {
+      const response = await route.fetch();
+      const json = await response.json();
+      const elements = json["elements"].filter(
+        (element) => element["givenName"] != null
+      );
+      dRepGivenName =
+        elements[Math.floor(Math.random() * elements.length)]["givenName"];
+      dRepId = json["elements"][0]["view"];
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(json),
+      });
+    }
+  );
+
+  const responsePromise = page.waitForResponse(
+    "**/drep/list?page=0&pageSize=10&sort=Random"
+  );
+
+  dRepDirectoryPage = new DRepDirectoryPage(page);
+  await dRepDirectoryPage.goto();
+  await dRepDirectoryPage.filterBtn.click();
+  await page.getByTestId("Active-checkbox").click();
+  await dRepDirectoryPage.searchInput.click();
+
+  await responsePromise;
+  return { dRepGivenName, dRepId, dRepDirectoryPage };
+}

--- a/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
@@ -147,6 +147,8 @@ export default class DRepDirectoryPage {
   }
 
   async getAllListedDReps() {
+    // wait for the dRep list to render properly
+    await this.page.waitForTimeout(3_000);
     // add assertion to wait until the search input is visible
     await expect(this.searchInput).toBeVisible({ timeout: 10_000 });
 

--- a/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
@@ -147,7 +147,8 @@ export default class DRepDirectoryPage {
   }
 
   async getAllListedDReps() {
-    await this.page.waitForTimeout(5_000); // load until the dRep card load properly
+    // add assertion to wait until the search input is visible
+    await expect(this.searchInput).toBeVisible({ timeout: 10_000 });
 
     return await this.page
       .getByRole("list")

--- a/tests/govtool-frontend/playwright/lib/pages/proposalDiscussionPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/proposalDiscussionPage.ts
@@ -29,15 +29,7 @@ export default class ProposalDiscussionPage {
 
   async goto() {
     await this.page.goto(`${environments.frontendUrl}/proposal_discussion`);
-    // Temporary fix for blank proposals issue in proposal view during disconnected state
-    // This code handles the blank proposals error, which is causing failing tests.
-    // It will be removed once the underlying issue is resolved.
-    await this.page.getByTestId("logo-button").click();
-    if (isMobile(this.page)) {
-      await this.page.getByTestId("open-drawer-button").click();
-    }
-    await this.page.getByText("Proposals", { exact: true }).click();
-
+    // wait for the proposal cards to load
     await this.page.waitForTimeout(2_000);
   }
 

--- a/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
@@ -184,7 +184,7 @@ export default class ProposalSubmissionPage {
 
   async getFirstDraft() {
     await expect(
-      this.page.locator('[data-testid^="draft-"][data-testid$="-card"]')
+      this.page.locator('[data-testid^="draft-"][data-testid$="-card"]').first()
     ).toBeVisible({ timeout: 10_000 }); // slow rendering
 
     return this.page

--- a/tests/govtool-frontend/playwright/tests/1-wallet-connect/walletConnect.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/1-wallet-connect/walletConnect.spec.ts
@@ -1,3 +1,4 @@
+import environments from "@constants/environments";
 import createWallet from "@fixtures/createWallet";
 import { test } from "@fixtures/walletExtension";
 import { setAllureEpic } from "@helpers/allure";
@@ -17,12 +18,13 @@ test("1A. Should connect wallet and choose stake-key to use", async ({
   const shellyWallet = await ShelleyWallet.generate();
   const extraPubStakeKey = convertBufferToHex(shellyWallet.stakeKey.public);
   const extraRewardAddress = convertBufferToHex(
-    shellyWallet.rewardAddressRawBytes(0)
+    shellyWallet.rewardAddressRawBytes(environments.networkId)
   );
 
   await createWallet(page, {
     extraRegisteredPubStakeKeys: [extraPubStakeKey],
     extraRewardAddresses: [extraRewardAddress],
+    networkId: environments.networkId,
   });
 
   const loginPage = new LoginPage(page);
@@ -30,7 +32,9 @@ test("1A. Should connect wallet and choose stake-key to use", async ({
 });
 
 test("1C. Should disconnect Wallet When connected", async ({ page }) => {
-  await createWallet(page);
+  await createWallet(page, {
+    networkId: environments.networkId,
+  });
 
   const loginPage = new LoginPage(page);
   await loginPage.login();
@@ -38,8 +42,10 @@ test("1C. Should disconnect Wallet When connected", async ({ page }) => {
   await loginPage.logout();
 });
 
-test("1D. Should reject wallet connection in mainnet", async ({ page }) => {
-  const wrongNetworkId = 1; // mainnet network
+test("1D. Should reject wallet connection if on different network", async ({
+  page,
+}) => {
+  const wrongNetworkId = environments.networkId == 0 ? 1 : 0;
   await createWallet(page, {
     networkId: wrongNetworkId,
   });

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
@@ -3,7 +3,7 @@ import { createTempDRepAuth } from "@datafactory/createAuth";
 import { faker } from "@faker-js/faker";
 import { test } from "@fixtures/walletExtension";
 import { setAllureEpic } from "@helpers/allure";
-import { skipIfNotHardFork } from "@helpers/cardano";
+import { skipIfMainnet, skipIfNotHardFork } from "@helpers/cardano";
 import { ShelleyWallet } from "@helpers/crypto";
 import { createNewPageWithWallet } from "@helpers/page";
 import DRepRegistrationPage from "@pages/dRepRegistrationPage";
@@ -14,7 +14,7 @@ import walletManager from "lib/walletManager";
 test.beforeEach(async () => {
   await setAllureEpic("2. Delegation");
   await skipIfNotHardFork();
-  test.skip(environments.networkId === 1);
+  await skipIfMainnet();
 });
 
 test("2N. Should show DRep information on details page", async ({

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
@@ -14,6 +14,7 @@ import walletManager from "lib/walletManager";
 test.beforeEach(async () => {
   await setAllureEpic("2. Delegation");
   await skipIfNotHardFork();
+  test.skip(environments.networkId === 1);
 });
 
 test("2N. Should show DRep information on details page", async ({

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
@@ -1,16 +1,11 @@
 import environments from "@constants/environments";
-import { dRep01Wallet, user01Wallet } from "@constants/staticWallets";
 import { createTempDRepAuth } from "@datafactory/createAuth";
 import { faker } from "@faker-js/faker";
 import { test } from "@fixtures/walletExtension";
 import { setAllureEpic } from "@helpers/allure";
 import { skipIfNotHardFork } from "@helpers/cardano";
 import { ShelleyWallet } from "@helpers/crypto";
-import { isMobile, openDrawer } from "@helpers/mobile";
 import { createNewPageWithWallet } from "@helpers/page";
-import extractDRepFromWallet from "@helpers/shellyWallet";
-import DRepDetailsPage from "@pages/dRepDetailsPage";
-import DRepDirectoryPage from "@pages/dRepDirectoryPage";
 import DRepRegistrationPage from "@pages/dRepRegistrationPage";
 import { expect } from "@playwright/test";
 import { LinkType } from "@types";
@@ -19,22 +14,6 @@ import walletManager from "lib/walletManager";
 test.beforeEach(async () => {
   await setAllureEpic("2. Delegation");
   await skipIfNotHardFork();
-});
-
-test("2C. Should open wallet connection popup on delegate in disconnected state", async ({
-  page,
-}) => {
-  await page.goto("/");
-  if (isMobile(page)) {
-    openDrawer(page);
-  }
-
-  await page.getByTestId("view-drep-directory-button").click();
-  await page.getByTestId("search-input").fill(dRep01Wallet.dRepId);
-  await page
-    .getByTestId(`${dRep01Wallet.dRepId}-connect-to-delegate-button`)
-    .click();
-  await expect(page.getByTestId("connect-your-wallet-modal")).toBeVisible();
 });
 
 test("2N. Should show DRep information on details page", async ({
@@ -123,125 +102,4 @@ test("2N. Should show DRep information on details page", async ({
       dRepPage.getByTestId(`${link.description.toLowerCase()}-link`)
     ).toHaveText(link.url);
   }
-});
-
-test("2P. Should enable sharing of DRep details", async ({ page, context }) => {
-  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-
-  const dRepDetailsPage = new DRepDetailsPage(page);
-  await dRepDetailsPage.goto(dRep01Wallet.dRepId);
-
-  await dRepDetailsPage.shareLink();
-  await expect(page.getByText("Copied to clipboard")).toBeVisible();
-
-  const copiedText = await page.evaluate(() => navigator.clipboard.readText());
-  expect(copiedText).toEqual(
-    `${environments.frontendUrl}/drep_directory/${dRep01Wallet.dRepId}`
-  );
-});
-
-test("2Q. Should include DRep status and voting power on the DRep card", async ({
-  page,
-}) => {
-  const dRepDirectory = new DRepDirectoryPage(page);
-  await dRepDirectory.goto();
-
-  await dRepDirectory.searchInput.fill(dRep01Wallet.dRepId);
-  const dRepCard = dRepDirectory.getDRepCard(dRep01Wallet.dRepId);
-
-  await expect(
-    dRepCard.getByTestId(`${dRep01Wallet.dRepId}-voting-power`)
-  ).toBeVisible();
-  await expect(
-    dRepCard.getByTestId(`${dRep01Wallet.dRepId}-Active-pill`)
-  ).toBeVisible();
-});
-
-test.describe("Insufficient funds", () => {
-  test.use({ storageState: ".auth/user01.json", wallet: user01Wallet });
-
-  test("2T. Should show warning message on delegation when insufficient funds", async ({
-    page,
-  }) => {
-    const dRepDirectoryPage = new DRepDirectoryPage(page);
-    await dRepDirectoryPage.goto();
-
-    await dRepDirectoryPage.searchInput.fill(dRep01Wallet.dRepId);
-    const delegateBtn = page.getByTestId(
-      `${dRep01Wallet.dRepId}-delegate-button`
-    );
-    await expect(delegateBtn).toBeVisible();
-    await page.getByTestId(`${dRep01Wallet.dRepId}-delegate-button`).click();
-
-    await expect(dRepDirectoryPage.delegationErrorModal).toBeVisible({
-      timeout: 10_000,
-    });
-  });
-});
-
-test("2I. Should check validity of DRep Id", async ({ page }) => {
-  const dRepDirectory = new DRepDirectoryPage(page);
-  await dRepDirectory.goto();
-
-  await dRepDirectory.searchInput.fill(dRep01Wallet.dRepId);
-  await expect(dRepDirectory.getDRepCard(dRep01Wallet.dRepId)).toBeVisible();
-
-  const wallet = await ShelleyWallet.generate();
-  const invalidDRepId = extractDRepFromWallet(wallet);
-
-  await dRepDirectory.searchInput.fill(invalidDRepId);
-  await expect(dRepDirectory.getDRepCard(invalidDRepId)).not.toBeVisible();
-});
-
-test("2J. Should search by DRep id and DRep givenname", async ({ page }) => {
-  let dRepGivenName = "test";
-
-  await page.route(
-    "**/drep/list?page=0&pageSize=10&sort=Random",
-    async (route) => {
-      const response = await route.fetch();
-      const json = await response.json();
-      const elements = json["elements"].filter(
-        (element) => element["givenName"] != null
-      );
-      dRepGivenName =
-        elements[Math.floor(Math.random() * elements.length)]["givenName"];
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(json),
-      });
-    }
-  );
-
-  const responsePromise = page.waitForResponse(
-    "**/drep/list?page=0&pageSize=10&sort=Random"
-  );
-
-  const dRepDirectory = new DRepDirectoryPage(page);
-  await dRepDirectory.goto();
-
-  await responsePromise;
-
-  // search by dRep Id
-  await dRepDirectory.searchInput.fill(dRep01Wallet.dRepId);
-  await expect(dRepDirectory.getDRepCard(dRep01Wallet.dRepId)).toBeVisible();
-
-  // search by dRep givenname
-  await dRepDirectory.searchInput.fill(dRepGivenName);
-  const searchDRepCards = await dRepDirectory.getAllListedDReps();
-
-  for (const dRepCard of searchDRepCards) {
-    expect((await dRepCard.innerText()).includes(dRepGivenName));
-  }
-});
-
-test("2M. Should access dRep directory page on disconnected state", async ({
-  page,
-}) => {
-  const dRepDirectoryPage = new DRepDirectoryPage(page);
-  await dRepDirectoryPage.goto();
-
-  const dRepCards = await dRepDirectoryPage.getAllListedDReps();
-  expect(dRepCards.length).toBeGreaterThan(1);
 });

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.loggedin.spec.ts
@@ -89,13 +89,14 @@ test.describe("DRep dependent tests", () => {
     page,
   }) => {
     await dRepDirectoryPage.searchInput.fill(dRepId);
-    const delegateBtn = page.getByTestId(`${dRepId}-delegate-button`);
-    await expect(delegateBtn).toBeVisible();
     await page.getByTestId(`${dRepId}-delegate-button`).click();
 
     await expect(dRepDirectoryPage.delegationErrorModal).toBeVisible({
       timeout: 10_000,
     });
+    await expect(dRepDirectoryPage.delegationErrorModal).toHaveText(
+      /UTxO Balance Insufficient/
+    );
   });
 
   test("2I. Should check validity of DRep Id", async () => {

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.loggedin.spec.ts
@@ -76,8 +76,8 @@ test("2X_2. Should include info button and voting power on the Signal-No-Confide
 });
 
 test.describe("DRep dependent tests", () => {
-  let dRepGivenName = "test";
-  let dRepId = "drep1ef7uslcjhjqrn4vv2y39c3yn345gzjsg7yufn76zye3v6fkz23q";
+  let dRepGivenName: string;
+  let dRepId: string;
   let dRepDirectoryPage: DRepDirectoryPage;
 
   test.beforeEach(async ({ page }) => {

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
@@ -137,13 +137,11 @@ test("2M. Should access dRep directory page on disconnected state", async ({
 });
 
 test.describe("DRep dependent tests", () => {
-  let dRepGivenName = "test";
   let dRepId = "drep1ef7uslcjhjqrn4vv2y39c3yn345gzjsg7yufn76zye3v6fkz23q";
   let dRepDirectoryPage: DRepDirectoryPage;
 
   test.beforeEach(async ({ page }) => {
-    ({ dRepDirectoryPage, dRepId, dRepGivenName } =
-      await fetchFirstActiveDRepDetails(page));
+    ({ dRepDirectoryPage, dRepId } = await fetchFirstActiveDRepDetails(page));
   });
 
   test("2P. Should enable sharing of DRep details", async ({
@@ -184,5 +182,19 @@ test.describe("DRep dependent tests", () => {
     await page.getByTestId("search-input").fill(dRepId);
     await page.getByTestId(`${dRepId}-connect-to-delegate-button`).click();
     await expect(page.getByTestId("connect-your-wallet-modal")).toBeVisible();
+  });
+
+  test("2L. Should copy DRepId", async ({ page, context }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    await dRepDirectoryPage.searchInput.fill(dRepId);
+    await page.getByTestId(`${dRepId}-copy-id-button`).click();
+    await expect(page.getByText("Copied to clipboard")).toBeVisible({
+      timeout: 10_000,
+    });
+    const copiedTextDRepDirectory = await page.evaluate(() =>
+      navigator.clipboard.readText()
+    );
+    expect(copiedTextDRepDirectory).toEqual(dRepId);
   });
 });

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
@@ -137,7 +137,7 @@ test("2M. Should access dRep directory page on disconnected state", async ({
 });
 
 test.describe("DRep dependent tests", () => {
-  let dRepId = "drep1ef7uslcjhjqrn4vv2y39c3yn345gzjsg7yufn76zye3v6fkz23q";
+  let dRepId: string;
   let dRepDirectoryPage: DRepDirectoryPage;
 
   test.beforeEach(async ({ page }) => {

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
@@ -24,6 +24,7 @@ import walletManager from "lib/walletManager";
 test.beforeEach(async () => {
   await setAllureEpic("2. Delegation");
   await skipIfNotHardFork();
+  test.skip(environments.networkId === 1);
 });
 
 test.describe("Delegate to others", () => {

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
@@ -74,24 +74,6 @@ test.describe("Delegate to others", () => {
       page.getByTestId("delegate-to-another-drep-button")
     ).toBeVisible();
   });
-
-  test("2L. Should copy delegated DRepId", async ({ page, context }) => {
-    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-
-    const dRepDirectory = new DRepDirectoryPage(page);
-    await dRepDirectory.goto();
-
-    await dRepDirectory.searchInput.fill(dRep01Wallet.dRepId);
-    await page.getByTestId(`${dRep01Wallet.dRepId}-copy-id-button`).click();
-    await expect(page.getByText("Copied to clipboard")).toBeVisible({
-      timeout: 10_000,
-    });
-
-    const copiedTextDRepDirectory = await page.evaluate(() =>
-      navigator.clipboard.readText()
-    );
-    expect(copiedTextDRepDirectory).toEqual(dRep01Wallet.dRepId);
-  });
 });
 
 test.describe("Change delegation", () => {

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
@@ -12,7 +12,7 @@ import {
 import { createTempDRepAuth } from "@datafactory/createAuth";
 import { test } from "@fixtures/walletExtension";
 import { setAllureEpic } from "@helpers/allure";
-import { skipIfNotHardFork } from "@helpers/cardano";
+import { skipIfMainnet, skipIfNotHardFork } from "@helpers/cardano";
 import { createNewPageWithWallet } from "@helpers/page";
 import { waitForTxConfirmation } from "@helpers/transaction";
 import DRepDirectoryPage from "@pages/dRepDirectoryPage";
@@ -24,7 +24,7 @@ import walletManager from "lib/walletManager";
 test.beforeEach(async () => {
   await setAllureEpic("2. Delegation");
   await skipIfNotHardFork();
-  test.skip(environments.networkId === 1);
+  await skipIfMainnet();
 });
 
 test.describe("Delegate to others", () => {

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -18,6 +18,7 @@ import { GovernanceActionType } from "@types";
 test.beforeEach(async () => {
   await setAllureEpic("3. DRep registration");
   await skipIfNotHardFork();
+  test.skip(environments.networkId === 1);
 });
 
 test.describe("Logged in DReps", () => {

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -5,7 +5,7 @@ import { faker } from "@faker-js/faker";
 import { test } from "@fixtures/walletExtension";
 import { setAllureEpic } from "@helpers/allure";
 import { ShelleyWallet } from "@helpers/crypto";
-import { skipIfNotHardFork } from "@helpers/cardano";
+import { skipIfMainnet, skipIfNotHardFork } from "@helpers/cardano";
 import { createNewPageWithWallet } from "@helpers/page";
 import { waitForTxConfirmation } from "@helpers/transaction";
 import DRepRegistrationPage from "@pages/dRepRegistrationPage";
@@ -18,7 +18,7 @@ import { GovernanceActionType } from "@types";
 test.beforeEach(async () => {
   await setAllureEpic("3. DRep registration");
   await skipIfNotHardFork();
-  test.skip(environments.networkId === 1);
+  await skipIfMainnet();
 });
 
 test.describe("Logged in DReps", () => {

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
@@ -7,10 +7,12 @@ import { invalid as mockInvalid, valid as mockValid } from "@mock/index";
 import { skipIfNotHardFork } from "@helpers/cardano";
 import EditDRepPage from "@pages/editDRepPage";
 import { expect } from "@playwright/test";
+import environments from "@constants/environments";
 
 test.beforeEach(async () => {
   await setAllureEpic("3. DRep registration");
   await skipIfNotHardFork();
+  test.skip(environments.networkId === 1);
 });
 
 test.use({ wallet: dRep02Wallet, storageState: ".auth/dRep02.json" });

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
@@ -4,7 +4,7 @@ import { test } from "@fixtures/walletExtension";
 import { setAllureEpic } from "@helpers/allure";
 import { ShelleyWallet } from "@helpers/crypto";
 import { invalid as mockInvalid, valid as mockValid } from "@mock/index";
-import { skipIfNotHardFork } from "@helpers/cardano";
+import { skipIfMainnet, skipIfNotHardFork } from "@helpers/cardano";
 import EditDRepPage from "@pages/editDRepPage";
 import { expect } from "@playwright/test";
 import environments from "@constants/environments";
@@ -12,7 +12,7 @@ import environments from "@constants/environments";
 test.beforeEach(async () => {
   await setAllureEpic("3. DRep registration");
   await skipIfNotHardFork();
-  test.skip(environments.networkId === 1);
+  await skipIfMainnet();
 });
 
 test.use({ wallet: dRep02Wallet, storageState: ".auth/dRep02.json" });

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
@@ -30,6 +30,7 @@ import {
 test.beforeEach(async () => {
   await setAllureEpic("4. Proposal visibility");
   await skipIfNotHardFork();
+  test.skip(environments.networkId === 1);
 });
 
 test.describe("Logged in DRep", () => {

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
@@ -7,6 +7,7 @@ import { setAllureEpic } from "@helpers/allure";
 import {
   isBootStrapingPhase,
   lovelaceToAda,
+  skipIfMainnet,
   skipIfNotHardFork,
 } from "@helpers/cardano";
 import { createNewPageWithWallet } from "@helpers/page";
@@ -30,7 +31,7 @@ import {
 test.beforeEach(async () => {
   await setAllureEpic("4. Proposal visibility");
   await skipIfNotHardFork();
-  test.skip(environments.networkId === 1);
+  await skipIfMainnet();
 });
 
 test.describe("Logged in DRep", () => {

--- a/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
@@ -12,17 +12,13 @@ import GovernanceActionDetailsPage from "@pages/governanceActionDetailsPage";
 import GovernanceActionsPage from "@pages/governanceActionsPage";
 import { Page, expect } from "@playwright/test";
 import kuberService from "@services/kuberService";
-import {
-  BootstrapGovernanceActionType,
-  GovernanceActionType,
-} from "@types";
+import { BootstrapGovernanceActionType, GovernanceActionType } from "@types";
 import walletManager from "lib/walletManager";
-
-const invalidInfinityProposals = require("../../lib/_mock/invalidInfinityProposals.json");
 
 test.beforeEach(async () => {
   await setAllureEpic("5. Proposal functionality");
   await skipIfNotHardFork();
+  test.skip(environments.networkId === 1);
 });
 
 test.describe("Proposal checks", () => {
@@ -125,47 +121,6 @@ test.describe("Proposal checks", () => {
         ).not.toEqual(randomContext);
       }
     });
-  });
-});
-
-test.describe("Bad Proposals", () => {
-  test.use({ storageState: ".auth/dRep01.json", wallet: dRep01Wallet });
-
-  let govActionsPage: GovernanceActionsPage;
-
-  test.beforeEach(async ({ page }) => {
-    await page.route("**/proposal/list?**", async (route) =>
-      route.fulfill({
-        body: JSON.stringify(invalidInfinityProposals),
-      })
-    );
-
-    govActionsPage = new GovernanceActionsPage(page);
-    await govActionsPage.goto();
-  });
-
-  test("5G. Should show warning in bad governance action proposal to the users to visit the site at their own risk, when external url is opened", async () => {
-    const govActionDetailsPage = await govActionsPage.viewFirstProposal();
-
-    await govActionDetailsPage.externalModalBtn.click();
-
-    await expect(govActionDetailsPage.externalLinkModal).toBeVisible();
-    await expect(
-      govActionDetailsPage.currentPage.getByText("Be careful", {
-        exact: false,
-      })
-    ).toBeVisible();
-  });
-
-  test("5H. Should open a new tab in Bad governance action proposal, when external URL is opened", async ({
-    page,
-  }) => {
-    const govActionDetailsPage = await govActionsPage.viewFirstProposal();
-
-    await govActionDetailsPage.externalModalBtn.click();
-    await govActionDetailsPage.continueModalBtn.click();
-    const existingPages = page.context().pages();
-    expect(existingPages).toHaveLength(1);
   });
 });
 
@@ -287,9 +242,9 @@ test.describe("Bootstrap phase", () => {
   test("5L. Should restrict dRep votes to Info Governance actions During Bootstrapping Phase", async ({
     browser,
   }) => {
-    const voteBlacklistOptions = Object.keys(BootstrapGovernanceActionType).filter(
-      (option) => option !== GovernanceActionType.InfoAction
-    );
+    const voteBlacklistOptions = Object.keys(
+      BootstrapGovernanceActionType
+    ).filter((option) => option !== GovernanceActionType.InfoAction);
 
     await Promise.all(
       voteBlacklistOptions.map(async (voteBlacklistOption) => {

--- a/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
@@ -4,7 +4,11 @@ import { createTempDRepAuth } from "@datafactory/createAuth";
 import { faker } from "@faker-js/faker";
 import { test } from "@fixtures/walletExtension";
 import { setAllureEpic } from "@helpers/allure";
-import { isBootStrapingPhase, skipIfNotHardFork } from "@helpers/cardano";
+import {
+  isBootStrapingPhase,
+  skipIfMainnet,
+  skipIfNotHardFork,
+} from "@helpers/cardano";
 import { encodeCIP129Identifier } from "@helpers/encodeDecode";
 import { createNewPageWithWallet } from "@helpers/page";
 import { waitForTxConfirmation } from "@helpers/transaction";
@@ -18,7 +22,7 @@ import walletManager from "lib/walletManager";
 test.beforeEach(async () => {
   await setAllureEpic("5. Proposal functionality");
   await skipIfNotHardFork();
-  test.skip(environments.networkId === 1);
+  await skipIfMainnet();
 });
 
 test.describe("Proposal checks", () => {

--- a/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.spec.ts
@@ -1,0 +1,49 @@
+import { test } from "@fixtures/walletExtension";
+import { setAllureEpic } from "@helpers/allure";
+import { skipIfNotHardFork } from "@helpers/cardano";
+import GovernanceActionsPage from "@pages/governanceActionsPage";
+import { expect } from "@playwright/test";
+const invalidInfinityProposals = require("../../lib/_mock/invalidInfinityProposals.json");
+
+test.beforeEach(async () => {
+  await setAllureEpic("5. Proposal functionality");
+  await skipIfNotHardFork();
+});
+test.describe("Bad Proposals", () => {
+  let govActionsPage: GovernanceActionsPage;
+
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/proposal/list?**", async (route) =>
+      route.fulfill({
+        body: JSON.stringify(invalidInfinityProposals),
+      })
+    );
+
+    govActionsPage = new GovernanceActionsPage(page);
+    await govActionsPage.goto();
+  });
+
+  test("5G. Should show warning in bad governance action proposal to the users to visit the site at their own risk, when external url is opened", async () => {
+    const govActionDetailsPage = await govActionsPage.viewFirstProposal();
+
+    await govActionDetailsPage.externalModalBtn.click();
+
+    await expect(govActionDetailsPage.externalLinkModal).toBeVisible();
+    await expect(
+      govActionDetailsPage.currentPage.getByText("Be careful", {
+        exact: false,
+      })
+    ).toBeVisible();
+  });
+
+  test("5H. Should open a new tab in Bad governance action proposal, when external URL is opened", async ({
+    page,
+  }) => {
+    const govActionDetailsPage = await govActionsPage.viewFirstProposal();
+
+    await govActionDetailsPage.externalModalBtn.click();
+    await govActionDetailsPage.continueModalBtn.click();
+    const existingPages = page.context().pages();
+    expect(existingPages).toHaveLength(1);
+  });
+});

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.dRep.spec.ts
@@ -8,6 +8,7 @@ import { expect } from "@playwright/test";
 test.beforeEach(async () => {
   await setAllureEpic("6. Miscellaneous");
   await skipIfNotHardFork();
+  test.skip(environments.networkId === 1);
 });
 
 test.use({

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.dRep.spec.ts
@@ -2,13 +2,13 @@ import environments from "@constants/environments";
 import { dRep01Wallet } from "@constants/staticWallets";
 import { test } from "@fixtures/walletExtension";
 import { setAllureEpic } from "@helpers/allure";
-import { skipIfNotHardFork } from "@helpers/cardano";
+import { skipIfMainnet, skipIfNotHardFork } from "@helpers/cardano";
 import { expect } from "@playwright/test";
 
 test.beforeEach(async () => {
   await setAllureEpic("6. Miscellaneous");
   await skipIfNotHardFork();
-  test.skip(environments.networkId === 1);
+  await skipIfMainnet();
 });
 
 test.use({

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.ga.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.ga.spec.ts
@@ -14,6 +14,7 @@ import { proposalFaucetWallet } from "@constants/proposalFaucetWallet";
 test.beforeEach(async () => {
   await setAllureEpic("7. Proposal submission");
   await skipIfNotHardFork();
+  test.skip(environments.networkId === 1);
 });
 
 Object.values(ProposalType).forEach((proposalType, index) => {

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.ga.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.ga.spec.ts
@@ -7,14 +7,14 @@ import { waitForTxConfirmation } from "@helpers/transaction";
 import ProposalDiscussionPage from "@pages/proposalDiscussionPage";
 import ProposalSubmissionPage from "@pages/proposalSubmissionPage";
 import { expect } from "@playwright/test";
-import { skipIfNotHardFork } from "@helpers/cardano";
+import { skipIfMainnet, skipIfNotHardFork } from "@helpers/cardano";
 import { ProposalType } from "@types";
 import { proposalFaucetWallet } from "@constants/proposalFaucetWallet";
 
 test.beforeEach(async () => {
   await setAllureEpic("7. Proposal submission");
   await skipIfNotHardFork();
-  test.skip(environments.networkId === 1);
+  await skipIfMainnet();
 });
 
 Object.values(ProposalType).forEach((proposalType, index) => {

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
@@ -12,6 +12,7 @@ import { setAllureEpic } from "@helpers/allure";
 import {
   skipIfTreasuryAndBootstrapping,
   skipIfNotHardFork,
+  isBootStrapingPhase,
 } from "@helpers/cardano";
 import { ShelleyWallet } from "@helpers/crypto";
 import { createNewPageWithWallet } from "@helpers/page";
@@ -329,9 +330,11 @@ test.describe("Info Proposal Draft", () => {
     });
 
     const proposalSubmissionPage = new ProposalSubmissionPage(page);
-    const { proposalFormValue } = await proposalSubmissionPage.createDraft(
-      ProposalType.treasury
-    );
+    const createProposalType = (await isBootStrapingPhase())
+      ? ProposalType.info
+      : ProposalType.treasury;
+    const { proposalFormValue } =
+      await proposalSubmissionPage.createDraft(createProposalType);
     const draftCard = proposalSubmissionPage.getFirstDraft();
     const draftCardAllInnerText = await (await draftCard).allInnerTexts();
 
@@ -343,7 +346,7 @@ test.describe("Info Proposal Draft", () => {
       .click();
 
     await expect(proposalSubmissionPage.governanceActionType).toHaveText(
-      ProposalType.treasury
+      createProposalType
     );
     await expect(proposalSubmissionPage.titleInput).toHaveValue(
       proposalFormValue.prop_name
@@ -357,12 +360,16 @@ test.describe("Info Proposal Draft", () => {
     await expect(proposalSubmissionPage.rationaleInput).toHaveValue(
       proposalFormValue.prop_rationale
     );
-    await expect(proposalSubmissionPage.receivingAddressInput).toHaveValue(
-      proposalFormValue.prop_receiving_address
-    );
-    await expect(proposalSubmissionPage.amountInput).toHaveValue(
-      proposalFormValue.prop_amount
-    );
+
+    if (createProposalType === ProposalType.treasury) {
+      await expect(proposalSubmissionPage.receivingAddressInput).toHaveValue(
+        proposalFormValue.prop_receiving_address
+      );
+      await expect(proposalSubmissionPage.amountInput).toHaveValue(
+        proposalFormValue.prop_amount
+      );
+    }
+
     await expect(proposalSubmissionPage.linkUrlInput).toHaveValue(
       proposalFormValue.proposal_links[0].prop_link
     );

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
@@ -141,6 +141,8 @@ test.describe("Proposal created logged state", () => {
         await proposalSubmissionPage.submitBtn.click();
 
         await expect(page.getByTestId("submit-as-GA-button")).toBeVisible();
+        const proposalDetailsPage = new ProposalDiscussionDetailsPage(page);
+
         await expect(proposalSubmissionPage.titleContent).toHaveText(
           proposal.prop_name
         );
@@ -159,6 +161,9 @@ test.describe("Proposal created logged state", () => {
         await expect(proposalSubmissionPage.linkTextContent).toHaveText(
           proposal.proposal_links[0].prop_link_text
         );
+
+        // cleanup
+        await proposalDetailsPage.deleteProposal();
       });
     });
   });
@@ -428,6 +433,9 @@ test.describe("Info Proposal Draft", () => {
     await proposalSubmissionPage.submitBtn.click();
 
     await expect(page.getByTestId("submit-as-GA-button")).toBeVisible();
+    const proposalDiscussionDetailsPage = new ProposalDiscussionDetailsPage(
+      page
+    );
     await expect(proposalSubmissionPage.titleContent).toHaveText(
       proposalFormValue.prop_name
     );
@@ -446,6 +454,9 @@ test.describe("Info Proposal Draft", () => {
     await expect(proposalSubmissionPage.linkTextContent).toHaveText(
       proposalFormValue.proposal_links[0].prop_link_text
     );
+
+    //cleanup
+    proposalDiscussionDetailsPage.deleteProposal();
   });
 });
 

--- a/tests/govtool-frontend/playwright/tests/8-proposal-discussion/proposalDiscussion.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/8-proposal-discussion/proposalDiscussion.loggedin.spec.ts
@@ -3,10 +3,8 @@ import {
   proposal02Wallet,
   user01Wallet,
 } from "@constants/staticWallets";
-import { createTempUserAuth } from "@datafactory/createAuth";
 import { faker } from "@faker-js/faker";
 import { test } from "@fixtures/proposal";
-import { ShelleyWallet } from "@helpers/crypto";
 import { createNewPageWithWallet } from "@helpers/page";
 import ProposalDiscussionDetailsPage from "@pages/proposalDiscussionDetailsPage";
 import { Page, expect } from "@playwright/test";
@@ -130,20 +128,6 @@ test.describe("Proposal created with poll enabled (user auth)", () => {
     await expect(
       page.getByTestId(`poll-${oppositeVote.toLowerCase()}-count`)
     ).not.toHaveText(`${oppositeVote}: (100%)`);
-  });
-});
-
-test.describe("Proposal created logged out state", () => {
-  let userPage: Page;
-
-  test.beforeEach(async ({ page, browser }) => {
-    const wallet = (await ShelleyWallet.generate()).json();
-    const tempUserAuth = await createTempUserAuth(page, wallet);
-
-    userPage = await createNewPageWithWallet(browser, {
-      storageState: tempUserAuth,
-      wallet,
-    });
   });
 });
 

--- a/tests/govtool-frontend/playwright/tests/dRep.setup.ts
+++ b/tests/govtool-frontend/playwright/tests/dRep.setup.ts
@@ -23,6 +23,7 @@ setup.beforeEach(async () => {
   await setAllureEpic("Setup");
   await setAllureStory("Register DRep");
   await skipIfNotHardFork();
+  setup.skip(environments.networkId === 1);
 });
 
 async function generateWallets(num: number) {

--- a/tests/govtool-frontend/playwright/tests/dRep.setup.ts
+++ b/tests/govtool-frontend/playwright/tests/dRep.setup.ts
@@ -1,7 +1,7 @@
 import environments from "@constants/environments";
 import { dRepWallets } from "@constants/staticWallets";
 import { setAllureEpic, setAllureStory } from "@helpers/allure";
-import { skipIfNotHardFork } from "@helpers/cardano";
+import { skipIfMainnet, skipIfNotHardFork } from "@helpers/cardano";
 import { ShelleyWallet } from "@helpers/crypto";
 import { uploadMetadataAndGetJsonHash } from "@helpers/metadata";
 import { pollTransaction } from "@helpers/transaction";
@@ -23,7 +23,7 @@ setup.beforeEach(async () => {
   await setAllureEpic("Setup");
   await setAllureStory("Register DRep");
   await skipIfNotHardFork();
-  setup.skip(environments.networkId === 1);
+  await skipIfMainnet();
 });
 
 async function generateWallets(num: number) {

--- a/tests/govtool-frontend/playwright/tests/dRep.teardown.ts
+++ b/tests/govtool-frontend/playwright/tests/dRep.teardown.ts
@@ -1,6 +1,7 @@
 import environments from "@constants/environments";
 import { dRepWallets } from "@constants/staticWallets";
 import { setAllureEpic, setAllureStory } from "@helpers/allure";
+import { skipIfMainnet } from "@helpers/cardano";
 import { pollTransaction } from "@helpers/transaction";
 import { test as cleanup, expect } from "@playwright/test";
 import kuberService from "@services/kuberService";
@@ -11,7 +12,7 @@ cleanup.describe.configure({ timeout: environments.txTimeOut });
 cleanup.beforeEach(async () => {
   await setAllureEpic("Setup");
   await setAllureStory("Cleanup");
-  cleanup.skip(environments.networkId === 1);
+  await skipIfMainnet();
 });
 
 cleanup("DRep de-registration", async () => {

--- a/tests/govtool-frontend/playwright/tests/dRep.teardown.ts
+++ b/tests/govtool-frontend/playwright/tests/dRep.teardown.ts
@@ -11,6 +11,7 @@ cleanup.describe.configure({ timeout: environments.txTimeOut });
 cleanup.beforeEach(async () => {
   await setAllureEpic("Setup");
   await setAllureStory("Cleanup");
+  cleanup.skip(environments.networkId === 1);
 });
 
 cleanup("DRep de-registration", async () => {

--- a/tests/govtool-frontend/playwright/tests/delegation.teardown.ts
+++ b/tests/govtool-frontend/playwright/tests/delegation.teardown.ts
@@ -11,6 +11,7 @@ cleanup.beforeEach(async () => {
   await setAllureEpic("Setup");
   await setAllureStory("Cleanup");
   await skipIfNotHardFork();
+  cleanup.skip(environments.networkId === 1);
 });
 cleanup(`Abstain delegation`, async () => {
   const stakePrivKeys = adaHolderWallets.map((wallet) => wallet.stake.private);

--- a/tests/govtool-frontend/playwright/tests/delegation.teardown.ts
+++ b/tests/govtool-frontend/playwright/tests/delegation.teardown.ts
@@ -1,7 +1,7 @@
 import environments from "@constants/environments";
 import { adaHolderWallets } from "@constants/staticWallets";
 import { setAllureStory, setAllureEpic } from "@helpers/allure";
-import { skipIfNotHardFork } from "@helpers/cardano";
+import { skipIfMainnet, skipIfNotHardFork } from "@helpers/cardano";
 import { pollTransaction } from "@helpers/transaction";
 import { test as cleanup } from "@playwright/test";
 import kuberService from "@services/kuberService";
@@ -11,7 +11,7 @@ cleanup.beforeEach(async () => {
   await setAllureEpic("Setup");
   await setAllureStory("Cleanup");
   await skipIfNotHardFork();
-  cleanup.skip(environments.networkId === 1);
+  await skipIfMainnet();
 });
 cleanup(`Abstain delegation`, async () => {
   const stakePrivKeys = adaHolderWallets.map((wallet) => wallet.stake.private);

--- a/tests/govtool-frontend/playwright/tests/faucet.setup.ts
+++ b/tests/govtool-frontend/playwright/tests/faucet.setup.ts
@@ -1,6 +1,7 @@
 import environments from "@constants/environments";
 import { faucetWallet } from "@constants/staticWallets";
 import { setAllureEpic, setAllureStory } from "@helpers/allure";
+import { skipIfMainnet } from "@helpers/cardano";
 import { pollTransaction } from "@helpers/transaction";
 import { test as setup } from "@playwright/test";
 import { loadAmountFromFaucet } from "@services/faucetService";
@@ -11,7 +12,7 @@ setup.describe.configure({ timeout: environments.txTimeOut });
 setup.beforeEach(async () => {
   await setAllureEpic("Setup");
   await setAllureStory("Faucet");
-  setup.skip(environments.networkId === 1);
+  await skipIfMainnet();
 });
 
 setup("Faucet setup", async () => {

--- a/tests/govtool-frontend/playwright/tests/faucet.setup.ts
+++ b/tests/govtool-frontend/playwright/tests/faucet.setup.ts
@@ -11,6 +11,7 @@ setup.describe.configure({ timeout: environments.txTimeOut });
 setup.beforeEach(async () => {
   await setAllureEpic("Setup");
   await setAllureStory("Faucet");
+  setup.skip(environments.networkId === 1);
 });
 
 setup("Faucet setup", async () => {

--- a/tests/govtool-frontend/playwright/tests/faucet.teardown.ts
+++ b/tests/govtool-frontend/playwright/tests/faucet.teardown.ts
@@ -1,6 +1,7 @@
 import environments from "@constants/environments";
 import { faucetWallet } from "@constants/staticWallets";
 import { setAllureEpic, setAllureStory } from "@helpers/allure";
+import { skipIfMainnet } from "@helpers/cardano";
 import { pollTransaction } from "@helpers/transaction";
 import { test as cleanup, expect } from "@playwright/test";
 import kuberService from "@services/kuberService";
@@ -9,7 +10,7 @@ cleanup.describe.configure({ timeout: environments.txTimeOut });
 cleanup.beforeEach(async () => {
   await setAllureEpic("Setup");
   await setAllureStory("Cleanup");
-  cleanup.skip(environments.networkId === 1);
+  await skipIfMainnet();
 });
 
 cleanup("Refund faucet", async () => {

--- a/tests/govtool-frontend/playwright/tests/faucet.teardown.ts
+++ b/tests/govtool-frontend/playwright/tests/faucet.teardown.ts
@@ -9,6 +9,7 @@ cleanup.describe.configure({ timeout: environments.txTimeOut });
 cleanup.beforeEach(async () => {
   await setAllureEpic("Setup");
   await setAllureStory("Cleanup");
+  cleanup.skip(environments.networkId === 1);
 });
 
 cleanup("Refund faucet", async () => {
@@ -16,7 +17,7 @@ cleanup("Refund faucet", async () => {
     const faucetRemainingBalance = await kuberService.getBalance(
       faucetWallet.address
     );
-  
+
     const transferBalance = Math.floor(faucetRemainingBalance) - 3;
     const { txId, lockInfo } = await kuberService.transferADA(
       [environments.faucet.address],
@@ -24,7 +25,7 @@ cleanup("Refund faucet", async () => {
     );
     await pollTransaction(txId, lockInfo);
   } catch (err) {
-     console.log(err);
+    console.log(err);
     if (err.status === 400) {
       expect(true, "Failed to trasfer Ada").toBeTruthy();
     } else {

--- a/tests/govtool-frontend/playwright/tests/wallet.bootstrap.ts
+++ b/tests/govtool-frontend/playwright/tests/wallet.bootstrap.ts
@@ -1,5 +1,6 @@
 import { adaHolderWallets, dRepWallets } from "@constants/staticWallets";
 import { setAllureEpic, setAllureStory } from "@helpers/allure";
+import { skipIfMainnet } from "@helpers/cardano";
 import { pollTransaction } from "@helpers/transaction";
 import { expect, test as setup } from "@playwright/test";
 import kuberService from "@services/kuberService";
@@ -10,7 +11,7 @@ setup.describe.configure({ mode: "serial", timeout: environments.txTimeOut });
 setup.beforeEach(async () => {
   await setAllureEpic("Setup");
   await setAllureStory("Wallet bootstrap");
-  setup.skip(environments.networkId === 1);
+  await skipIfMainnet();
 });
 
 setup("Initialize static wallets", async () => {

--- a/tests/govtool-frontend/playwright/tests/wallet.bootstrap.ts
+++ b/tests/govtool-frontend/playwright/tests/wallet.bootstrap.ts
@@ -10,6 +10,7 @@ setup.describe.configure({ mode: "serial", timeout: environments.txTimeOut });
 setup.beforeEach(async () => {
   await setAllureEpic("Setup");
   await setAllureStory("Wallet bootstrap");
+  setup.skip(environments.networkId === 1);
 });
 
 setup("Initialize static wallets", async () => {


### PR DESCRIPTION
## List of changes

- Separate ADA-independent tests into a different file for better organization
- Skipped ADA-spending tests and added Allure descriptions for improved reporting.
- Configured networkId to dynamically switch and use a mainnet wallet for mainnet tests.
- Modified test 1D to validate across different networks instead of being mainnet-specific.
- Implemented a workflow dispatch mechanism to trigger Playwright automated tests on gov.tools.
- Added logic to clean up proposals created during tests to avoid clutter and maintain test integrity.

## Checklist

- [related issue](https://github.com/cardanoapi/govtool-test-reports/issues/8)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
