### PR TITLE
Add proposal metadata error behaviour test for both live voting and outcomes 

### DIFF
--- a/tests/govtool-frontend/playwright/lib/_mock/outcome.json
+++ b/tests/govtool-frontend/playwright/lib/_mock/outcome.json
@@ -1,0 +1,41 @@
+[
+  {
+    "id": "320",
+    "tx_hash": "833382b22ebd07bb7dee60001cfdce78ede3b8397b1027daeb7996f61c072bde",
+    "index": "0",
+    "type": "InfoAction",
+    "description": {
+      "data": {
+        "tag": "InfoAction"
+      }
+    },
+    "expiry_date": "2025-02-27T00:01:04.000Z",
+    "expiration": 856,
+    "time": "2025-01-27T16:15:21.000Z",
+    "epoch_no": 825,
+    "url": "https://bit.ly/3zCH2HL",
+    "data_hash": "99a19b124ceb89bbd92354e8d11f913d1aec7280ce19ac4c1c6cc72f0ea91884",
+    "proposal_params": null,
+    "title": null,
+    "abstract": null,
+    "motivation": null,
+    "rationale": null,
+    "yes_votes": "0",
+    "no_votes": "14333625476330",
+    "abstain_votes": "0",
+    "pool_yes_votes": "0",
+    "pool_no_votes": "0",
+    "pool_abstain_votes": "0",
+    "cc_yes_votes": "0",
+    "cc_no_votes": "0",
+    "cc_abstain_votes": "0",
+    "prev_gov_action_index": null,
+    "prev_gov_action_tx_hash": null,
+    "status": {
+      "ratified_epoch": null,
+      "enacted_epoch": null,
+      "dropped_epoch": 857,
+      "expired_epoch": 856
+    }
+  }
+]

--- a/tests/govtool-frontend/playwright/lib/constants/index.ts
+++ b/tests/govtool-frontend/playwright/lib/constants/index.ts
@@ -1,3 +1,6 @@
+import { faker } from "@faker-js/faker";
+import { InvalidMetadataType } from "@types";
+
 export const SECURITY_RELEVANT_PARAMS_MAP: Record<string, string> = {
   maxBlockBodySize: "max_block_size",
   maxTxSize: "max_tx_size",
@@ -30,4 +33,25 @@ export const outcomeStatusType = [
   "Ratified",
   "Enacted",
   "Live",
+];
+
+export const InvalidMetadata: InvalidMetadataType[] = [
+  {
+    type: "Data Formatted Incorrectly",
+    reason: "metadata is not in the correct format.",
+    url: "https://bit.ly/3zCH2HL",
+    hash: "1111111111111111111111111111111111111111111111111111111111111111",
+  },
+  {
+    type: "Data Missing",
+    reason: "metadata URL could not be found.",
+    url: faker.internet.url() + "/test.jsonld",
+    hash: "99a19b124ceb89bbd92354e8d11f913d1aec7280ce19ac4c1c6cc72f0ea91884",
+  },
+  {
+    type: "Data Not Verifiable",
+    reason: "metadata hash and URL do not match.",
+    url: "https://metadata-govtool.cardanoapi.io/data/data.jsonld",
+    hash: "e71bf6171adda3754a87fff5c2d8d9e404eb3366428a5be13f7e76357a39004f",
+  },
 ];

--- a/tests/govtool-frontend/playwright/lib/constants/index.ts
+++ b/tests/govtool-frontend/playwright/lib/constants/index.ts
@@ -38,9 +38,9 @@ export const outcomeStatusType = [
 export const InvalidMetadata: InvalidMetadataType[] = [
   {
     type: "Data Formatted Incorrectly",
-    reason: "metadata is not in the correct format.",
-    url: "https://bit.ly/3zCH2HL",
-    hash: "1111111111111111111111111111111111111111111111111111111111111111",
+    reason: "hash is valid but incorrect metadata format.",
+    url: "https://metadata-govtool.cardanoapi.io/data/Lolita",
+    hash: "62a37df07103f0a69690c8975700e06b7c3c3069cb3d105abec00e820e831dda",
   },
   {
     type: "Data Missing",
@@ -52,6 +52,12 @@ export const InvalidMetadata: InvalidMetadataType[] = [
     type: "Data Not Verifiable",
     reason: "metadata hash and URL do not match.",
     url: "https://metadata-govtool.cardanoapi.io/data/data.jsonld",
+    hash: "e71bf6171adda3754a87fff5c2d8d9e404eb3366428a5be13f7e76357a39004f",
+  },
+  {
+    type: "Data Not Verifiable",
+    reason: "metadata hash and URL do not match and is incorrect ga format",
+    url: "https://metadata-govtool.cardanoapi.io/data/Lolita",
     hash: "e71bf6171adda3754a87fff5c2d8d9e404eb3366428a5be13f7e76357a39004f",
   },
 ];

--- a/tests/govtool-frontend/playwright/lib/types.ts
+++ b/tests/govtool-frontend/playwright/lib/types.ts
@@ -9,6 +9,13 @@ export type KuberValue = {
   [policyId: string]: Record<string, BigInt | number> | BigInt | number;
 };
 
+export interface PaginatedLiveProposal {
+  page: number;
+  pageSize: number;
+  total: number;
+  elements: IProposal[];
+}
+
 export interface IProposal {
   id: string;
   txHash: string;
@@ -301,4 +308,11 @@ interface outcomeMetadataBody {
   motivation: "string";
   rationale: string;
   title: string;
+}
+
+export interface InvalidMetadataType {
+  type: string;
+  reason: string;
+  url: string;
+  hash: string;
 }


### PR DESCRIPTION
## List of changes

- Add proposal metadata error behaviour test for both live voting and outcomes 

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
