### PR TITLE
chore: remove abstain from total drep votes calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ changes.
 
 ### Removed
 
--
+- Remove abstain from total DRep votes calculation
 
 ## [v2.0.11](https://github.com/IntersectMBO/govtool/releases/tag/v2.0.11) 2025-02-04
 

--- a/govtool/backend/sql/get-network-metrics.sql
+++ b/govtool/backend/sql/get-network-metrics.sql
@@ -196,7 +196,7 @@ SELECT
     TotalDRepVotes.count AS total_drep_votes,
     TotalRegisteredDReps.unique_registrations AS total_registered_dreps,
 	TotalDRepDistr.total_drep_distr,
-    COALESCE(TotalStakeControlledByActiveDReps.total, 0) + COALESCE(AlwaysAbstainVotingPower.amount, 0) + COALESCE(AlwaysNoConfidenceVotingPower.amount, 0) AS total_stake_controlled_dreps,
+    COALESCE(TotalStakeControlledByActiveDReps.total, 0) + COALESCE(AlwaysNoConfidenceVotingPower.amount, 0) AS total_stake_controlled_by_active_dreps,
     COALESCE(TotalStakeControlledBySPOs.total, 0) AS total_stake_controlled_by_spos,
     TotalActiveDReps.unique_active_drep_registrations AS total_active_dreps,
     TotalInactiveDReps.total_inactive_dreps AS total_inactive_dreps,

--- a/govtool/frontend/src/components/molecules/GovernanceActionDetailsCardVotes.tsx
+++ b/govtool/frontend/src/components/molecules/GovernanceActionDetailsCardVotes.tsx
@@ -58,7 +58,7 @@ export const GovernanceActionDetailsCardVotes = ({
           isInProgress={isInProgress}
         />
       ) : (
-        <VotesSubmitted votes={proposal} />
+        <VotesSubmitted type={proposal.type} votes={proposal} />
       )}
     </Box>
   );

--- a/govtool/frontend/src/components/organisms/Modal/SubmittedVotesModal.tsx
+++ b/govtool/frontend/src/components/organisms/Modal/SubmittedVotesModal.tsx
@@ -23,7 +23,7 @@ export const SubmittedVotesModal = forwardRef<HTMLDivElement>((_, ref) => {
     >
       <ModalContents>
         <Box alignItems="center">
-          <VotesSubmitted votes={state} />
+          <VotesSubmitted type={state.type} votes={state} />
         </Box>
       </ModalContents>
     </ModalWrapper>


### PR DESCRIPTION
![Zrzut ekranu z 2025-02-06 18-43-09](https://github.com/user-attachments/assets/e7c9f6d1-8619-45b9-b6f7-c118767bf0fc)

Compared to cardanoscan.io
![Zrzut ekranu z 2025-02-06 18-44-33](https://github.com/user-attachments/assets/d985961d-3916-4ac5-8b98-a4074ecee159)

Calculations:

Total DRep stake: Total Voting Power coming from Active DReps and pre-defined no-confidence

Yes votes: All yes votes coming from Active DReps
No votes: All no votes coming from Active DReps and pre-defined no confidence
Abstain: All abstain votes coming from Active DReps and pre-defined abstain
Not voted: Total DRep stake - Yes votes - No votes - Abstain votes (with slight adjustments for No confidence Governance Action

Yes votes percentage: **Yes votes** / **Total DRep stake**
No votes percentage: **No votes** / **Total DRep stake**
Not Voted percentage: 100 - yes votes percentage - no votes percentage.