### PR TITLE
fix: outcomes api url env issue

### DIFF
--- a/.github/workflows/build-and-deploy-test-stack.yml
+++ b/.github/workflows/build-and-deploy-test-stack.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   deploy:
     name: Deploy app
+    environment: 'preview-govtool'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -61,7 +62,7 @@ jobs:
             cd $DEST_DIR/tests/test-infrastructure
             ./build-and-deploy.sh update-images
             yes | docker system prune -f || echo "Ignoring system prune eror"
-          envs: GOVTOOL_TAG, GRAFANA_ADMIN_PASSWORD, GRAFANA_SLACK_RECIPIENT, GRAFANA_SLACK_OAUTH_TOKEN, SENTRY_DSN_BACKEND, GTM_ID, NPMRC_TOKEN, SENTRY_DSN_FRONTEND, PIPELINE_URL, USERSNAP_SPACE_API_KEY, APP_ENV, PDF_API_URL, KUBER_API_KEY, IPFS_GATEWAY, IPFS_PROJECT_ID, VITE_OUTCOMES_API_URL
+          envs: GOVTOOL_TAG, GRAFANA_ADMIN_PASSWORD, GRAFANA_SLACK_RECIPIENT, GRAFANA_SLACK_OAUTH_TOKEN, SENTRY_DSN_BACKEND, GTM_ID, NPMRC_TOKEN, SENTRY_DSN_FRONTEND, PIPELINE_URL, USERSNAP_SPACE_API_KEY, APP_ENV, PDF_API_URL, KUBER_API_KEY, IPFS_GATEWAY, IPFS_PROJECT_ID, OUTCOMES_API_URL
         env:
           GOVTOOL_TAG: ${{ github.sha }}
           GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
@@ -75,7 +76,7 @@ jobs:
           USERSNAP_SPACE_API_KEY: ${{ secrets.USERSNAP_SPACE_API_KEY }}
           APP_ENV: test
           PDF_API_URL: ${{ secrets.PDF_API_URL }}
-          OUTCOMES_API_URL: ${{ secrets.OUTCOMES_API_URL }}
+          OUTCOMES_API_URL: ${{ secrets.VITE_OUTCOMES_API_URL }}
           KUBER_API_KEY: ${{ secrets.KUBER_API_KEY }}
           IPFS_GATEWAY: $${{secrets.IPFS_GATEWAY}}
           IPFS_PROJECT_ID: $${{secrets.IPFS_PROJECT_ID}}


### PR DESCRIPTION
## List of changes

- Change secrets OUTCOMES_API_URL to VITE_OUTCOMES_API_URL
- Change env VITE_OUTCOMES_API_URL to OUTCOMES_API_URL
- Add preview-govtool environment

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
