### PR TITLE
fix: fetching metadata from ipfs.io gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ changes.
 ### Fixed
 
 - Fix CIP-129 DRep view identifier for script based DReps [Issue 2583](https://github.com/IntersectMBO/govtool/issues/2583)
+- Fix fetching metadata from IPFS gateway
 - Fix bad request on passing the random sorting to GA list request [Issue 2535](https://github.com/IntersectMBO/govtool/issues/2535)
 - Fix wrong drep activity conditions
 

--- a/govtool/metadata-validation/src/app.service.ts
+++ b/govtool/metadata-validation/src/app.service.ts
@@ -32,6 +32,8 @@ export class AppService {
         this.httpService
           .get(url, {
             headers: {
+              // Required to not being blocked by APIs that require a User-Agent
+              'User-Agent': 'GovTool/Metadata-Validation-Tool',
               'Content-Type': 'application/json',
               ...(isIPFS &&
                 process.env.IPFS_PROJECT_ID && {


### PR DESCRIPTION
## List of changes

-  fetching metadata from ipfs.io gateway

### Why this was happening:
* ipfs.io appears to block requests from bots. As a result, the GovTool metadata validation service was blocked because it used the default axios user-agent.

## Checklist

- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
