### PR TITLE
Fix dRep directory url path and increase assertion timeout

### DIFF
--- a/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
@@ -44,7 +44,7 @@ export default class DRepDirectoryPage {
 
   async goto() {
     await this.page.goto(
-      `${environments.frontendUrl}/connected/dRep_directory`
+      `${environments.frontendUrl}/connected/drep_directory`
     );
   }
 

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
@@ -69,7 +69,7 @@ test("2N. Should show DRep information on details page", async ({
   // Add an assertion to prevent clicking on "View Your dRep Details".
   await expect(
     dRepPage.getByTestId("dRep-id-display-card-dashboard")
-  ).toContainText(wallet.dRepId, { timeout: 10_000 });
+  ).toContainText(wallet.dRepId, { timeout: 20_000 });
   await dRepPage.getByTestId("view-drep-details-button").click();
 
   // Verification

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
@@ -178,7 +178,7 @@ test.describe("Register DRep state", () => {
 
     await expect(
       dRepPage.getByText("You Have Retired as a Direct")
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 20_000 });
   });
 });
 

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -138,7 +138,9 @@ test.describe("Temporary DReps", () => {
 
     await dRepRegistrationPage.confirmBtn.click();
 
-    await expect(dRepPage.getByTestId("d-rep-in-progress")).not.toBeVisible();
+    await expect(dRepPage.getByTestId("d-rep-in-progress")).not.toBeVisible({
+      timeout: 20_000,
+    });
 
     // connected state
     const dRepDirectoryPage = new DRepDirectoryPage(page);

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -233,7 +233,8 @@ test.describe("Temporary DReps", () => {
       .click();
 
     await expect(dRepPage.getByTestId("d-rep-in-progress")).toHaveText(
-      /in progress/i
+      /in progress/i,
+      { timeout: 20_000 }
     );
   });
 });

--- a/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
@@ -183,13 +183,15 @@ test.describe("Perform voting", () => {
 
     await expect(
       govActionDetailsPage.currentPage.getByTestId("my-vote").getByText("No")
-    ).toBeVisible({ timeout: 15_000 });
+    ).toBeVisible({ timeout: 20_000 });
   });
 
   test("5F. Should show notification of casted vote after vote", async ({}, testInfo) => {
     test.setTimeout(testInfo.timeout + environments.txTimeOut);
     await govActionDetailsPage.vote();
-    await expect(govActionDetailsPage.voteSuccessModal).toBeVisible();
+    await expect(govActionDetailsPage.voteSuccessModal).toBeVisible({
+      timeout: 20_000,
+    });
   });
 
   test("5I. Should view the vote details,when viewing governance action already voted by the DRep", async ({}, testInfo) => {

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.ga.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.ga.spec.ts
@@ -54,7 +54,7 @@ Object.values(ProposalType).forEach((proposalType, index) => {
     await expect(userPage.getByTestId("ga-submitted-modal-title")).toHaveText(
       /governance action submitted!/i,
       {
-        timeout: 10_000,
+        timeout: 20_000,
       }
     );
 


### PR DESCRIPTION
## List of changes

- Change dRep directory URL path from '/dRep_directory' to '/drep_directory'
- Increase assertion timeout for slow-loading

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
