### PR TITLE
Bugfix: remaining failing test

### DIFF
--- a/tests/govtool-frontend/playwright/.gitignore
+++ b/tests/govtool-frontend/playwright/.gitignore
@@ -21,4 +21,5 @@ lib/_mock/registerDRepCopyWallets.json
 lib/_mock/registeredDRepCopyWallets.json
 lib/_mock/wallets.json
 lib/_mock/proposals.json
+lib/_mock/protocolParameter.json
 ./lock_logs.txt

--- a/tests/govtool-frontend/playwright/lib/forms/dRepForm.ts
+++ b/tests/govtool-frontend/playwright/lib/forms/dRepForm.ts
@@ -13,7 +13,7 @@ const formErrors = {
   linkDescription: "max-80-characters-error",
   email: "invalid-email-address-error",
   links: {
-    url:"link-reference-description-1-error",
+    url: "link-reference-description-1-error",
     description: "link-reference-description-1-error",
   },
   identity: {
@@ -160,21 +160,52 @@ export default class DRepForm {
     for (const err of formErrors.dRepName) {
       await expect(this.form.getByTestId(err)).toBeHidden();
     }
+    const objectivesInputText = await this.objectivesInput.textContent();
+    const motivationsInputText = await this.motivationsInput.textContent();
+    const qualificationsInputText =
+      await this.qualificationsInput.textContent();
+    const isReferenceLinkErrorVisible = await this.form
+      .getByTestId(formErrors.links.url)
+      .isVisible();
+    const isIdentityLinkErrorVisible = await this.form
+      .getByTestId(formErrors.identity.url)
+      .isVisible();
+    const isPaymentAddressErrorVisible = await this.form
+      .getByTestId(formErrors.paymentAddress)
+      .isVisible();
 
-    expect(await this.objectivesInput.textContent()).toEqual(
-      dRepInfo.objectives
-    );
+    expect(await this.objectivesInput.textContent(), {
+      message:
+        objectivesInputText !== dRepInfo.objectives &&
+        `${dRepInfo.objectives} is not equal to ${await this.objectivesInput.textContent()}`,
+    }).toEqual(dRepInfo.objectives);
 
-    expect(await this.motivationsInput.textContent()).toEqual(
-      dRepInfo.motivations
-    );
-    expect(await this.qualificationsInput.textContent()).toEqual(
-      dRepInfo.qualifications
-    );
+    expect(await this.motivationsInput.textContent(), {
+      message:
+        motivationsInputText !== dRepInfo.motivations &&
+        `${dRepInfo.motivations} is not equal to ${await this.motivationsInput.textContent()}`,
+    }).toEqual(dRepInfo.motivations);
+    expect(await this.qualificationsInput.textContent(), {
+      message:
+        qualificationsInputText !== dRepInfo.qualifications &&
+        `${dRepInfo.qualifications} is not equal to ${await this.qualificationsInput.textContent()}`,
+    }).toEqual(dRepInfo.qualifications);
 
-    await expect(this.form.getByTestId(formErrors.links.url)).toBeHidden();
-    await expect(this.form.getByTestId(formErrors.identity.url)).toBeHidden();
-    await expect(this.form.getByTestId(formErrors.paymentAddress)).toBeHidden();
+    await expect(this.form.getByTestId(formErrors.links.url), {
+      message:
+        isReferenceLinkErrorVisible &&
+        `${dRepInfo.linksReferenceLinks[0].url} is an invalid url`,
+    }).toBeHidden();
+    await expect(this.form.getByTestId(formErrors.identity.url), {
+      message:
+        isIdentityLinkErrorVisible &&
+        `${dRepInfo.identityReferenceLinks[0].url} is an invalid url`,
+    }).toBeHidden();
+    await expect(this.form.getByTestId(formErrors.paymentAddress), {
+      message:
+        isPaymentAddressErrorVisible &&
+        `${dRepInfo.paymentAddress} is an invalid paymentAddress`,
+    }).toBeHidden();
     await expect(this.continueBtn).toBeEnabled();
   }
 
@@ -200,28 +231,68 @@ export default class DRepForm {
 
     expect(nameErrors.length).toBeGreaterThanOrEqual(1);
 
-    await expect(
-      this.form.getByTestId(formErrors.paymentAddress)
-    ).toBeVisible();
+    const objectivesInputText = await this.objectivesInput.textContent();
+    const motivationsInputText = await this.motivationsInput.textContent();
+    const qualificationsInputText =
+      await this.qualificationsInput.textContent();
+    const isReferenceLinkErrorVisible = await this.form
+      .getByTestId(formErrors.links.url)
+      .isVisible();
+    const isReferenceLinkDescriptionErrorVisible = await this.form
+      .getByTestId(formErrors.links.description)
+      .isVisible();
+    const isIdentityLinkErrorVisible = await this.form
+      .getByTestId(formErrors.identity.url)
+      .isVisible();
+    const isIdentityLinkDescriptionErrorVisible = await this.form
+      .getByTestId(formErrors.identity.description)
+      .isVisible();
+    const isPaymentAddressErrorVisible = await this.form
+      .getByTestId(formErrors.paymentAddress)
+      .isVisible();
 
-    expect(await this.objectivesInput.textContent()).not.toEqual(
-      dRepInfo.objectives
-    );
-    expect(await this.motivationsInput.textContent()).not.toEqual(
-      dRepInfo.qualifications
-    );
-    expect(await this.qualificationsInput.textContent()).not.toEqual(
-      dRepInfo.qualifications
-    );
+    await expect(this.form.getByTestId(formErrors.paymentAddress), {
+      message:
+        !isPaymentAddressErrorVisible &&
+        `${dRepInfo.paymentAddress} is a valid paymentAddress`,
+    }).toBeVisible();
 
-    await expect(this.form.getByTestId(formErrors.links.url)).toBeVisible();
-    await expect(
-      this.form.getByTestId(formErrors.links.description)
-    ).toBeVisible();
-    await expect(this.form.getByTestId(formErrors.identity.url)).toBeVisible();
-    await expect(
-      this.form.getByTestId(formErrors.identity.description)
-    ).toBeVisible();
+    expect(await this.objectivesInput.textContent(), {
+      message:
+        objectivesInputText === dRepInfo.objectives &&
+        `${dRepInfo.objectives} is equal to ${await this.objectivesInput.textContent()}`,
+    }).not.toEqual(dRepInfo.objectives);
+    expect(await this.motivationsInput.textContent(), {
+      message:
+        motivationsInputText === dRepInfo.motivations &&
+        `${dRepInfo.motivations} is equal to ${await this.motivationsInput.textContent()}`,
+    }).not.toEqual(dRepInfo.qualifications);
+    expect(await this.qualificationsInput.textContent(), {
+      message:
+        qualificationsInputText === dRepInfo.qualifications &&
+        `${dRepInfo.qualifications} is equal to ${await this.qualificationsInput.textContent()}`,
+    }).not.toEqual(dRepInfo.qualifications);
+
+    await expect(this.form.getByTestId(formErrors.links.url), {
+      message:
+        !isReferenceLinkErrorVisible &&
+        `${dRepInfo.linksReferenceLinks[0].url} is a valid url`,
+    }).toBeVisible();
+    await expect(this.form.getByTestId(formErrors.links.description), {
+      message:
+        !isReferenceLinkDescriptionErrorVisible &&
+        `${dRepInfo.linksReferenceLinks[0].description} is a valid description`,
+    }).toBeVisible();
+    await expect(this.form.getByTestId(formErrors.identity.url), {
+      message:
+        !isIdentityLinkErrorVisible &&
+        `${dRepInfo.identityReferenceLinks[0].url} is a valid url`,
+    }).toBeVisible();
+    await expect(this.form.getByTestId(formErrors.identity.description), {
+      message:
+        !isIdentityLinkDescriptionErrorVisible &&
+        `${dRepInfo.identityReferenceLinks[0].description} is a valid description`,
+    }).toBeVisible();
 
     await expect(this.continueBtn).toBeDisabled();
   }

--- a/tests/govtool-frontend/playwright/lib/helpers/cardano.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/cardano.ts
@@ -4,6 +4,8 @@ import kuberService from "@services/kuberService";
 import { ProposalType, ProtocolParams } from "@types";
 import { allure } from "allure-playwright";
 import { bech32 } from "bech32";
+import { functionWaitedAssert } from "./waitedLoop";
+import { createFile, getFile } from "./file";
 
 export function lovelaceToAda(lovelace: number) {
   if (lovelace === 0) return 0;
@@ -17,8 +19,16 @@ export function generateWalletAddress() {
 }
 
 export async function getProtocolParamsMajorVersion() {
-  const protocolParameter: ProtocolParams =
-    await kuberService.queryProtocolParams();
+  let protocolParameter = await getFile("protocolParameter.json");
+  if (protocolParameter === undefined) {
+    await functionWaitedAssert(
+      async () => {
+        protocolParameter = await kuberService.queryProtocolParams();
+        await createFile("protocolParameter.json", protocolParameter);
+      },
+      { name: "queryProtocolParams" }
+    );
+  }
   return protocolParameter.protocolVersion.major;
 }
 

--- a/tests/govtool-frontend/playwright/lib/helpers/file.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/file.ts
@@ -1,4 +1,4 @@
-import { writeFile } from "fs";
+import { readFile, writeFile } from "fs";
 const path = require("path");
 
 const baseFilePath = path.resolve(__dirname, "../_mock");
@@ -17,4 +17,21 @@ export async function createFile(fileName: string, data?: any) {
       }
     )
   );
+}
+
+export async function getFile(fileName: string): Promise<any> {
+  const data: string = await new Promise((resolve, reject) =>
+    readFile(`${baseFilePath}/${fileName}`, "utf8", (err, data) => {
+      if (err) {
+        if (err.code === "ENOENT") {
+          resolve(undefined);
+        } else {
+          reject(err);
+        }
+      } else {
+        resolve(data);
+      }
+    })
+  );
+  return data ? JSON.parse(data) : undefined;
 }

--- a/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
@@ -199,8 +199,15 @@ export default class DRepDirectoryPage {
     await this.goto();
 
     await this.searchInput.fill(dRepId);
+    const isEmptyContainerVisible = await this.page
+      .getByText("No DReps found")
+      .isVisible();
 
-    await expect(this.page.getByText("No DReps found")).toBeVisible({
+    await expect(this.page.getByText("No DReps found"), {
+      message:
+        !isEmptyContainerVisible &&
+        `DRep with id ${dRepId} is found in the list`,
+    }).toBeVisible({
       timeout: 20_000,
     });
   }

--- a/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
@@ -140,20 +140,28 @@ export default class DRepDirectoryPage {
       const isValid = validationFn(dRepList[i], dRepList[i + 1]);
       expect(isValid).toBe(true);
     }
-    // Frontend validation
-    const cip105DRepListFE = await this.getAllListedCIP105DRepIds();
-    const cip129DRepListFE = await this.getAllListedCIP129DRepIds();
 
-    const cip129DRepListApi = dRepList.map((dRep) =>
-      convertDRepToCIP129(dRep.drepId, dRep.isScriptBased)
+    await functionWaitedAssert(
+      async () => {
+        // Frontend validation
+        const cip105DRepListFE = await this.getAllListedCIP105DRepIds();
+        const cip129DRepListFE = await this.getAllListedCIP129DRepIds();
+
+        const cip129DRepListApi = dRepList.map((dRep) =>
+          convertDRepToCIP129(dRep.drepId, dRep.isScriptBased)
+        );
+
+        for (let i = 0; i <= cip105DRepListFE.length - 1; i++) {
+          await expect(cip129DRepListFE[i], {
+            message: `Cip129 dRep Id from Api:${cip129DRepListApi[i]} is not equal to ${await cip129DRepListFE[i].textContent()} on sort ${option}`,
+          }).toHaveText(cip129DRepListApi[i]);
+          await expect(cip105DRepListFE[i], {
+            message: `Cip105 dRep Id from Api:${dRepList[i].view} is not equal to ${await cip105DRepListFE[i].textContent()}  on sort ${option}`,
+          }).toHaveText(`(CIP-105) ${dRepList[i].view}`);
+        }
+      },
+      { name: `frontend sort validation of ${option}` }
     );
-
-    for (let i = 0; i <= cip105DRepListFE.length - 1; i++) {
-      await expect(cip129DRepListFE[i]).toHaveText(cip129DRepListApi[i]);
-      await expect(cip105DRepListFE[i]).toHaveText(
-        `(CIP-105) ${dRepList[i].view}`
-      );
-    }
   }
   getDRepCard(dRepId: string) {
     return this.page.getByTestId(`${dRepId}-drep-card`);

--- a/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
@@ -68,9 +68,6 @@ export default class DRepDirectoryPage {
   async filterDReps(filterOptions: string[]) {
     for (const option of filterOptions) {
       await this.page.getByTestId(`${option}-checkbox`).click();
-      if (option !== "Active" && filterOptions.length === 1) {
-        await this.page.getByTestId(`Active-checkbox`).click();
-      }
     }
   }
 

--- a/tests/govtool-frontend/playwright/lib/walletManager.ts
+++ b/tests/govtool-frontend/playwright/lib/walletManager.ts
@@ -1,6 +1,6 @@
 import { StaticWallet } from "@types";
-import * as fs from "fs";
 import { LockInterceptor } from "./lockInterceptor";
+import { createFile, getFile } from "@helpers/file";
 const path = require("path");
 
 const baseFilePath = path.resolve(__dirname, "./_mock");
@@ -28,36 +28,11 @@ class WalletManager {
   }
 
   async writeWallets(wallets: StaticWallet[], purpose: Purpose) {
-    await new Promise<void>((resolve, reject) =>
-      fs.writeFile(
-        `${baseFilePath}/${purpose}Wallets.json`,
-        JSON.stringify(wallets, null, 2),
-        (err) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve();
-          }
-        }
-      )
-    );
+    await createFile(`${purpose}Wallets.json`, wallets);
   }
 
   async readWallets(purpose: Purpose): Promise<StaticWallet[]> {
-    const data: string = await new Promise((resolve, reject) =>
-      fs.readFile(
-        `${baseFilePath}/${purpose}Wallets.json`,
-        "utf8",
-        (err, data) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(data);
-          }
-        }
-      )
-    );
-    return JSON.parse(data);
+    return await getFile(`${purpose}Wallets.json`);
   }
 
   async removeCopyWallet(walletToRemove: StaticWallet, purpose: Purpose) {

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
@@ -129,6 +129,7 @@ test("2K_1. Should filter DReps", async ({ page }) => {
   await dRepDirectory.goto();
 
   await dRepDirectory.filterBtn.click();
+  await page.getByTestId(`Active-checkbox`).click();
 
   // Single filter
   for (const option of dRepFilterOptions) {

--- a/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
@@ -186,8 +186,16 @@ test.describe("Perform voting", () => {
     await govActionDetailsPage.reVote();
     await governanceActionsPage.votedTab.click();
 
+    const isNoVoteVisible = await govActionDetailsPage.currentPage
+      .getByTestId("my-vote")
+      .getByText("No")
+      .isVisible();
+
     await expect(
-      govActionDetailsPage.currentPage.getByTestId("my-vote").getByText("No")
+      govActionDetailsPage.currentPage.getByTestId("my-vote").getByText("No"),
+      {
+        message: !isNoVoteVisible && "No vote not visible",
+      }
     ).toBeVisible({ timeout: 60_000 });
   });
 

--- a/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/6-miscellaneous/miscellaneous.spec.ts
@@ -285,7 +285,9 @@ test("6S. Should Warn users that they are in bootstrapping phase via banner", as
 
   await responsePromise;
 
-  await expect(page.getByTestId("system-bootstrapping-warning")).toBeVisible();
+  await expect(page.getByTestId("system-bootstrapping-warning")).toBeVisible({
+    timeout: 60_000,
+  });
 
   const [bootstrap] = await Promise.all([
     context.waitForEvent("page"),

--- a/tests/govtool-frontend/playwright/tests/8-proposal-discussion/proposalDiscussion.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/8-proposal-discussion/proposalDiscussion.spec.ts
@@ -115,6 +115,7 @@ test("8C. Should search the list of proposed governance actions.", async ({
     async () => {
       const proposalCards = await proposalDiscussionPage.getAllProposals();
       for (const proposalCard of proposalCards) {
+        await expect(proposalCard).toBeVisible();
         const proposalTitle = await proposalCard
           .locator('[data-testid^="proposal-"][data-testid$="-title"]')
           .innerText();


### PR DESCRIPTION
## List of changes

- Increase assertion timeout to 1 min
- Wrap validation and visibility test with assertion function for retries to 1mins
- Add message for failing assertion of proposal and dRep visibility and validation
- Write proposalParameter to file and get parameter from file instead of fetch on each test

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
