### PR TITLE
fix: handle missing report number in commit status script

### DIFF
--- a/.github/scripts/set_commit_status.sh
+++ b/.github/scripts/set_commit_status.sh
@@ -9,7 +9,7 @@ fi
 # Retrieve necessary variables from workflow
 START_TIME=${START_TIME:-$(date +%s)}
 TEST_STATUS=${TEST_STATUS:-"failure"}
-REPORT_NUMBER=${REPORT_NUMBER:-1}
+REPORT_NUMBER=${REPORT_NUMBER:-0}
 REPORT_NAME=${REPORT_NAME:-"govtool-frontend"}
 HOST_URL=${HOST_URL:-"https://govtool.cardanoapi.io"}
 CONTEXT="Playwright Tests : $HOST_URL"
@@ -60,6 +60,12 @@ elif [[ "$TEST_STATUS" == "failure" && "$TOTAL" -ne 0 ]]; then
   DESCRIPTION="Tests failed in ${TEST_DURATION}: Passed ${PASSED}, Failed ${FAILED} out of ${TOTAL}"
 else
   DESCRIPTION="⚠️ Tests execution failed :$TEST_STATUS"
+  TEST_STATUS="error"
+  TARGET_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+fi
+
+if [[ "$REPORT_NUMBER" == 0 ]]; then
+  DESCRIPTION="⚠️ Test execution failed due to missing report number"
   TEST_STATUS="error"
   TARGET_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 fi


### PR DESCRIPTION
## List of changes

- Fix incorrect report number linkage in failure publish reports for both backend and integration tests.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
