### PR TITLE
Fix proposal submission metadata issue, handle missing wallets file, and improve active dRep fetch retries

### DIFF
--- a/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
@@ -140,7 +140,7 @@ export default class ProposalSubmissionPage {
 
     const dRepMetadata = await this.downloadVoteMetadata();
     const url = await metadataBucketService.uploadMetadata(
-      dRepMetadata.name,
+      faker.lorem.word({ length: { min: 5, max: 10 } }),
       dRepMetadata.data
     );
     await this.metadataUrlInput.fill(url);

--- a/tests/govtool-frontend/playwright/lib/walletManager.ts
+++ b/tests/govtool-frontend/playwright/lib/walletManager.ts
@@ -32,7 +32,7 @@ class WalletManager {
   }
 
   async readWallets(purpose: Purpose): Promise<StaticWallet[]> {
-    return await getFile(`${purpose}Wallets.json`);
+    return (await getFile(`${purpose}Wallets.json`)) ?? [];
   }
 
   async removeCopyWallet(walletToRemove: StaticWallet, purpose: Purpose) {


### PR DESCRIPTION
## List of changes

- Use a random word for metadata upload in proposal submission as data.jsonId is used for all proposal submission metadata
- Return empty array if wallets file is not found to fix "file not found" error
- Filter by active status and Retries fetchFirstActiveDRepDetails if donNotList flag is true as it fails searches dRep_directory test

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
