### PR TITLE
chore(#2682): remove logging to sentry on failed delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ changes.
 ### Removed
 
 - Remove logging to sentry for DRep registration transaction [Issue 2681](https://github.com/IntersectMBO/govtool/issues/2681)
+- Remove logging to sentry when delegation transaction fails [Issue 2682](https://github.com/IntersectMBO/govtool/issues/2682)
 
 ## [v2.0.7](https://github.com/IntersectMBO/govtool/releases/tag/v2.0.7) 2025-01-20
 

--- a/govtool/frontend/src/hooks/useDelegateToDrep.ts
+++ b/govtool/frontend/src/hooks/useDelegateToDrep.ts
@@ -1,5 +1,4 @@
 import { useCallback, useState } from "react";
-import * as Sentry from "@sentry/react";
 
 import { useCardano, useSnackbar } from "@context";
 import { useGetVoterInfo, useTranslation, useWalletErrorModal } from "@hooks";
@@ -60,8 +59,6 @@ export const useDelegateTodRep = () => {
               : (error as { message: string | null })?.message,
           dataTestId: "delegate-transaction-error-modal",
         });
-        Sentry.setTag("hook", "useDelegateTodRep");
-        Sentry.captureException(error);
       } finally {
         setIsDelegating(null);
       }


### PR DESCRIPTION
## List of changes

- remove logging to sentry on failed delegation

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2682)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
