### PR TITLE
fix(#2891): change vote rationale character limit to 10000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ changes.
 ### Changed
 
 - Change votes representation on Governance Actions [Issue 2880](https://github.com/IntersectMBO/govtool/issues/2880)
+- Change vote rationale character limit to 10000 [Issue 2891](https://github.com/IntersectMBO/govtool/issues/2891)
 
 ### Removed
 

--- a/govtool/frontend/src/components/organisms/VoteContext/VoteContextText.tsx
+++ b/govtool/frontend/src/components/organisms/VoteContext/VoteContextText.tsx
@@ -10,6 +10,7 @@ type VoteContextTextProps = {
   setStep: Dispatch<SetStateAction<number>>;
   onCancel: () => void;
 };
+const MAX_LENGTH = 10000;
 
 export const VoteContextText = ({
   setStep,
@@ -31,9 +32,9 @@ export const VoteContextText = ({
         message: t("createGovernanceAction.fields.validations.required"),
       },
       maxLength: {
-        value: 500,
+        value: MAX_LENGTH,
         message: t("createGovernanceAction.fields.validations.maxLength", {
-          maxLength: 500,
+          maxLength: MAX_LENGTH,
         }),
       },
     },
@@ -64,13 +65,13 @@ export const VoteContextText = ({
         {t("govActions.provideContextAboutYourVote")}
       </Typography>
       <Typography variant="body1" sx={{ fontWeight: 400, mb: 2 }}>
-        {/* TODO: Update text when design is finalised */}
-        Additional information about your vote
+        {t("govActions.additionalInformationAboutYourVote")}
       </Typography>
       <ControlledField.TextArea
         {...{ control, errors }}
         {...fieldProps}
         isModifiedLayout
+        maxLength={MAX_LENGTH}
         data-testid="provide-context-input"
       />
     </VoteContextWrapper>

--- a/govtool/frontend/src/i18n/locales/en.json
+++ b/govtool/frontend/src/i18n/locales/en.json
@@ -394,6 +394,7 @@
     "optional": "(optional)",
     "provideContext": "Provide context",
     "provideContextAboutYourVote": "Provide context about your vote",
+    "additionalInformationAboutYourVote": "Additional information about your vote",
     "provideNewContextAboutYourVote": "Provide new context about your vote",
     "rationale": "Rationale",
     "seeExternalData": "See external data",


### PR DESCRIPTION
## List of changes

- change vote rationale character limit to 10000

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2891)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
