### PR TITLE
Fix: commit status checkout issue

### DIFF
--- a/.github/scripts/set_commit_status.sh
+++ b/.github/scripts/set_commit_status.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Ensure required environment variables are set
-if [ -z "$GITHUB_REPOSITORY" ] || [ -z "$GITHUB_SHA" ] || [ -z "$GITHUB_TOKEN" ] || [ -z "$GITHUB_RUN_ID" ]; then
+if [ -z "$GITHUB_REPOSITORY" ] || [ -z "$GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA" ] || [ -z "$GITHUB_TOKEN" ] || [ -z "$GITHUB_RUN_ID" ]; then
   echo "Missing required environment variables!"
   exit 1
 fi
@@ -69,7 +69,7 @@ fi
 # Send commit status update to GitHub
 curl -X POST -H "Authorization: Bearer ${GITHUB_TOKEN}" \
   -H "Accept: application/vnd.github+json" \
-  https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA} \
+  https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA} \
   -d "{\"state\": \"${TEST_STATUS}\", \"context\": \"${CONTEXT}\", \"description\": \"${DESCRIPTION}\", \"target_url\": \"${TARGET_URL}\"}"
 
 echo "Commit status updated successfully!"

--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -53,7 +53,7 @@ jobs:
           echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
           curl -X POST -H "Authorization: Bearer ${{ github.token }}" \
             -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
+            https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }} \
             -d "{\"state\": \"pending\", \"context\": \"Backend Tests : ${{env.BASE_URL}}\", \"target_url\": \"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"
 
 

--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Set pending commit status
         id: set-pending-status

--- a/.github/workflows/test_integration_playwright.yml
+++ b/.github/workflows/test_integration_playwright.yml
@@ -48,6 +48,8 @@ jobs:
         working-directory: tests/govtool-frontend/playwright
     steps:
       - uses: actions/checkout@v4
+        with:
+            ref: ${{ github.event.workflow_run.head_sha }}
       - name: Set pending commit status
         id: set-pending-status
         run: |

--- a/.github/workflows/test_integration_playwright.yml
+++ b/.github/workflows/test_integration_playwright.yml
@@ -54,7 +54,7 @@ jobs:
           echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
           curl -X POST -H "Authorization: Bearer ${{ github.token }}" \
             -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
+            https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }} \
             -d "{\"state\": \"pending\", \"context\": \"Playwright Tests : ${{env.HOST_URL}}\", \"target_url\": \"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## List of changes

- Checkout integration and backend test to workflow triggered head sha
- use status on GitHub API to workflow triggered head sha

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
