### PR TITLE
fix(#2472): trim whitespace from search input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ changes.
 ### Fixed
 
 - Fix searching by full DRep IDs on wrong prefix cut [Issue 2639](https://github.com/IntersectMBO/govtool/issues/2639)
+- Trim whitespace from search bar input [Issue 2472](https://github.com/IntersectMBO/govtool/issues/2472)
 
 ### Changed
 

--- a/govtool/frontend/src/context/dataActionsBar.tsx
+++ b/govtool/frontend/src/context/dataActionsBar.tsx
@@ -44,7 +44,7 @@ interface ProviderProps {
 const DataActionsBarProvider: FC<ProviderProps> = ({ children }) => {
   const isAdjusting = useRef<boolean>(false);
   const [searchText, setSearchText] = useState<string>("");
-  const debouncedSearchText = useDebounce(searchText, 300);
+  const debouncedSearchText = useDebounce(searchText.trim(), 300);
   const [filtersOpen, setFiltersOpen] = useState<boolean>(false);
   const [chosenFilters, setChosenFilters] = useState<string[]>([]);
   const [sortOpen, setSortOpen] = useState<boolean>(false);


### PR DESCRIPTION
## List of changes

- trim whitespace from search input

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2472)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
