### PR TITLE
fix(#2888): fix displaying givenName placeholder instead of value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ changes.
 - Fix displaying vote pill on voted on cards
 - Fix incorrect link to learn more about direct voters [Issue 2647](https://github.com/IntersectMBO/govtool/issues/2647)
 - Fix missing No DRep found message on DRep Directory [Issue 2889](https://github.com/IntersectMBO/govtool/issues/2889)
+- Fix displaying givenName placeholder instead of actual value on DRep card [Issue 2888](https://github.com/IntersectMBO/govtool/issues/2888)
 
 ### Changed
 

--- a/govtool/frontend/src/components/organisms/DashboardCards/DRepDashboardCard.tsx
+++ b/govtool/frontend/src/components/organisms/DashboardCards/DRepDashboardCard.tsx
@@ -66,7 +66,7 @@ export const DRepDashboardCard = ({
               i18nKey="dashboard.cards.drep.retirementInProgressWithGivenName"
               values={{
                 deposit: correctAdaFormat(voter?.deposit),
-                name: voter?.givenName,
+                givenName: voter?.givenName,
               }}
             />
           ) : (
@@ -140,7 +140,7 @@ export const DRepDashboardCard = ({
         description: voter?.givenName ? (
           <Trans
             i18nKey="dashboard.cards.drep.notRegisteredWasRegisteredDescriptionWithGivenName"
-            values={{ name: voter?.givenName }}
+            values={{ givenName: voter?.givenName ?? "DRep" }}
           />
         ) : (
           <Trans i18nKey="dashboard.cards.drep.notRegisteredWasRegisteredDescription" />


### PR DESCRIPTION
## List of changes

- fix displaying givenName placeholder instead of value

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2888)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
