### PR TITLE
feat(#2911): show drep metadata url and hash on detailed profile view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ changes.
 
 ### Added
 
--
+- Add metadata url and hash to drep details [Issue 2911](https://github.com/IntersectMBO/govtool/issues/2911)
 
 ### Fixed
 

--- a/govtool/frontend/src/components/organisms/DRepDetailsCard.tsx
+++ b/govtool/frontend/src/components/organisms/DRepDetailsCard.tsx
@@ -48,6 +48,7 @@ export const DRepDetailsCard = ({
     drepId,
     votingPower,
     isScriptBased,
+    metadataHash,
   } = dRepData;
 
   const groupedReferences = references?.reduce<Record<string, Reference[]>>(
@@ -235,6 +236,53 @@ export const DRepDetailsCard = ({
               />
             )}
           </DRepDetailsInfoItem>
+          {url && (
+            <DRepDetailsInfoItem
+              label={t("forms.dRepData.metadataUrl")}
+              dataTestId="metadata-url"
+            >
+              <Link
+                data-testid="metadata-url-link"
+                href={url}
+                target="_blank"
+                sx={{
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  display: "flex",
+                  gap: 1,
+                  alignItems: "center",
+                }}
+              >
+                <Typography
+                  color="primary"
+                  fontWeight={400}
+                  sx={{
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
+                  {url}
+                </Typography>
+                <img
+                  alt="link"
+                  height={16}
+                  src={ICONS.externalLinkIcon}
+                  width={16}
+                />
+              </Link>
+            </DRepDetailsInfoItem>
+          )}
+          {metadataHash && (
+            <DRepDetailsInfoItem
+              label={t("forms.dRepData.metadataHash")}
+              dataTestId="metadata-hash"
+            >
+              <CopyableText
+                value={metadataHash}
+                dataTestId="copy-metadata-hash"
+              />
+            </DRepDetailsInfoItem>
+          )}
         </>
       )}
       {/* CIP-119 DATA END */}

--- a/govtool/frontend/src/i18n/locales/en.json
+++ b/govtool/frontend/src/i18n/locales/en.json
@@ -328,7 +328,9 @@
       "references": "References",
       "referenceDescription": "Description",
       "referenceDescriptionHelpfulText": "Limit: 80 characters",
-      "referenceURL": "URL"
+      "referenceURL": "URL",
+      "metadataUrl": "Metadata URL",
+      "metadataHash": "Metadata Hash"
     },
     "errors": {
       "tooLongUrl": "Url must be less than 128 bytes",


### PR DESCRIPTION
## List of changes

- show drep metadata url and hash on detailed profile view

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2911)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
