### PR TITLE
fix: wrong drep activity conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ changes.
 
 - Fix CIP-129 DRep view identifier for script based DReps [Issue 2583](https://github.com/IntersectMBO/govtool/issues/2583)
 - Fix bad request on passing the random sorting to GA list request [Issue 2535](https://github.com/IntersectMBO/govtool/issues/2535)
+- Fix wrong drep activity conditions
 
 ### Changed
 


### PR DESCRIPTION
## List of changes

- Introduced changes to list-dreps SQL, including the epoch from the newest vote, making the DRep activity also depend on the recent DRep action and not only on the registrations or updates.

## Checklist

- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
