### PR TITLE
fix: remove unnecessary filter in fetchFirstActiveDRepDetails ,add scroll to page and show correct message in revote "5E" test

### DIFF
--- a/tests/govtool-frontend/playwright/lib/helpers/dRep.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/dRep.ts
@@ -33,8 +33,6 @@ export async function fetchFirstActiveDRepDetails(page: Page) {
 
   dRepDirectoryPage = new DRepDirectoryPage(page);
   await dRepDirectoryPage.goto();
-  await dRepDirectoryPage.filterBtn.click();
-  await page.getByTestId("Active-checkbox").click();
   await responsePromise;
 
   await dRepDirectoryPage.searchInput.click();

--- a/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/5-proposal-functionality/proposalFunctionality.dRep.spec.ts
@@ -178,6 +178,10 @@ test.describe("Perform voting", () => {
 
     await governanceActionsPage.votedTab.click();
 
+    await govActionDetailsPage.currentPage.evaluate(() =>
+      window.scrollTo(0, 500)
+    );
+
     await expect(
       govActionDetailsPage.currentPage.getByTestId("my-vote").getByText("Yes")
     ).toBeVisible();
@@ -191,10 +195,19 @@ test.describe("Perform voting", () => {
       .getByText("No")
       .isVisible();
 
+    const textContent = await govActionDetailsPage.currentPage
+      .getByTestId("my-vote")
+      .textContent();
+
+    await govActionDetailsPage.currentPage.evaluate(() =>
+      window.scrollTo(0, 500)
+    );
     await expect(
       govActionDetailsPage.currentPage.getByTestId("my-vote").getByText("No"),
       {
-        message: !isNoVoteVisible && "No vote not visible",
+        message:
+          !isNoVoteVisible &&
+          `"No" vote not visible, current vote status: ${textContent.match(/My Vote:(Yes|No)/)[1]}`,
       }
     ).toBeVisible({ timeout: 60_000 });
   });


### PR DESCRIPTION
## List of changes

- Remove redundant filter in fetchFirstActiveDRepDetails, as the active filter is applied by default
- As it unchecked the active filter and fetch random dRep instead of active dRep
- Add scroll to the page for a proper screenshot for vote status 
- Add proper status message for revote 5E test

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
