### PR TITLE
fix(#3108): hide voting threshold for cc in info type governance action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ changes.
 
 ### Removed
 
+- Remove ratification threshold for Info Action for Consitutional Committee [Issue 3108](https://github.com/IntersectMBO/govtool/issues/3108)
+
 ## [v2.0.13](https://github.com/IntersectMBO/govtool/releases/tag/v2.0.13) 2025-02-27
 
 ### Added

--- a/govtool/frontend/src/components/molecules/VotesSubmitted.tsx
+++ b/govtool/frontend/src/components/molecules/VotesSubmitted.tsx
@@ -207,7 +207,11 @@ export const VotesSubmitted = ({
             noVotesPercentage={ccNoVotesPercentage}
             notVotedVotes={ccNotVotedVotes}
             notVotedPercentage={ccNotVotedVotesPercentage}
-            threshold={Number(ccThreshold)}
+            threshold={
+              type !== GovernanceActionType.InfoAction
+                ? Number(ccThreshold)
+                : null
+            }
           />
         )}
       </Box>


### PR DESCRIPTION
## List of changes

- hide voting threshold for cc in info type governance action

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3108)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
