### PR TITLE
fix: usage of trim on missing label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ changes.
 
 ### Fixed
 
-- Fix calculating stake key balance [Issue 2653](https://github.com/IntersectMBO/govtool/issues/2653)
+- Fix usage of trim on missing label
 
 ### Changed
 

--- a/govtool/frontend/src/utils/testIdFromLabel.ts
+++ b/govtool/frontend/src/utils/testIdFromLabel.ts
@@ -1,2 +1,2 @@
 export const testIdFromLabel = (label: string) =>
-  label.trim().replace(/ /g, "-").toLocaleLowerCase();
+  label?.trim().replace(/ /g, "-").toLocaleLowerCase();


### PR DESCRIPTION
## List of changes

- Fix usage of trim on missing label

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2669)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
