### PR TITLE
fix(#3134): calculating withdrawals when there are no rewards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,13 @@ changes.
 
 ### Fixed
 
+- Fix calculating withdrawals when rewards records are empty for a given stake key [Issue 3134](https://github.com/IntersectMBO/govtool/issues/3134)
+
 ### Changed
 
 ### Removed
 
 ## [v2.0.13](https://github.com/IntersectMBO/govtool/releases/tag/v2.0.13) 2025-02-27
-
 
 ### Added
 

--- a/govtool/backend/sql/get-stake-key-voting-power.sql
+++ b/govtool/backend/sql/get-stake-key-voting-power.sql
@@ -38,7 +38,15 @@ Withdrawal AS (
     w.addr_id
 )
 SELECT
-  (COALESCE(rr.amount, 0) + COALESCE(r.amount, 0) + COALESCE(b.amount, 0) - COALESCE(w.withdrawal_amount, 0)) AS total_balance,
+  (COALESCE(rr.amount, 0) + COALESCE(r.amount, 0) + COALESCE(b.amount, 0) - 
+  -- records in rewards tables might be missing for some epochs
+  -- so we need to check if the sum of rewards is greater than the sum of withdrawals before subtracting
+    CASE 
+      WHEN COALESCE(rr.amount, 0) + COALESCE(r.amount, 0) > COALESCE(w.withdrawal_amount, 0) 
+      THEN COALESCE(w.withdrawal_amount, 0) 
+      ELSE 0 
+    END
+  ) AS total_balance,
   b.addr_raw::text AS stake_address
 FROM
   Balance b


### PR DESCRIPTION
## List of changes

- add conditional subtracting of withdrawals until records with rewards are populated in db-sync.
Referring to the db-sync documentation rewards might not be populated instantly making the balance negative when withdrawals of rewards are existing

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3134)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
