### PR TITLE
fix(#2683): handle missing usersnap api key exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ changes.
 - Fix usage of trim on missing label
 - Fix blank screen when registering as a DRep [Issue 2408](https://github.com/IntersectMBO/govtool/issues/2408)
 - Fix type mismatch between sql and haskell code for stake key address
+- Handle missing api key exception [Issue 2683](https://github.com/IntersectMBO/govtool/issues/2683)
 
 ### Changed
 

--- a/govtool/frontend/src/context/usersnapContext.tsx
+++ b/govtool/frontend/src/context/usersnapContext.tsx
@@ -73,11 +73,19 @@ export const UsersnapProvider = ({
   }, [usersnapApi]);
 
   useEffect(() => {
-    loadSpace(API_KEY).then((api) => {
-      api.init(initParams);
-      setUsersnapApi(api);
-    });
-  }, [initParams]);
+    const initUsersnapSpace = async () => {
+      if (API_KEY) {
+        try {
+          const api = await loadSpace(API_KEY);
+          api.init(initParams);
+          setUsersnapApi(api);
+        } catch (error) {
+          console.error(error);
+        }
+      }
+    };
+    initUsersnapSpace();
+  }, [initParams, API_KEY]);
 
   const value = useMemo(() => ({ openFeedbackWindow }), [openFeedbackWindow]);
 


### PR DESCRIPTION
## List of changes

- handle missing usersnap api key exception

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2683)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
