### PR TITLE
Enable VITE_IS_GOVERNANCE_OUTCOMES_PILLAR_ENABLED flag on test/qa stack

### DIFF
--- a/tests/test-infrastructure/docker-compose-govtool.yml
+++ b/tests/test-infrastructure/docker-compose-govtool.yml
@@ -50,6 +50,7 @@ services:
         VITE_PDF_API_URL: ${PDF_API_URL}
         VITE_IPFS_GATEWAY: ${IPFS_GATEWAY}
         VITE_IPFS_PROJECT_ID: ${IPFS_PROJECT_ID}
+        VITE_IS_GOVERNANCE_OUTCOMES_PILLAR_ENABLED: "true"
     environment:
       VIRTUAL_HOST: https://${BASE_DOMAIN}
     networks:


### PR DESCRIPTION
## List of changes

-  enable VITE_IS_GOVERNANCE_OUTCOMES_PILLAR_ENABLED flag in govtool stack

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
