### PR TITLE
Fix : Report 275 failing test

### DIFF
--- a/tests/govtool-frontend/playwright/generate_wallets.ts
+++ b/tests/govtool-frontend/playwright/generate_wallets.ts
@@ -15,10 +15,11 @@ function saveWallets(wallets: ShelleyWallet[]): void {
   const jsonWallets = [];
   for (let i = 0; i < wallets.length; i++) {
     const dRepId = extractDRepFromWallet(wallets[i]);
+    const networkId = process.env.NETWORK === "mainnet" ? 1 : 0;
 
     jsonWallets.push({
       ...wallets[i].json(),
-      address: wallets[i].addressBech32(0), // testnet
+      address: wallets[i].addressBech32(networkId),
       dRepId,
     });
   }

--- a/tests/govtool-frontend/playwright/lib/helpers/dRep.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/dRep.ts
@@ -1,5 +1,6 @@
 import DRepDirectoryPage from "@pages/dRepDirectoryPage";
 import { Page } from "@playwright/test";
+import { IDRep } from "@types";
 import { bech32 } from "bech32";
 
 export async function fetchFirstActiveDRepDetails(page: Page) {
@@ -12,7 +13,7 @@ export async function fetchFirstActiveDRepDetails(page: Page) {
       const response = await route.fetch();
       const json = await response.json();
       const elements = json["elements"].filter(
-        (element) => element["givenName"] != null
+        (element: IDRep) => element.givenName != null && !element.isScriptBased
       );
       dRepGivenName =
         elements[Math.floor(Math.random() * elements.length)]["givenName"];

--- a/tests/govtool-frontend/playwright/lib/helpers/dRep.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/dRep.ts
@@ -2,6 +2,7 @@ import DRepDirectoryPage from "@pages/dRepDirectoryPage";
 import { Page } from "@playwright/test";
 import { IDRep } from "@types";
 import { bech32 } from "bech32";
+import * as crypto from "crypto";
 
 export async function fetchFirstActiveDRepDetails(page: Page) {
   let dRepGivenName: string;

--- a/tests/govtool-frontend/playwright/lib/helpers/metadata.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/metadata.ts
@@ -8,6 +8,7 @@ import * as fs from "fs";
 import { ShelleyWallet } from "./crypto";
 import { calculateImageSHA256 } from "./dRep";
 import { imageObject } from "@types";
+import environments from "@constants/environments";
 
 export async function downloadMetadata(download: Download): Promise<{
   name: string;
@@ -22,7 +23,9 @@ export async function downloadMetadata(download: Download): Promise<{
 
 async function calculateMetadataHash() {
   try {
-    const paymentAddress = (await ShelleyWallet.generate()).addressBech32(0);
+    const paymentAddress = (await ShelleyWallet.generate()).addressBech32(
+      environments.networkId
+    );
     const imageUrl = faker.image.avatarGitHub();
     const imageSHA256 = (await calculateImageSHA256(imageUrl)) || "";
     const imageObject: imageObject = {

--- a/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
@@ -159,7 +159,7 @@ export default class GovernanceActionsPage {
 
     await expect(
       this.page.getByRole("progressbar").getByRole("img")
-    ).toBeHidden({ timeout: 10_000 });
+    ).toBeHidden({ timeout: 20_000 });
 
     // Frontend validation
     for (let dIdx = 0; dIdx <= proposalsByType.length - 1; dIdx++) {

--- a/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
@@ -348,7 +348,9 @@ export default class ProposalSubmissionPage {
     proposalType: ProposalType = ProposalType.treasury
   ): Promise<number> {
     await this.addLinkBtn.click();
-    const receivingAddr = ShelleyWallet.fromJson(wallet).rewardAddressBech32(0);
+    const receivingAddr = ShelleyWallet.fromJson(wallet).rewardAddressBech32(
+      environments.networkId
+    );
 
     const proposalRequest: ProposalCreateRequest =
       this.generateValidProposalFormFields(
@@ -374,7 +376,9 @@ export default class ProposalSubmissionPage {
     const proposalFormValue = this.generateValidProposalFormFields(
       proposalType,
       true,
-      ShelleyWallet.fromJson(proposal04Wallet).rewardAddressBech32(0)
+      ShelleyWallet.fromJson(proposal04Wallet).rewardAddressBech32(
+        environments.networkId
+      )
     );
     await this.fillupForm(proposalFormValue);
 

--- a/tests/govtool-frontend/playwright/lib/types.ts
+++ b/tests/govtool-frontend/playwright/lib/types.ts
@@ -110,6 +110,7 @@ export type IDRep = {
   status: DRepStatus;
   type: string;
   latestTxHash: string;
+  givenName: string | null;
   latestRegistrationDate: string;
 };
 

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.drep.spec.ts
@@ -39,7 +39,9 @@ test("2N. Should show DRep information on details page", async ({
   const objectives = faker.lorem.paragraph(2);
   const motivations = faker.lorem.paragraph(2);
   const qualifications = faker.lorem.paragraph(2);
-  const paymentAddress = ShelleyWallet.fromJson(wallet).rewardAddressBech32(0);
+  const paymentAddress = ShelleyWallet.fromJson(wallet).addressBech32(
+    environments.networkId
+  );
   const linksReferenceLinks: LinkType[] = [
     {
       url: faker.internet.url(),

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
@@ -264,9 +264,9 @@ test.describe("Abstain delegation", () => {
 
     const balance = await kuberService.getBalance(adaHolder03Wallet.address);
 
-    await expect(
-      page.getByText(`You have delegated ₳${balance}`)
-    ).toBeVisible();
+    await expect(page.getByText(`You have delegated ₳${balance}`)).toBeVisible({
+      timeout: 20_000,
+    });
   });
 });
 
@@ -291,9 +291,9 @@ test.describe("No confidence delegation", () => {
     await waitForTxConfirmation(page);
 
     const balance = await kuberService.getBalance(adaHolder04Wallet.address);
-    await expect(
-      page.getByText(`You have delegated ₳${balance}`)
-    ).toBeVisible();
+    await expect(page.getByText(`You have delegated ₳${balance}`)).toBeVisible({
+      timeout: 20_000,
+    });
   });
 });
 
@@ -318,13 +318,13 @@ test.describe("Delegated ADA visibility", () => {
     );
     await expect(
       page.getByText(`You have delegated ₳ ${adaHolderVotingPower}`)
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 20_000 });
 
     await page.goto("/");
     await expect(
       page.getByText(
         `Your Voting Power of ₳${adaHolderVotingPower} is Delegated to`
       )
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 20_000 });
   });
 });

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegationFunctionality.delegation.spec.ts
@@ -102,7 +102,7 @@ test.describe("Change delegation", () => {
       page
         .getByTestId(`${dRepIdFirst}-delegated-card`)
         .getByTestId(`${dRepIdFirst}-copy-id-button`)
-    ).toHaveText(dRepIdFirst, { timeout: 20_000 });
+    ).toHaveText(`(CIP-105) ${dRepIdFirst}`, { timeout: 20_000 });
 
     // verify delegation
     await dRepDirectoryPage.delegateToDRep(dRepIdSecond);
@@ -113,7 +113,7 @@ test.describe("Change delegation", () => {
       page
         .getByTestId(`${dRepIdSecond}-delegated-card`)
         .getByTestId(`${dRepIdSecond}-copy-id-button`)
-    ).toHaveText(dRepIdSecond, { timeout: 20_000 });
+    ).toHaveText(`(CIP-105) ${dRepIdSecond}`, { timeout: 20_000 });
   });
 });
 
@@ -149,7 +149,9 @@ test.describe("Register DRep state", () => {
     await waitForTxConfirmation(dRepPage);
 
     // Checks in dashboard
-    await expect(dRepPage.getByText("You are a Direct Voter")).toBeVisible();
+    await expect(dRepPage.getByText("You are a Direct Voter")).toBeVisible({
+      timeout: 20_000,
+    });
     await expect(
       dRepPage.getByTestId("register-as-sole-voter-button")
     ).not.toBeVisible();
@@ -168,7 +170,9 @@ test.describe("Register DRep state", () => {
     ).toBeVisible({ timeout: 15_000 });
     await dRepPage.getByTestId("confirm-modal-button").click();
     await waitForTxConfirmation(dRepPage);
-    await expect(dRepPage.getByText("You are a Direct Voter")).toBeVisible();
+    await expect(dRepPage.getByText("You are a Direct Voter")).toBeVisible({
+      timeout: 20_000,
+    });
 
     const dRepDirectoryPage = new DRepDirectoryPage(dRepPage);
     await dRepDirectoryPage.goto();

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -29,11 +29,13 @@ test.describe("Logged in DReps", () => {
   }) => {
     await page.goto("/");
 
-    await expect(page.getByTestId("voting-power-chips")).toBeVisible();
+    await expect(page.getByTestId("voting-power-chips")).toBeVisible({
+      timeout: 20_000,
+    });
 
     await expect(
       page.getByTestId("dRep-id-display-card-dashboard")
-    ).toContainText(dRep01Wallet.dRepId, { timeout: 10_000 });
+    ).toContainText(dRep01Wallet.dRepId, { timeout: 20_000 });
 
     const governanceActionsPage = new GovernanceActionsPage(page);
 
@@ -57,7 +59,7 @@ test.describe("Logged in DReps", () => {
     // Add an assertion to prevent clicking on "View Your dRep Details".
     await expect(
       page.getByTestId("dRep-id-display-card-dashboard")
-    ).toContainText(dRep01Wallet.dRepId, { timeout: 10_000 });
+    ).toContainText(dRep01Wallet.dRepId, { timeout: 20_000 });
 
     await page.getByTestId("view-drep-details-button").click();
     await page.getByTestId("edit-drep-data-button").click();

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -70,7 +70,9 @@ test.describe("Logged in DReps", () => {
       objectives: faker.lorem.paragraph(2),
       motivations: faker.lorem.paragraph(2),
       qualifications: faker.lorem.paragraph(2),
-      paymentAddress: (await ShelleyWallet.generate()).addressBech32(0),
+      paymentAddress: (await ShelleyWallet.generate()).addressBech32(
+        environments.networkId
+      ),
       linksReferenceLinks: [
         {
           url: faker.internet.url(),

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -233,7 +233,9 @@ test.describe("Temporary DReps", () => {
 
     const dRepRegistrationPage = new DRepRegistrationPage(dRepPage);
     await dRepRegistrationPage.goto();
-    await dRepRegistrationPage.register({ name: faker.person.firstName() });
+    await dRepRegistrationPage.registerWithoutTxConfirmation({
+      name: faker.person.firstName(),
+    });
     await dRepRegistrationPage.registrationSuccessModal
       .getByTestId("confirm-modal-button")
       .click();
@@ -242,5 +244,11 @@ test.describe("Temporary DReps", () => {
       /in progress/i,
       { timeout: 20_000 }
     );
+
+    await waitForTxConfirmation(dRepPage);
+
+    await expect(dRepPage.getByTestId("d-rep-in-progress")).not.toBeVisible({
+      timeout: 20_000,
+    });
   });
 });

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -201,7 +201,9 @@ test.describe("Temporary DReps", () => {
 
     await waitForTxConfirmation(dRepPage);
 
-    await expect(dRepPage.getByTestId("voting-power-chips")).not.toBeVisible();
+    await expect(dRepPage.getByTestId("voting-power-chips")).not.toBeVisible({
+      timeout: 20_000,
+    });
 
     await expect(dRepPage.getByTestId("dRep-id-display")).not.toBeVisible();
 

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.loggedin.spec.ts
@@ -7,6 +7,7 @@ import { invalid as mockInvalid, valid as mockValid } from "@mock/index";
 import { skipIfNotHardFork } from "@helpers/cardano";
 import DRepRegistrationPage from "@pages/dRepRegistrationPage";
 import { expect } from "@playwright/test";
+import environments from "@constants/environments";
 
 test.use({
   storageState: ".auth/user01.json",
@@ -64,7 +65,9 @@ test.describe("Validation of dRep Registration Form", () => {
         objectives: faker.lorem.paragraph(2),
         motivations: faker.lorem.paragraph(2),
         qualifications: faker.lorem.paragraph(2),
-        paymentAddress: (await ShelleyWallet.generate()).addressBech32(0),
+        paymentAddress: (await ShelleyWallet.generate()).addressBech32(
+          environments.networkId
+        ),
         linksReferenceLinks: [
           {
             url: faker.internet.url(),

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
@@ -33,7 +33,9 @@ test.describe("Validation of edit dRep Form", () => {
         objectives: faker.lorem.paragraph(2),
         motivations: faker.lorem.paragraph(2),
         qualifications: faker.lorem.paragraph(2),
-        paymentAddress: (await ShelleyWallet.generate()).addressBech32(0),
+        paymentAddress: (await ShelleyWallet.generate()).addressBech32(
+          environments.networkId
+        ),
         linksReferenceLinks: [
           {
             url: faker.internet.url(),

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
@@ -44,7 +44,8 @@ test.describe("Logged in DRep", () => {
     const votingPower = await res.json();
 
     await expect(page.getByTestId("voting-power-chips-value")).toHaveText(
-      `₳ ${lovelaceToAda(votingPower)}`
+      `₳ ${lovelaceToAda(votingPower)}`,
+      { timeout: 20_000 }
     );
   });
 
@@ -56,7 +57,7 @@ test.describe("Logged in DRep", () => {
 
       // assert to wait until the loading button is hidden
       await expect(page.getByTestId("to-vote-tab")).toBeVisible({
-        timeout: 15_000,
+        timeout: 20_000,
       });
 
       govActionDetailsPage = (await isBootStrapingPhase())

--- a/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
@@ -37,7 +37,7 @@ test.describe("Proposal checks", () => {
 
     // assert to wait until the loading button is hidden
     await expect(page.getByTestId("to-vote-tab")).toBeVisible({
-      timeout: 15_000,
+      timeout: 20_000,
     });
 
     currentPage = page;
@@ -150,7 +150,7 @@ test.describe("Perform voting", () => {
 
     // assert to wait until the loading button is hidden
     await expect(dRepPage.getByTestId("to-vote-tab")).toBeVisible({
-      timeout: 15_000,
+      timeout: 20_000,
     });
 
     govActionDetailsPage = (await isBootStrapingPhase())
@@ -277,10 +277,12 @@ test.describe("Bootstrap phase", () => {
         await governanceActionsPage.goto();
 
         // assert to wait until proposal cards are visible
-        await expect(dRepPage.getByTestId("voting-power-chips")).toBeVisible();
+        await expect(dRepPage.getByTestId("voting-power-chips")).toBeVisible({
+          timeout: 20_000,
+        });
         // wait until the loading button is hidden
         await expect(dRepPage.getByTestId("to-vote-tab")).toBeVisible({
-          timeout: 15_000,
+          timeout: 20_000,
         });
 
         const governanceActionDetailsPage =

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
@@ -178,7 +178,8 @@ test.describe("User Snap", () => {
       // Intercept Usersnap submit API
       await page.route(feedbackApiUrl, async (route) =>
         route.fulfill({
-          status: 200,
+          status: 403,
+          body: JSON.stringify({ error: "Blocked by test" }),
         })
       );
 
@@ -202,7 +203,8 @@ test.describe("User Snap", () => {
       // Intercept Usersnap submit API
       await page.route(feedbackApiUrl, async (route) =>
         route.fulfill({
-          status: 200,
+          status: 403,
+          body: JSON.stringify({ error: "Blocked by test" }),
         })
       );
 

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
@@ -128,14 +128,14 @@ test.describe("Proposal created logged state", () => {
 
         await proposalSubmissionPage.addLinkBtn.click();
 
-        const walletAddressBech32 = ShelleyWallet.fromJson(
+        const stakeAddressBech32 = ShelleyWallet.fromJson(
           wallet
-        ).addressBech32(environments.networkId);
+        ).rewardAddressBech32(environments.networkId);
         const proposal: ProposalCreateRequest =
           proposalSubmissionPage.generateValidProposalFormFields(
             type,
             false,
-            walletAddressBech32
+            stakeAddressBech32
           );
 
         await proposalSubmissionPage.fillupForm(proposal);
@@ -182,14 +182,14 @@ test.describe("Proposal created logged state", () => {
 
         await proposalSubmissionPage.addLinkBtn.click();
 
-        const walletAddressBech32 = ShelleyWallet.fromJson(
+        const rewardAddressBech32 = ShelleyWallet.fromJson(
           proposal01Wallet
-        ).addressBech32(environments.networkId);
+        ).rewardAddressBech32(environments.networkId);
         const proposal: ProposalCreateRequest =
           proposalSubmissionPage.generateValidProposalFormFields(
             type,
             false,
-            walletAddressBech32
+            rewardAddressBech32
           );
 
         await proposalSubmissionPage.fillupForm(proposal);

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
@@ -1,3 +1,4 @@
+import environments from "@constants/environments";
 import {
   proposal01Wallet,
   proposal03Wallet,
@@ -56,7 +57,7 @@ test.describe("Proposal created logged state", () => {
         for (let i = 0; i < 50; i++) {
           const rewardAddressBech32 = (
             await ShelleyWallet.generate()
-          ).rewardAddressBech32(0);
+          ).rewardAddressBech32(environments.networkId);
           const formFields: ProposalCreateRequest =
             proposalSubmissionPage.generateValidProposalFormFields(
               type,
@@ -127,8 +128,9 @@ test.describe("Proposal created logged state", () => {
 
         await proposalSubmissionPage.addLinkBtn.click();
 
-        const walletAddressBech32 =
-          ShelleyWallet.fromJson(wallet).rewardAddressBech32(0);
+        const walletAddressBech32 = ShelleyWallet.fromJson(
+          wallet
+        ).addressBech32(environments.networkId);
         const proposal: ProposalCreateRequest =
           proposalSubmissionPage.generateValidProposalFormFields(
             type,
@@ -180,8 +182,9 @@ test.describe("Proposal created logged state", () => {
 
         await proposalSubmissionPage.addLinkBtn.click();
 
-        const walletAddressBech32 =
-          ShelleyWallet.fromJson(proposal01Wallet).rewardAddressBech32(0);
+        const walletAddressBech32 = ShelleyWallet.fromJson(
+          proposal01Wallet
+        ).addressBech32(environments.networkId);
         const proposal: ProposalCreateRequest =
           proposalSubmissionPage.generateValidProposalFormFields(
             type,

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
@@ -354,7 +354,8 @@ test.describe("Info Proposal Draft", () => {
       .click();
 
     await expect(proposalSubmissionPage.governanceActionType).toHaveText(
-      createProposalType
+      createProposalType,
+      { timeout: 20_000 }
     );
     await expect(proposalSubmissionPage.titleInput).toHaveValue(
       proposalFormValue.prop_name

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.loggedin.spec.ts
@@ -32,7 +32,7 @@ test.describe("Proposal created logged state", () => {
   test.use({ storageState: ".auth/proposal01.json", wallet: proposal01Wallet });
   test("7B. Should access proposal creation page", async ({ page }) => {
     await page.goto("/");
-    await page.getByTestId("propose-governance-actions-button").click();
+    await page.getByTestId("proposal-discussion-link").click();
 
     await expect(page.getByText(/proposals/i)).toHaveCount(2);
   });


### PR DESCRIPTION
## List of changes

- Update the fetch logic for the first dRep filter to exclude script-based dReps, as they cause issues displaying the dRep ID on the dRep card.  
- Update dRep assertions to include the CIP-105 prefix.  
- Use the wallet address to generate the payment address for dReps.  
- Update the proposal discussion link.  
- Fix the issue with user snap URL interception.  
- Increase the timeout for assertions.
- Use env networkId instead of hardcoded zero to get the address from wallet
-  fix crypto not found issue
- generate wallet address according to environment network
- use stake address on proposal creation form instead of wallet address

## Checklist

- [related report](https://intersectmbo.github.io/govtool-test-reports/govtool-frontend/275/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
