### PR TITLE
fix(#3022): fix displaying helper buttons on governance action card details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ changes.
 - Remove abstain votes (not auto abstain) from total DRep stake
 - Fix counting committee members [Issue 2948](https://github.com/IntersectMBO/govtool/issues/2948)
 - Fix refetching DRep list on every enter [Issue 2994](https://github.com/IntersectMBO/govtool/issues/2994)
+- Fix displaying helper buttons on governance action card details [Issue 3022](https://github.com/IntersectMBO/govtool/issues/3022)
 
 ### Changed
 

--- a/govtool/frontend/src/components/organisms/GovernanceActionDetailsCardData.tsx
+++ b/govtool/frontend/src/components/organisms/GovernanceActionDetailsCardData.tsx
@@ -338,14 +338,14 @@ export const GovernanceActionDetailsCardData = ({
           <GovernanceActionCardElement
             label={t("govActions.anchorURL")}
             text={url}
-            textVariant="longText"
+            textVariant={screenWidth > 1600 ? "longText" : "oneLine"}
             dataTestId="anchor-url"
             isLinkButton
           />
           <GovernanceActionCardElement
             label={t("govActions.anchorHash")}
             text={metadataHash}
-            textVariant="longText"
+            textVariant={screenWidth > 1600 ? "longText" : "oneLine"}
             dataTestId="anchor-hash"
             isCopyButton
           />


### PR DESCRIPTION
## List of changes

- sync metadata links styles with the other links and hashes on gov action details

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3022)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
