### PR TITLE
feat(#2893): move ratification threshold label below voters title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ changes.
 
 - Change votes representation on Governance Actions [Issue 2880](https://github.com/IntersectMBO/govtool/issues/2880)
 - Change vote rationale character limit to 10000 [Issue 2891](https://github.com/IntersectMBO/govtool/issues/2891)
+- Move ratification threshold label below the voter type [Issue 2893](https://github.com/IntersectMBO/govtool/issues/2893)
 
 ### Removed
 

--- a/govtool/frontend/src/components/molecules/VotesSubmitted.tsx
+++ b/govtool/frontend/src/components/molecules/VotesSubmitted.tsx
@@ -226,27 +226,6 @@ const VotesGroup = ({
       >
         {t(`govActions.${type}`)}
       </Typography>
-      <Vote
-        type={type}
-        vote="yes"
-        percentage={yesVotesPercentage}
-        value={yesVotes}
-      />
-      <Vote type={type} vote="abstain" value={abstainVotes} />
-      <Vote
-        type={type}
-        vote="no"
-        percentage={noVotesPercentage}
-        value={noVotes}
-      />
-      {typeof notVotedVotes === "number" && (
-        <Vote
-          type={type}
-          vote="notVoted"
-          percentage={notVotedPercentage}
-          value={notVotedVotes}
-        />
-      )}
       {threshold !== undefined && threshold !== null && (
         <Box
           display="flex"
@@ -278,6 +257,27 @@ const VotesGroup = ({
             {threshold * 100}%
           </Typography>
         </Box>
+      )}
+      <Vote
+        type={type}
+        vote="yes"
+        percentage={yesVotesPercentage}
+        value={yesVotes}
+      />
+      <Vote type={type} vote="abstain" value={abstainVotes} />
+      <Vote
+        type={type}
+        vote="no"
+        percentage={noVotesPercentage}
+        value={noVotes}
+      />
+      {typeof notVotedVotes === "number" && (
+        <Vote
+          type={type}
+          vote="notVoted"
+          percentage={notVotedPercentage}
+          value={notVotedVotes}
+        />
       )}
     </Box>
   );


### PR DESCRIPTION
## List of changes

- move ratification threshold label below voters title

![Zrzut ekranu z 2025-02-04 11-48-51](https://github.com/user-attachments/assets/82d8272c-37f0-4408-a5f6-631096a90a11)

![Zrzut ekranu z 2025-02-04 11-49-24](https://github.com/user-attachments/assets/6d5977a9-55e7-4af3-9f99-028ab842c8b1)


## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2893)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
