### PR TITLE
fix: remove abstain governance action votes from total stake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ changes.
 
 - Fix calculating votes counting for governance actions
 - Fix crashing backend on unhandled missing proposal from vote [Issue 2920](https://github.com/IntersectMBO/govtool/issues/2920)
+- Remove abstain votes (not auto abstain) from total DRep stake
 
 ### Changed
 

--- a/govtool/backend/sql/list-proposals.sql
+++ b/govtool/backend/sql/list-proposals.sql
@@ -251,7 +251,7 @@ SELECT
         ELSE
             drep_voting_power.no_confidence
         END) no_votes,
-    COALESCE(SUM(ldd_drep.amount) FILTER (WHERE rdv.vote::text = 'Abstain'), 0) + drep_voting_power.abstain abstain_votes,
+    COALESCE(SUM(ldd_drep.amount) FILTER (WHERE rdv.vote::text = 'Abstain'), 0) abstain_votes,
 	COALESCE(ps.poolYesVotes, 0) pool_yes_votes,
 	COALESCE(ps.poolNoVotes, 0) pool_no_votes,
 	COALESCE(ps.poolAbstainVotes, 0) pool_abstain_votes,

--- a/govtool/frontend/src/components/molecules/VotesSubmitted.tsx
+++ b/govtool/frontend/src/components/molecules/VotesSubmitted.tsx
@@ -50,27 +50,38 @@ export const VotesSubmitted = ({
   const { t } = useTranslation();
   const { epochParams, networkMetrics } = useAppContext();
 
+  // Coming from be
+  // Equal to: total active drep stake + auto no-confidence stake
   const totalStakeControlledByDReps =
-    networkMetrics?.totalStakeControlledByDReps ?? 0;
+    (networkMetrics?.totalStakeControlledByDReps ?? 0) -
+    // As this being voted for the action becomes part of the total active stake
+    dRepAbstainVotes;
+
+  // Governance action abstain votesa + auto abstain votes
+  const totalAbstainVotes =
+    dRepAbstainVotes + (networkMetrics?.alwaysAbstainVotingPower ?? 0);
 
   // TODO: Move this logic to backend
   const dRepYesVotesPercentage = totalStakeControlledByDReps
     ? (dRepYesVotes / totalStakeControlledByDReps) * 100
     : undefined;
+
   const dRepNoVotesPercentage = totalStakeControlledByDReps
     ? (dRepNoVotes / totalStakeControlledByDReps) * 100
     : undefined;
+
   const dRepNotVotedVotes = totalStakeControlledByDReps
     ? totalStakeControlledByDReps -
       (dRepYesVotes -
+        // As this is already added on backend
         (govActionType === GovernanceActionType.NoConfidence
           ? networkMetrics?.alwaysNoConfidenceVotingPower ?? 0
           : 0)) -
       (dRepNoVotes -
+        // As this is already added on backend
         (govActionType === GovernanceActionType.NoConfidence
           ? 0
-          : networkMetrics?.alwaysNoConfidenceVotingPower ?? 0)) -
-      (dRepAbstainVotes - (networkMetrics?.alwaysAbstainVotingPower ?? 0))
+          : networkMetrics?.alwaysNoConfidenceVotingPower ?? 0))
     : undefined;
   const dRepNotVotedVotesPercentage =
     100 - (dRepYesVotesPercentage ?? 0) - (dRepNoVotesPercentage ?? 0);
@@ -143,7 +154,7 @@ export const VotesSubmitted = ({
             yesVotesPercentage={dRepYesVotesPercentage}
             noVotes={dRepNoVotes}
             noVotesPercentage={dRepNoVotesPercentage}
-            abstainVotes={dRepAbstainVotes}
+            abstainVotes={totalAbstainVotes}
             notVotedVotes={dRepNotVotedVotes}
             notVotedPercentage={dRepNotVotedVotesPercentage}
             threshold={(() => {


### PR DESCRIPTION
## List of changes

- remove abstain governance action votes from total stake

Which results in:
![Zrzut ekranu z 2025-02-07 15-12-39](https://github.com/user-attachments/assets/0777002e-219d-4267-9f49-84f1a15671b7)

Summary of equation:

Network metrics:
**Total active DRep stake**: Voting power coming from all **active** DReps
**Auto abstain**: Voting power coming from pre-defined always abstain DRep
**No confidence**: Voting power coming from pre-defined always no-confidence DRep

List proposals:
**Yes votes**: Sum of Voting power coming from DReps who voted **Yes** (+ no confidence when Governance Action Type === No confidence)
**No votes**: Sum of Voting power coming from DReps who voted **No** (+ no confidence when Governance Action Type !== No confidence)
**Abstain votes**: Sum of Voting power coming from DReps who voted **Abstain** and **Auto-abstain**

_IMPORTANT_
As DReps who voted `Abstain` because of making a vote action are active, these Voting powers are included in Total active stake.

Equations for the `percentages` and `not voted` on the frontend for the displayed votes:
**Not voted**: Total active DRep stake - yes votes - no votes - abstain votes
**Yes votes percentage**: Yes votes / (Total active DRep stake - abstain votes)
**No votes percentage**: No votes / (Total active DRep stake - abstain votes)
**Not voted percentage**:  100 - **Yes votes percentage** - **No votes percentage**


