### PR TITLE
Increase Node.js memory limit to 4GB in storybook dockerfile

### DIFF
--- a/govtool/frontend/storybook.Dockerfile
+++ b/govtool/frontend/storybook.Dockerfile
@@ -16,6 +16,8 @@ FROM node:18-alpine as builder
 ARG NPMRC_TOKEN
 WORKDIR /src
 
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+
 COPY --from=deps /src/node_modules ./node_modules
 COPY . .
 


### PR DESCRIPTION
### Temporary fix

This solution is temporary as we shouldn't exceed the default heap memory limit.

## List of changes

- increase the heap memory limit to 4GB in the storybook 

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2553)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
