### PR TITLE
fix(2647): incorrect link to docs for direct voters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ changes.
 - Fix displaying DRep with doNotList property as string
 - Handle exception when no index is provided to /proposal/get endpoint [Issue 1841](https://github.com/IntersectMBO/govtool/issues/1841)
 - Fix displaying vote pill on voted on cards
+- Fix incorrect link to learn more about direct voters [Issue 2647](https://github.com/IntersectMBO/govtool/issues/2647)
 
 ### Changed
 

--- a/govtool/frontend/src/pages/RegisterAsDirectVoter.tsx
+++ b/govtool/frontend/src/pages/RegisterAsDirectVoter.tsx
@@ -147,7 +147,7 @@ export const RegisterAsDirectVoter = () => {
           values={{ deposit: correctAdaFormat(epochParams?.drep_deposit) }}
           components={[
             <Link
-              onClick={() => openInNewTab("https://sancho.network/")}
+              onClick={() => openInNewTab("https://docs.gov.tools/cardano-govtool/faqs/direct-voter-vs-drep")}
               sx={{ cursor: "pointer" }}
               key="0"
             />,

--- a/govtool/frontend/src/pages/RetireAsDirectVoter.tsx
+++ b/govtool/frontend/src/pages/RetireAsDirectVoter.tsx
@@ -121,7 +121,7 @@ export const RetireAsDirectVoter = () => {
           values={{ deposit: correctAdaFormat(voter?.deposit) }}
           components={[
             <Link
-              onClick={() => openInNewTab("https://sancho.network/")}
+              onClick={() => openInNewTab("https://docs.gov.tools/cardano-govtool/faqs/direct-voter-vs-drep")}
               sx={{ cursor: "pointer", textDecoration: "none" }}
               key="0"
             />,


### PR DESCRIPTION
## List of changes

- Fix incorrect link to docs for direct voters

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2647)
- [ ] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
