### PR TITLE
fix(#3203): Fix wrong CIP-129 script based DRep prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ changes.
 
 - hotfix for ada handle and payment address validation order [Issue 3155](https://github.com/IntersectMBO/govtool/issues/3155)
 - fix proposal list performance by pre-filtering active proposals [Issue 3190](https://github.com/IntersectMBO/govtool/issues/3190)
+- Fix wrong prefix of script based dreps in CIP-129 standard [Issue 3203](https://github.com/IntersectMBO/govtool/issues/3203)
 
 ### Changed
 

--- a/govtool/frontend/src/components/organisms/DRepCard.tsx
+++ b/govtool/frontend/src/components/organisms/DRepCard.tsx
@@ -62,7 +62,7 @@ export const DRepCard = ({
 
   const cip129Identifier = encodeCIP129Identifier({
     txID: `${isScriptBased ? "23" : "22"}${drepId}`,
-    bech32Prefix: isScriptBased ? "drep_script" : "drep",
+    bech32Prefix: "drep",
   });
 
   const base64Image = getBase64ImageDetails(image ?? "");

--- a/govtool/frontend/src/components/organisms/DRepDetailsCard.tsx
+++ b/govtool/frontend/src/components/organisms/DRepDetailsCard.tsx
@@ -117,7 +117,7 @@ export const DRepDetailsCard = ({
           <CopyableText
             value={encodeCIP129Identifier({
               txID: `${isScriptBased ? "23" : "22"}${drepId}`,
-              bech32Prefix: isScriptBased ? "drep_script" : "drep",
+              bech32Prefix: "drep",
             })}
             dataTestId="copy-cip-129-drep-id-button"
           />


### PR DESCRIPTION
## List of changes

- Fix wrong CIP-129 script based DRep prefix
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/9f8e412f-2cdd-4f47-aa87-b6a9e825171b" />


## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3203)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
