### PR TITLE
Feat: merge utxos on faucet refund

### DIFF
--- a/tests/govtool-frontend/playwright/lib/constants/staticWallets.ts
+++ b/tests/govtool-frontend/playwright/lib/constants/staticWallets.ts
@@ -37,7 +37,7 @@ export const userWallets = [user01Wallet];
 
 export const dRepWallets = [dRep01Wallet, dRep02Wallet];
 
-export const proposalWallet = [
+export const proposalWallets = [
   proposal01Wallet,
   proposal02Wallet,
   proposal03Wallet,
@@ -51,6 +51,6 @@ export const allStaticWallets = [
   ...dRepWallets,
   ...adaHolderWallets,
   user01Wallet,
-  ...proposalWallet,
+  ...proposalWallets,
   faucetWallet,
 ];

--- a/tests/govtool-frontend/playwright/lib/constants/staticWallets.ts
+++ b/tests/govtool-frontend/playwright/lib/constants/staticWallets.ts
@@ -1,5 +1,6 @@
 const staticWallets: StaticWallet[] = require("../_mock/wallets.json");
 import { StaticWallet } from "@types";
+import { proposalFaucetWallet } from "./proposalFaucetWallet";
 export const faucetWallet = staticWallets[0];
 
 export const dRep01Wallet = staticWallets[1];
@@ -53,4 +54,5 @@ export const allStaticWallets = [
   user01Wallet,
   ...proposalWallets,
   faucetWallet,
+  proposalFaucetWallet,
 ];

--- a/tests/govtool-frontend/playwright/lib/constants/staticWallets.ts
+++ b/tests/govtool-frontend/playwright/lib/constants/staticWallets.ts
@@ -37,4 +37,20 @@ export const userWallets = [user01Wallet];
 
 export const dRepWallets = [dRep01Wallet, dRep02Wallet];
 
-export const proposalWallets = [proposal01Wallet];
+export const proposalWallet = [
+  proposal01Wallet,
+  proposal02Wallet,
+  proposal03Wallet,
+  proposal04Wallet,
+  proposal05Wallet,
+  proposal06Wallet,
+  proposal07Wallet,
+];
+
+export const allStaticWallets = [
+  ...dRepWallets,
+  ...adaHolderWallets,
+  user01Wallet,
+  ...proposalWallet,
+  faucetWallet,
+];

--- a/tests/govtool-frontend/playwright/lib/services/kuberService.ts
+++ b/tests/govtool-frontend/playwright/lib/services/kuberService.ts
@@ -173,27 +173,14 @@ const kuberService = {
       cborHex: "5820" + wallet.payment.private,
     }));
 
-    selections.push({
-      type: "PaymentSigningKeyShelley_ed25519",
-      description: "Payment Signing Key",
-      cborHex: "5820" + proposalFaucetWallet.payment.private,
-    });
-
-    const inputs = [
-      proposalFaucetWallet.address,
-      ...wallets.map((wallet) => wallet.address),
-    ];
-    console.log({
-      inputs,
-      selections,
-      changeAddress: proposalFaucetWallet.address,
-    });
+    const inputs = wallets.map((wallet) => wallet.address);
     return kuber.signAndSubmitTx({
       inputs,
       selections,
       changeAddress: proposalFaucetWallet.address,
     });
   },
+
   transferADA: (receiverAddressList: string[], ADA = 20) => {
     const kuber = new Kuber(faucetWallet.address, faucetWallet.payment.private);
     const req = {


### PR DESCRIPTION
## List of changes

- Add kuber service to merge the utxos with the proposal faucet wallet
- Merge utxos all wallets used during a test on faucet refund

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
