### PR TITLE
Fix: flaky/timeout issue of report-321

### DIFF
--- a/tests/govtool-frontend/playwright/.gitignore
+++ b/tests/govtool-frontend/playwright/.gitignore
@@ -16,6 +16,7 @@ allure-report/
 lib/_mock/registerDRepWallets.json
 lib/_mock/registeredDRepWallets.json
 lib/_mock/proposalSubmissionWallets.json
+lib/_mock/proposalSubmissionCopyWallets.json
 lib/_mock/registerDRepCopyWallets.json
 lib/_mock/registeredDRepCopyWallets.json
 lib/_mock/wallets.json

--- a/tests/govtool-frontend/playwright/lib/helpers/exceptionHandler.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/exceptionHandler.ts
@@ -1,4 +1,5 @@
-import { Expect, ExpectMatcherUtils } from "@playwright/test";
+import { Page } from "@playwright/test";
+import { Logger } from "./logger";
 
 export async function expectWithInfo(
   expectation: () => Promise<void>,
@@ -8,5 +9,22 @@ export async function expectWithInfo(
     await expectation();
   } catch (e) {
     throw new Error(errorMessage);
+  }
+}
+
+export async function failureWithConsoleMessages(page: Page, fn: Function) {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleMessages.push(msg.text());
+    }
+  });
+  try {
+    await fn();
+  } catch (error) {
+    Logger.fail(
+      `Failed: ${error.message}\nConsole messages: ${consoleMessages.join("\n")}`
+    );
+    throw error;
   }
 }

--- a/tests/govtool-frontend/playwright/lib/helpers/shellyWallet.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/shellyWallet.ts
@@ -12,3 +12,11 @@ export default function extractDRepFromWallet(wallet: ShelleyWallet) {
   const dRepIdBech32 = bech32.encode("drep", words);
   return dRepIdBech32;
 }
+
+export async function generateWallets(num: number) {
+  return await Promise.all(
+    Array.from({ length: num }, () =>
+      ShelleyWallet.generate().then((wallet) => wallet.json())
+    )
+  );
+}

--- a/tests/govtool-frontend/playwright/lib/helpers/waitedLoop.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/waitedLoop.ts
@@ -1,0 +1,12 @@
+export async function waitedLoop(
+  conditionFn,
+  timeout = 60000,
+  interval = 2000
+) {
+  const startTime = Date.now();
+  while (Date.now() - startTime < timeout) {
+    if (await conditionFn()) return true;
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+  return false;
+}

--- a/tests/govtool-frontend/playwright/lib/helpers/waitedLoop.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/waitedLoop.ts
@@ -11,8 +11,15 @@ export async function waitedLoop(
   return false;
 }
 
-export async function functionWaitedAssert(fn, options) {
-  const { timeout = 60000, interval = 2000, message } = options;
+export async function functionWaitedAssert(
+  fn,
+  options: { timeout?: number; interval?: number; message?: string } = {
+    timeout: 6000,
+    interval: 2000,
+    message: null,
+  }
+) {
+  const { timeout, interval, message } = options;
   const startTime = Date.now();
 
   while (true) {

--- a/tests/govtool-frontend/playwright/lib/helpers/waitedLoop.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/waitedLoop.ts
@@ -10,3 +10,21 @@ export async function waitedLoop(
   }
   return false;
 }
+
+export async function functionWaitedAssert(fn, options) {
+  const { timeout = 60000, interval = 2000, message } = options;
+  const startTime = Date.now();
+
+  while (true) {
+    try {
+      await fn();
+      return true;
+    } catch (error) {
+      if (Date.now() - startTime >= timeout) {
+        const errorMessage = message || error.message;
+        throw new Error(errorMessage);
+      }
+      await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+  }
+}

--- a/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
@@ -197,7 +197,7 @@ export default class DRepDirectoryPage {
     const responsePromise = this.page.waitForResponse((response) =>
       response
         .url()
-        .includes(`api/drep/list?page=${pageNumber}&pageSize=10&sort=${option}`)
+        .includes(`drep/list?page=${pageNumber}&pageSize=10&sort=${option}`)
     );
     const response = await responsePromise;
     const json = await response.json();

--- a/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
@@ -1,4 +1,5 @@
 import { convertDRepToCIP129 } from "@helpers/dRep";
+import { functionWaitedAssert, waitedLoop } from "@helpers/waitedLoop";
 import { Locator, Page, expect } from "@playwright/test";
 import { IDRep } from "@types";
 import environments from "lib/constants/environments";
@@ -75,22 +76,35 @@ export default class DRepDirectoryPage {
   }
 
   async validateFilters(filters: string[], filterOptions: string[]) {
-    const excludedFilters = filterOptions.filter(
-      (filter) => !filters.includes(filter)
+    let errorMessage = "";
+    await functionWaitedAssert(
+      async () => {
+        const excludedFilters = filterOptions.filter(
+          (filter) => !filters.includes(filter)
+        );
+
+        const dRepList = await this.getAllListedDReps();
+
+        for (const filter of excludedFilters) {
+          await expect(this.page.getByTestId(`${filter}-checkbox`)).toHaveCount(
+            1
+          );
+        }
+
+        for (const dRep of dRepList) {
+          const hasFilter = await this._validateTypeFiltersInDRep(
+            dRep,
+            filters
+          );
+          const actualFilter = await dRep
+            .locator('[data-testid$="-pill"]')
+            .textContent();
+          errorMessage = `${actualFilter} does not match any of the ${filters}`;
+          expect(hasFilter).toBe(true);
+        }
+      },
+      { message: errorMessage }
     );
-
-    await this.page.waitForTimeout(4_000); // wait for the dRep list to render properly
-
-    const dRepList = await this.getAllListedDReps();
-
-    for (const filter of excludedFilters) {
-      await expect(this.page.getByTestId(`${filter}-checkbox`)).toHaveCount(1);
-    }
-
-    for (const dRep of dRepList) {
-      const hasFilter = await this._validateTypeFiltersInDRep(dRep, filters);
-      expect(hasFilter).toBe(true);
-    }
   }
 
   async _validateTypeFiltersInDRep(
@@ -128,7 +142,6 @@ export default class DRepDirectoryPage {
       const isValid = validationFn(dRepList[i], dRepList[i + 1]);
       expect(isValid).toBe(true);
     }
-
     // Frontend validation
     const cip105DRepListFE = await this.getAllListedCIP105DRepIds();
     const cip129DRepListFE = await this.getAllListedCIP129DRepIds();
@@ -138,9 +151,9 @@ export default class DRepDirectoryPage {
     );
 
     for (let i = 0; i <= cip105DRepListFE.length - 1; i++) {
-      await expect(cip105DRepListFE[i]).toHaveText(dRepList[i].view);
-      await expect(cip129DRepListFE[i]).toHaveText(
-        `(CIP-129) ${cip129DRepListApi[i]}`
+      await expect(cip129DRepListFE[i]).toHaveText(cip129DRepListApi[i]);
+      await expect(cip105DRepListFE[i]).toHaveText(
+        `(CIP-105) ${dRepList[i].view}`
       );
     }
   }
@@ -149,18 +162,6 @@ export default class DRepDirectoryPage {
   }
 
   async getAllListedCIP105DRepIds() {
-    await this.page.waitForTimeout(2_000);
-
-    const dRepCards = await this.getAllListedDReps();
-
-    return dRepCards.map((dRep) =>
-      dRep.locator('[data-testid$="-copy-id-button"]').first()
-    );
-  }
-
-  async getAllListedCIP129DRepIds() {
-    await this.page.waitForTimeout(2_000);
-
     const dRepCards = await this.getAllListedDReps();
 
     return dRepCards.map((dRep) =>
@@ -168,16 +169,37 @@ export default class DRepDirectoryPage {
     );
   }
 
+  async getAllListedCIP129DRepIds() {
+    const dRepCards = await this.getAllListedDReps();
+
+    return dRepCards.map((dRep) =>
+      dRep.locator('[data-testid$="-copy-id-button"]').first()
+    );
+  }
+
   async getAllListedDReps() {
-    // wait for the dRep list to render properly
-    await this.page.waitForTimeout(3_000);
-    // add assertion to wait until the search input is visible
     await expect(this.searchInput).toBeVisible({ timeout: 10_000 });
 
-    return await this.page
-      .getByRole("list")
-      .locator('[data-testid$="-drep-card"]')
-      .all();
+    await waitedLoop(async () => {
+      return (
+        (await this.page.locator('[data-testid$="-drep-card"]').count()) > 0
+      );
+    });
+
+    return this.page.locator('[data-testid$="-drep-card"]').all();
+  }
+  async getDRepListFromApi(
+    option: string,
+    pageNumber: number = 0
+  ): Promise<IDRep[]> {
+    const responsePromise = this.page.waitForResponse((response) =>
+      response
+        .url()
+        .includes(`api/drep/list?page=${pageNumber}&pageSize=10&sort=${option}`)
+    );
+    const response = await responsePromise;
+    const json = await response.json();
+    return json.elements;
   }
 
   async verifyDRepInList(dRepId: string) {
@@ -185,10 +207,8 @@ export default class DRepDirectoryPage {
 
     await this.searchInput.fill(dRepId);
 
-    await this.page.waitForTimeout(5_000); // wait until the dRep list render properly
-
-    await expect(
-      this.page.getByTestId(`${dRepId}-drep-card`)
-    ).not.toBeVisible();
+    await expect(this.page.getByText("No DReps found")).toBeVisible({
+      timeout: 20_000,
+    });
   }
 }

--- a/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
@@ -190,19 +190,6 @@ export default class DRepDirectoryPage {
 
     return this.page.locator('[data-testid$="-drep-card"]').all();
   }
-  async getDRepListFromApi(
-    option: string,
-    pageNumber: number = 0
-  ): Promise<IDRep[]> {
-    const responsePromise = this.page.waitForResponse((response) =>
-      response
-        .url()
-        .includes(`drep/list?page=${pageNumber}&pageSize=10&sort=${option}`)
-    );
-    const response = await responsePromise;
-    const json = await response.json();
-    return json.elements;
-  }
 
   async verifyDRepInList(dRepId: string) {
     await this.goto();

--- a/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
@@ -41,6 +41,8 @@ export default class DRepDirectoryPage {
     '[data-testid$="-delegate-button"]'
   );
 
+  readonly NoDRepText = this.page.getByText("No DReps found");
+
   constructor(private readonly page: Page) {}
 
   async goto() {

--- a/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
@@ -4,6 +4,7 @@ import { GovernanceActionType, IProposal } from "@types";
 import environments from "lib/constants/environments";
 import GovernanceActionDetailsPage from "./governanceActionDetailsPage";
 import { getEnumKeyByValue } from "@helpers/enum";
+import { waitedLoop } from "@helpers/waitedLoop";
 
 const MAX_SLIDES_DISPLAY_PER_TYPE = 6;
 
@@ -94,8 +95,13 @@ export default class GovernanceActionsPage {
     }
   }
 
-  async getAllProposals() {
-    await this.page.waitForTimeout(4_000); // waits for proposals to render
+  async getAllProposals(): Promise<Locator[]> {
+    await waitedLoop(async () => {
+      return (
+        (await this.page.locator('[data-testid$="-card"]').count()) > 0 ||
+        this.page.getByText("No results for the search.")
+      );
+    });
     return this.page.locator('[data-testid$="-card"]').all();
   }
 

--- a/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
@@ -129,8 +129,6 @@ export default class ProposalSubmissionPage {
   async goto() {
     await this.page.goto(`${environments.frontendUrl}/proposal_discussion`);
 
-    await this.page.waitForTimeout(2_000); // wait until page load properly
-
     await this.verifyIdentityBtn.click();
     await this.proposalCreateBtn.click();
 
@@ -482,9 +480,7 @@ export default class ProposalSubmissionPage {
     await this.continueBtn.click();
     await this.submitBtn.click();
 
-    // Wait for redirection to `proposal-discussion-details` page
-    await this.page.waitForTimeout(2_000);
-
+    await expect(this.page.getByTestId("submit-as-GA-button")).toBeVisible();
     const currentPageUrl = this.page.url();
     return extractProposalIdFromUrl(currentPageUrl);
   }

--- a/tests/govtool-frontend/playwright/lib/services/kuberService.ts
+++ b/tests/govtool-frontend/playwright/lib/services/kuberService.ts
@@ -137,8 +137,12 @@ const kuberService = {
     });
   },
   // register stake and outputs 20A
-  initializeWallets: (wallets: StaticWallet[]) => {
-    const kuber = new Kuber(faucetWallet.address, faucetWallet.payment.private);
+  initializeWallets: (
+    wallets: StaticWallet[],
+    faucetAddress: string = faucetWallet.address,
+    faucetStakeKey: string = faucetWallet.payment.private
+  ) => {
+    const kuber = new Kuber(faucetAddress, faucetStakeKey);
     const outputs = [];
     const stakes = [];
     const certificates = [];
@@ -195,9 +199,11 @@ const kuberService = {
   },
 
   multipleTransferADA: (
-    outputs: { address: string; value: string | number }[]
+    outputs: { address: string; value: string | number }[],
+    addr = faucetWallet.address,
+    signingKey = faucetWallet.payment.private
   ) => {
-    const kuber = new Kuber(faucetWallet.address, faucetWallet.payment.private);
+    const kuber = new Kuber(addr, signingKey);
     const req = {
       outputs,
     };

--- a/tests/govtool-frontend/playwright/lib/walletManager.ts
+++ b/tests/govtool-frontend/playwright/lib/walletManager.ts
@@ -9,6 +9,7 @@ export type Purpose =
   | "registerDRep"
   | "registeredDRep"
   | "proposalSubmission"
+  | "proposalSubmissionCopy"
   | "registerDRepCopy"
   | "registeredDRepCopy";
 

--- a/tests/govtool-frontend/playwright/playwright.config.ts
+++ b/tests/govtool-frontend/playwright/playwright.config.ts
@@ -58,6 +58,11 @@ export default defineConfig({
       dependencies: environments.ci ? ["faucet setup"] : [],
     },
     {
+      name: "proposal setup",
+      testMatch: "**/proposal.setup.ts",
+      teardown: environments.ci && "cleanup faucet",
+    },
+    {
       name: "wallet bootstrap",
       testMatch: "**/wallet.bootstrap.ts",
       dependencies: environments.ci ? ["faucet setup"] : [],
@@ -72,6 +77,9 @@ export default defineConfig({
       name: "proposal submission",
       use: { ...devices["Desktop Chrome"] },
       testMatch: "**/*.ga.spec.ts",
+      dependencies: environments.ci
+        ? ["proposal setup"]
+        : [],
     },
     {
       name: "loggedin (desktop)",

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.loggedin.spec.ts
@@ -101,12 +101,16 @@ test.describe("DRep dependent tests", () => {
 
   test("2I. Should check validity of DRep Id", async () => {
     await dRepDirectoryPage.searchInput.fill(dRepId);
-    await expect(dRepDirectoryPage.getDRepCard(dRepId)).toBeVisible();
+    await expect(dRepDirectoryPage.getDRepCard(dRepId)).toBeVisible({
+      timeout: 20_000,
+    });
 
     const wallet = await ShelleyWallet.generate();
     const invalidDRepId = extractDRepFromWallet(wallet);
 
     await dRepDirectoryPage.searchInput.fill(invalidDRepId);
+
+    await expect(dRepDirectoryPage.NoDRepText).toBeVisible();
     await expect(
       dRepDirectoryPage.getDRepCard(invalidDRepId)
     ).not.toBeVisible();

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
@@ -84,20 +84,28 @@ test("2O. Should load more DReps on show more", async ({ page }) => {
   const dRepDirectory = new DRepDirectoryPage(page);
   await dRepDirectory.goto();
 
-  const dRepIdsBefore = await dRepDirectory.getAllListedCIP105DRepIds();
+  const dRepListBefore = await dRepDirectory.getDRepListFromApi(
+    SortOption.Random
+  );
+
+  const isShowMoreVisible = dRepListBefore.length >= 10;
+  await expect(dRepDirectory.showMoreBtn).toBeVisible({
+    visible: isShowMoreVisible,
+  });
+
+  if (!isShowMoreVisible) return;
+
   await dRepDirectory.showMoreBtn.click();
+  const dRepListAfter = await dRepDirectory.getDRepListFromApi(
+    SortOption.Random,
+    1
+  );
 
-  const dRepIdsAfter = await dRepDirectory.getAllListedCIP105DRepIds();
-  expect(dRepIdsAfter.length).toBeGreaterThanOrEqual(dRepIdsBefore.length);
-
-  if (dRepIdsAfter.length > dRepIdsBefore.length) {
-    await expect(dRepDirectory.showMoreBtn).toBeVisible();
-    expect(true).toBeTruthy();
-  } else {
-    await expect(dRepDirectory.showMoreBtn).not.toBeVisible();
-  }
+  const isShowMoreStillVisible = dRepListAfter.length >= dRepListBefore.length;
+  await expect(dRepDirectory.showMoreBtn).toBeVisible({
+    visible: isShowMoreStillVisible,
+  });
 });
-
 test("2K_1. Should filter DReps", async ({ page }) => {
   const dRepFilterOptions: DRepStatus[] = ["Active", "Inactive", "Retired"];
 

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
@@ -82,6 +82,11 @@ test("2K_3. Should sort DReps randomly", async ({ page }) => {
 });
 
 test("2O. Should load more DReps on show more", async ({ page }) => {
+  const responsePromise = page.waitForResponse((response) =>
+    response
+      .url()
+      .includes(`drep/list?page=1&pageSize=10&sort=${SortOption.Random}`)
+  );
   const dRepDirectory = new DRepDirectoryPage(page);
   await dRepDirectory.goto();
 
@@ -96,10 +101,9 @@ test("2O. Should load more DReps on show more", async ({ page }) => {
     { message: "Show more button not visible" }
   );
 
-  const dRepListAfter = await dRepDirectory.getDRepListFromApi(
-    SortOption.Random,
-    1
-  );
+  const response = await responsePromise;
+  const json = await response.json();
+  const dRepListAfter = json.elements;
 
   await functionWaitedAssert(
     async () => {

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/editDRep.dRep.spec.ts
@@ -73,7 +73,7 @@ test.describe("Validation of edit dRep Form", () => {
     const editDRepPage = new EditDRepPage(page);
     await editDRepPage.goto();
 
-    await page.waitForTimeout(3_000); // wait until dRep information load properly
+    await expect(editDRepPage.nameInput).toBeVisible({ timeout: 20_000 }); // assert to wait for the page to load
 
     for (let i = 0; i < 100; i++) {
       await editDRepPage.inValidateForm({

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.loggedin.spec.ts
@@ -5,6 +5,7 @@ import { skipIfNotHardFork } from "@helpers/cardano";
 import extractExpiryDateFromText from "@helpers/extractExpiryDateFromText";
 import { isMobile, openDrawer } from "@helpers/mobile";
 import removeAllSpaces from "@helpers/removeAllSpaces";
+import { functionWaitedAssert } from "@helpers/waitedLoop";
 import GovernanceActionsPage from "@pages/governanceActionsPage";
 import { expect } from "@playwright/test";
 
@@ -156,13 +157,18 @@ test("4L. Should search governance actions", async ({ page }) => {
 
   await governanceActionPage.searchInput.fill(governanceActionId);
 
-  const proposalCards = await governanceActionPage.getAllProposals();
+  await functionWaitedAssert(
+    async () => {
+      const proposalCards = await governanceActionPage.getAllProposals();
 
-  for (const proposalCard of proposalCards) {
-    await expect(
-      proposalCard.getByTestId(`${governanceActionId}-id`)
-    ).toBeVisible();
-  }
+      for (const proposalCard of proposalCards) {
+        await expect(
+          proposalCard.getByTestId(`${governanceActionId}-id`)
+        ).toBeVisible();
+      }
+    },
+    { message: `${governanceActionId} not found` }
+  );
 });
 
 test("4M. Should show view-all categorized governance actions", async ({

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.spec.ts
@@ -75,13 +75,19 @@ test("4K. Should display correct vote counts on governance details page for disc
         `${proposalToCheck.txHash}#${proposalToCheck.index}`
       );
 
+      const dRepTotalAbstainVote =
+        await govActionDetailsPage.getDRepTotalAbstainVoted(
+          proposalToCheck,
+          metricsResponsePromise
+        );
+
       // check dRep votes
       if (await areDRepVoteTotalsDisplayed(proposalToCheck)) {
         await expect(govActionDetailsPage.dRepYesVotes).toHaveText(
           `₳ ${correctVoteAdaFormat(proposalToCheck.dRepYesVotes)}`
         );
         await expect(govActionDetailsPage.dRepAbstainVotes).toHaveText(
-          `₳ ${correctVoteAdaFormat(proposalToCheck.dRepAbstainVotes)}`
+          `₳ ${correctVoteAdaFormat(dRepTotalAbstainVote)}`
         );
         await expect(govActionDetailsPage.dRepNoVotes).toHaveText(
           `₳ ${correctVoteAdaFormat(proposalToCheck.dRepNoVotes)}`

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.dRep.spec.ts
@@ -19,7 +19,8 @@ test.use({
 test("6H. Should restrict dRep registration for dRep", async ({ page }) => {
   await page.goto(`${environments.frontendUrl}/register_drep`);
 
-  await page.waitForTimeout(2_000);
-
+  await expect(page.getByText("You already are a DRep")).toBeVisible({
+    timeout: 20_000,
+  });
   await expect(page.getByTestId("name-input")).not.toBeVisible();
 });

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.ga.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.ga.spec.ts
@@ -10,6 +10,8 @@ import { expect } from "@playwright/test";
 import { skipIfMainnet, skipIfNotHardFork } from "@helpers/cardano";
 import { ProposalType } from "@types";
 import { proposalFaucetWallet } from "@constants/proposalFaucetWallet";
+import walletManager from "lib/walletManager";
+import { valid } from "@mock/index";
 
 test.beforeEach(async () => {
   await setAllureEpic("7. Proposal submission");
@@ -24,16 +26,19 @@ Object.values(ProposalType).forEach((proposalType, index) => {
   }, testInfo) => {
     test.setTimeout(testInfo.timeout + environments.txTimeOut);
 
-    const tempUserAuth = await createTempUserAuth(page, proposalFaucetWallet);
+    const wallet = await walletManager.popWallet("proposalSubmission");
+
+    const tempUserAuth = await createTempUserAuth(page, wallet);
 
     const userPage = await createNewPageWithWallet(browser, {
       storageState: tempUserAuth,
-      wallet: proposalFaucetWallet,
+      wallet: wallet,
     });
 
     const proposalDiscussionPage = new ProposalDiscussionPage(userPage);
     await proposalDiscussionPage.goto();
     await proposalDiscussionPage.verifyIdentityBtn.click();
+    await proposalDiscussionPage.setUsername(valid.username());
 
     const proposalSubmissionPage = new ProposalSubmissionPage(userPage);
     await proposalSubmissionPage.proposalCreateBtn.click();

--- a/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.ga.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/7-proposal-submission/proposalSubmission.ga.spec.ts
@@ -11,6 +11,7 @@ import { skipIfMainnet, skipIfNotHardFork } from "@helpers/cardano";
 import { ProposalType } from "@types";
 import { proposalFaucetWallet } from "@constants/proposalFaucetWallet";
 import walletManager from "lib/walletManager";
+import { failureWithConsoleMessages } from "@helpers/exceptionHandler";
 import { valid } from "@mock/index";
 
 test.beforeEach(async () => {
@@ -56,13 +57,15 @@ Object.values(ProposalType).forEach((proposalType, index) => {
 
     await proposalSubmissionPage.fillUpValidMetadata();
 
-    await expect(userPage.getByTestId("ga-submitted-modal-title")).toHaveText(
-      /governance action submitted!/i,
-      {
-        timeout: 20_000,
-      }
-    );
+    await failureWithConsoleMessages(userPage, async () => {
+      await expect(userPage.getByTestId("ga-submitted-modal-title")).toHaveText(
+        /governance action submitted!/i,
+        {
+          timeout: 20_000,
+        }
+      );
 
-    await waitForTxConfirmation(userPage);
+      await waitForTxConfirmation(userPage);
+    });
   });
 });

--- a/tests/govtool-frontend/playwright/tests/dRep.setup.ts
+++ b/tests/govtool-frontend/playwright/tests/dRep.setup.ts
@@ -2,8 +2,8 @@ import environments from "@constants/environments";
 import { dRepWallets } from "@constants/staticWallets";
 import { setAllureEpic, setAllureStory } from "@helpers/allure";
 import { skipIfMainnet, skipIfNotHardFork } from "@helpers/cardano";
-import { ShelleyWallet } from "@helpers/crypto";
 import { uploadMetadataAndGetJsonHash } from "@helpers/metadata";
+import { generateWallets } from "@helpers/shellyWallet";
 import { pollTransaction } from "@helpers/transaction";
 import { expect, test as setup } from "@playwright/test";
 import kuberService from "@services/kuberService";
@@ -25,14 +25,6 @@ setup.beforeEach(async () => {
   await skipIfNotHardFork();
   await skipIfMainnet();
 });
-
-async function generateWallets(num: number) {
-  return await Promise.all(
-    Array.from({ length: num }, () =>
-      ShelleyWallet.generate().then((wallet) => wallet.json())
-    )
-  );
-}
 
 setup("Register DRep of static wallets", async () => {
   setup.setTimeout(environments.txTimeOut);

--- a/tests/govtool-frontend/playwright/tests/faucet.teardown.ts
+++ b/tests/govtool-frontend/playwright/tests/faucet.teardown.ts
@@ -20,11 +20,14 @@ cleanup("Refund faucet", async () => {
     await walletManager.readWallets("registerDRepCopy");
   const registeredDRepWallets: StaticWallet[] =
     await walletManager.readWallets("registeredDRepCopy");
+  const proposalSubmissionWallets: StaticWallet[] =
+    await walletManager.readWallets("proposalSubmissionCopy");
   try {
     const { txId, lockInfo } = await kuberService.mergeUtXos([
       ...allStaticWallets,
       ...registerDRepWallets,
       ...registeredDRepWallets,
+      ...proposalSubmissionWallets,
     ]);
     await pollTransaction(txId, lockInfo);
   } catch (err) {

--- a/tests/govtool-frontend/playwright/tests/proposal.setup.ts
+++ b/tests/govtool-frontend/playwright/tests/proposal.setup.ts
@@ -1,5 +1,7 @@
 import environments from "@constants/environments";
 import { proposalFaucetWallet } from "@constants/proposalFaucetWallet";
+import { setAllureEpic, setAllureStory } from "@helpers/allure";
+import { skipIfMainnet, skipIfNotHardFork } from "@helpers/cardano";
 import { generateWallets } from "@helpers/shellyWallet";
 import { pollTransaction } from "@helpers/transaction";
 import { test as setup } from "@playwright/test";
@@ -13,6 +15,13 @@ let govActionDeposit: number;
 setup.beforeAll(async () => {
   const res = await kuberService.queryProtocolParams();
   govActionDeposit = res.govActionDeposit;
+});
+
+setup.beforeEach(async () => {
+  await setAllureEpic("Setup");
+  await setAllureStory("Proposal");
+  await skipIfNotHardFork();
+  await skipIfMainnet();
 });
 
 setup("Setup temporary proposal wallets", async () => {

--- a/tests/govtool-frontend/playwright/tests/proposal.setup.ts
+++ b/tests/govtool-frontend/playwright/tests/proposal.setup.ts
@@ -36,9 +36,9 @@ setup("Setup temporary proposal wallets", async () => {
     proposalFaucetWallet.address,
     proposalFaucetWallet.payment.private
   );
-  await pollTransaction(transferRes.txId, transferRes.lockInfo);
-
   // save to file
   await walletManager.writeWallets(proposalWallets, "proposalSubmission");
   await walletManager.writeWallets(proposalWallets, "proposalSubmissionCopy");
+
+  await pollTransaction(transferRes.txId, transferRes.lockInfo);
 });

--- a/tests/govtool-frontend/playwright/tests/proposal.setup.ts
+++ b/tests/govtool-frontend/playwright/tests/proposal.setup.ts
@@ -1,0 +1,44 @@
+import environments from "@constants/environments";
+import { proposalFaucetWallet } from "@constants/proposalFaucetWallet";
+import { generateWallets } from "@helpers/shellyWallet";
+import { pollTransaction } from "@helpers/transaction";
+import { test as setup } from "@playwright/test";
+import kuberService from "@services/kuberService";
+import walletManager from "lib/walletManager";
+
+const PROPOSAL_WALLETS_COUNT = 4;
+
+let govActionDeposit: number;
+
+setup.beforeAll(async () => {
+  const res = await kuberService.queryProtocolParams();
+  govActionDeposit = res.govActionDeposit;
+});
+
+setup("Setup temporary proposal wallets", async () => {
+  setup.setTimeout(2 * environments.txTimeOut);
+
+  const proposalWallets = await generateWallets(PROPOSAL_WALLETS_COUNT);
+
+  // initialize wallets
+  const initializeRes = await kuberService.initializeWallets(
+    [...proposalWallets],
+    proposalFaucetWallet.address,
+    proposalFaucetWallet.payment.private
+  );
+  await pollTransaction(initializeRes.txId, initializeRes.lockInfo);
+
+  const amountOutputs = proposalWallets.map((wallet) => {
+    return { address: wallet.address, value: govActionDeposit };
+  });
+  const transferRes = await kuberService.multipleTransferADA(
+    amountOutputs,
+    proposalFaucetWallet.address,
+    proposalFaucetWallet.payment.private
+  );
+  await pollTransaction(transferRes.txId, transferRes.lockInfo);
+
+  // save to file
+  await walletManager.writeWallets(proposalWallets, "proposalSubmission");
+  await walletManager.writeWallets(proposalWallets, "proposalSubmissionCopy");
+});


### PR DESCRIPTION
## List of changes

- Fix timeout / flaky test issue
- Setup 4 temporary proposal wallets for proposal submission
- Show a console message on the playwright log if there is an error on the proposal submission
- Replace timeout and use waitedLoop instead to loop until the required assert is matched
- Fix dRepTotalAbstainVote calculation
- Add intercept logic to used API response title for search proposal
- Fix dRep list test due to updates on CIP-129 and CIP-105 dRep ID display

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
