### PR TITLE
feat(#2686): add share button to every DRep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ changes.
 
 ### Added
 
--
+- Add share DRep button to every DRep instead of only our own [Issue 2686](https://github.com/IntersectMBO/govtool/issues/2686)
 
 ### Fixed
 

--- a/govtool/frontend/src/components/molecules/DataMissingHeader.tsx
+++ b/govtool/frontend/src/components/molecules/DataMissingHeader.tsx
@@ -7,6 +7,8 @@ import {
   getMetadataDataMissingStatusTranslation,
 } from "@/utils";
 import { ICONS } from "@/consts";
+import { Share } from "./Share";
+import { useScreenDimension } from "@/hooks";
 
 type DataMissingHeaderProps = {
   isDataMissing: MetadataValidationStatus | null;
@@ -24,6 +26,7 @@ export const DataMissingHeader = ({
   image,
 }: DataMissingHeaderProps) => {
   const base64Image = getBase64ImageDetails(image ?? "");
+  const { screenWidth } = useScreenDimension();
 
   return (
     <Box
@@ -78,6 +81,7 @@ export const DataMissingHeader = ({
             title}
         </Typography>
       </Box>
+      {screenWidth >= 1020 && <Share link={window.location.href} />}
     </Box>
   );
 };

--- a/govtool/frontend/src/components/organisms/DRepDetailsCardHeader.tsx
+++ b/govtool/frontend/src/components/organisms/DRepDetailsCardHeader.tsx
@@ -10,7 +10,7 @@ import {
   useScreenDimension,
   useTranslation,
 } from "@hooks";
-import { DataMissingHeader, Share } from "@molecules";
+import { DataMissingHeader } from "@molecules";
 import { correctDRepDirectoryFormat } from "@utils";
 import { DRepData } from "@/models";
 
@@ -115,7 +115,6 @@ export const DRepDetailsCardHeader = ({
                   style={{ marginLeft: "4px" }}
                 />
               </Button>
-              {screenWidth >= 1020 && <Share link={window.location.href} />}
             </Box>
           )}
         </Box>


### PR DESCRIPTION
## List of changes

- Previously `share DRep` button was visible only for our own registered DRep, this PR introduces this button for every DRep detail page

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2686)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
