### PR TITLE
Update deployment order

### DIFF
--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -1,9 +1,6 @@
 name: Backend Test
 
 on:
-  push:
-    branches:
-      - test
   workflow_dispatch:
     inputs:
       deployment:
@@ -26,6 +23,9 @@ on:
           - "preview"
           - "mainnet"
           - "preprod"
+  workflow_run:
+    workflows: ["Build and deploy GovTool test stack"]
+    types: [completed]
 
 jobs:
   backend-tests:

--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -6,7 +6,7 @@ on:
       deployment:
         required: true
         type: choice
-        default: "z6b8d2f7a-zca4a4c45-gtw.z937eb260.rustrocks.fr"
+        default: "govtool.cardanoapi.io/api"
         options:
           - "sanchogov.tools/api"
           - "staging.govtool.byron.network/api"

--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -30,6 +30,7 @@ on:
 jobs:
   backend-tests:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }} 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -68,7 +69,7 @@ jobs:
 
   publish-report:
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && needs.backend-tests.result != 'skipped'
     needs: backend-tests
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_integration_playwright.yml
+++ b/.github/workflows/test_integration_playwright.yml
@@ -6,7 +6,7 @@ on:
       deployment:
         required: true
         type: choice
-        default: "preview.gov.tools"
+        default: "govtool.cardanoapi.io"
         options:
           - "sanchogov.tools"
           - "staging.govtool.byron.network"

--- a/.github/workflows/test_integration_playwright.yml
+++ b/.github/workflows/test_integration_playwright.yml
@@ -30,6 +30,7 @@ on:
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }} 
     defaults:
       run:
         working-directory: tests/govtool-frontend/playwright
@@ -108,7 +109,7 @@ jobs:
 
   publish-report:
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && needs.integration-tests.result != 'skipped' 
     needs: integration-tests
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_integration_playwright.yml
+++ b/.github/workflows/test_integration_playwright.yml
@@ -1,9 +1,6 @@
 name: Integration Test [Playwright]
 
 on:
-  push:
-    branches:
-      - test
   workflow_dispatch:
     inputs:
       deployment:
@@ -27,7 +24,7 @@ on:
           - "preprod"
 
   workflow_run:
-    workflows: ["Build and deploy GovTool to TEST server"]
+    workflows: ["Build and deploy GovTool test stack"]
     types: [completed]
 
 jobs:


### PR DESCRIPTION
## List of changes

- Update workflow triggers for backend and integration tests to depend on the test stack deployment.
- update test workflow to run only on test stack deployment success

## Checklist

- [related issue](https://github.com/intersectMBO/govtool/issues/2775)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
