### PR TITLE
Improve dRep Search Test and Governance Action Validation Using IDs

### DIFF
--- a/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
@@ -132,7 +132,7 @@ export default class DRepDirectoryPage {
     const cip129DRepListFE = await this.getAllListedCIP129DRepIds();
 
     const cip129DRepListApi = dRepList.map((dRep) =>
-      convertDRepToCIP129(dRep.drepId)
+      convertDRepToCIP129(dRep.drepId, dRep.isScriptBased)
     );
 
     for (let i = 0; i <= cip105DRepListFE.length - 1; i++) {

--- a/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
@@ -1,3 +1,4 @@
+import { convertDRepToCIP129 } from "@helpers/dRep";
 import { Locator, Page, expect } from "@playwright/test";
 import { IDRep } from "@types";
 import environments from "lib/constants/environments";
@@ -127,23 +128,45 @@ export default class DRepDirectoryPage {
     }
 
     // Frontend validation
-    const dRepListFE = await this.getAllListedDRepIds();
+    const cip105DRepListFE = await this.getAllListedCIP105DRepIds();
+    const cip129DRepListFE = await this.getAllListedCIP129DRepIds();
 
-    for (let i = 0; i <= dRepListFE.length - 1; i++) {
-      await expect(dRepListFE[i]).toHaveText(dRepList[i].view);
+    const cip129DRepListApi = dRepList.map((dRep) =>
+      convertDRepToCIP129(dRep.drepId)
+    );
+
+    console.log(cip129DRepListApi);
+    console.log(cip129DRepListFE);
+
+    for (let i = 0; i <= cip105DRepListFE.length - 1; i++) {
+      await expect(cip105DRepListFE[i]).toHaveText(dRepList[i].view);
+      await expect(cip129DRepListFE[i]).toHaveText(
+        `(CIP-129) ${cip129DRepListApi[i]}`
+      );
     }
   }
   getDRepCard(dRepId: string) {
     return this.page.getByTestId(`${dRepId}-drep-card`);
   }
 
-  async getAllListedDRepIds() {
+  async getAllListedCIP105DRepIds() {
     await this.page.waitForTimeout(2_000);
 
-    return await this.page
-      .getByRole("list")
-      .locator('[data-testid$="-copy-id-button"]')
-      .all();
+    const dRepCards = await this.getAllListedDReps();
+
+    return dRepCards.map((dRep) =>
+      dRep.locator('[data-testid$="-copy-id-button"]').first()
+    );
+  }
+
+  async getAllListedCIP129DRepIds() {
+    await this.page.waitForTimeout(2_000);
+
+    const dRepCards = await this.getAllListedDReps();
+
+    return dRepCards.map((dRep) =>
+      dRep.locator('[data-testid$="-copy-id-button"]').last()
+    );
   }
 
   async getAllListedDReps() {

--- a/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
@@ -135,9 +135,6 @@ export default class DRepDirectoryPage {
       convertDRepToCIP129(dRep.drepId)
     );
 
-    console.log(cip129DRepListApi);
-    console.log(cip129DRepListFE);
-
     for (let i = 0; i <= cip105DRepListFE.length - 1; i++) {
       await expect(cip105DRepListFE[i]).toHaveText(dRepList[i].view);
       await expect(cip129DRepListFE[i]).toHaveText(

--- a/tests/govtool-frontend/playwright/lib/types.ts
+++ b/tests/govtool-frontend/playwright/lib/types.ts
@@ -100,6 +100,7 @@ export enum FullGovernanceDRepVoteActionsType {
 export type DRepStatus = "Active" | "Inactive" | "Retired";
 
 export type IDRep = {
+  isScriptBased: boolean;
   drepId: string;
   view: string;
   url: string;

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
@@ -84,10 +84,10 @@ test("2O. Should load more DReps on show more", async ({ page }) => {
   const dRepDirectory = new DRepDirectoryPage(page);
   await dRepDirectory.goto();
 
-  const dRepIdsBefore = await dRepDirectory.getAllListedDRepIds();
+  const dRepIdsBefore = await dRepDirectory.getAllListedCIP105DRepIds();
   await dRepDirectory.showMoreBtn.click();
 
-  const dRepIdsAfter = await dRepDirectory.getAllListedDRepIds();
+  const dRepIdsAfter = await dRepDirectory.getAllListedCIP105DRepIds();
   expect(dRepIdsAfter.length).toBeGreaterThanOrEqual(dRepIdsBefore.length);
 
   if (dRepIdsAfter.length > dRepIdsBefore.length) {

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.loggedin.spec.ts
@@ -131,15 +131,15 @@ test("4C_3. Should filter and sort Governance Action Type on governance actions 
 });
 
 test("4L. Should search governance actions", async ({ page }) => {
-  let governanceActionTitle = "TreasuryTitle";
+  let governanceActionId: string;
   await page.route("**/proposal/list?**", async (route) => {
     const response = await route.fetch();
     const data = await response.json();
-    const elementsWithTitle = data["elements"].filter(
-      (element) => element["title"]
+    const elementsWithIds = data["elements"].map(
+      (element) => element["txHash"] + "#" + element["index"]
     );
-    if (elementsWithTitle.length !== 0) {
-      governanceActionTitle = elementsWithTitle[0]["title"];
+    if (elementsWithIds.length !== 0) {
+      governanceActionId = elementsWithIds[0];
     }
     await route.fulfill({
       status: 200,
@@ -154,14 +154,14 @@ test("4L. Should search governance actions", async ({ page }) => {
 
   await responsePromise;
 
-  await governanceActionPage.searchInput.fill(governanceActionTitle);
+  await governanceActionPage.searchInput.fill(governanceActionId);
 
   const proposalCards = await governanceActionPage.getAllProposals();
 
   for (const proposalCard of proposalCards) {
-    expect(
-      (await proposalCard.textContent()).includes(`${governanceActionTitle}`)
-    ).toBeTruthy();
+    await expect(
+      proposalCard.getByTestId(`${governanceActionId}-id`)
+    ).toBeVisible();
   }
 });
 


### PR DESCRIPTION
## List of changes

- Check both CIP129 and CIP105 dRep on search dRep test
- Update governance action search to use IDs instead of titles and validate using IDs, as some governance action might be data not verifiable
- Add CIP129 DRep conversion service to convert dRep hash to CIP129 based on script

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
