### PR TITLE
Tests: script based dRep conversion

### DIFF
--- a/tests/govtool-frontend/playwright/lib/_mock/scriptDRep.json
+++ b/tests/govtool-frontend/playwright/lib/_mock/scriptDRep.json
@@ -1,0 +1,28 @@
+{
+  "page": 0,
+  "pageSize": 10,
+  "total": 1,
+  "elements": [
+    {
+      "isScriptBased": true,
+      "drepId": "429b12461640cefd3a4a192f7c531d8f6c6d33610b727f481eb22d39",
+      "view": "drep1g2d3y3skgr806wj2ryhhc5ca3akx6vmppde87jq7kgknjmv589e",
+      "url": null,
+      "metadataHash": null,
+      "deposit": 500000000,
+      "votingPower": 83414740266257,
+      "status": "Active",
+      "type": "SoleVoter",
+      "latestTxHash": "8de2a5f9074679de947549ea36c3980496503ffc40f0cbce5ce1ee3df66306e9",
+      "latestRegistrationDate": "2024-11-20T01:59:20Z",
+      "metadataError": null,
+      "paymentAddress": null,
+      "givenName": null,
+      "objectives": null,
+      "motivations": null,
+      "qualifications": null,
+      "imageUrl": null,
+      "imageHash": null
+    }
+  ]
+}

--- a/tests/govtool-frontend/playwright/lib/helpers/dRep.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/dRep.ts
@@ -88,10 +88,14 @@ export function tohex(drepId: string) {
   ).toString("hex");
 }
 
-export function convertDRepToCIP129(drepId: string, script = false): string {
+export function convertDRep(
+  drepId: string,
+  script = false
+): { cip129: string; cip105: string } {
   const hexPattern = /^[0-9a-fA-F]+$/;
   let cip129DRep: string;
   let cip129DrepHex: string;
+  let cip105DRep: string;
   const prefix = script ? "23" : "22";
   const addPrefix = (hex: string) => {
     if (hex.length === 56) {
@@ -102,8 +106,8 @@ export function convertDRepToCIP129(drepId: string, script = false): string {
       throw new Error("Invalid DRep hex length");
     }
   };
-  const drepIdFromHex = (hex: string) => {
-    return fromHex("drep", hex);
+  const drepIdFromHex = (prefix: string, hex: string) => {
+    return fromHex(prefix, hex);
   };
   if (hexPattern.test(drepId)) {
     cip129DrepHex = addPrefix(drepId);
@@ -115,6 +119,10 @@ export function convertDRepToCIP129(drepId: string, script = false): string {
       throw new Error("Invalid DRep Bech32 format");
     }
   }
-  cip129DRep = drepIdFromHex(cip129DrepHex);
-  return cip129DRep;
+  cip105DRep = drepIdFromHex(
+    cip129DrepHex.slice(0, 2) == "22" ? "drep" : "drep_script",
+    cip129DrepHex.slice(-56)
+  );
+  cip129DRep = drepIdFromHex("drep", cip129DrepHex);
+  return { cip129: cip129DRep, cip105: cip105DRep };
 }

--- a/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
@@ -1,4 +1,4 @@
-import { convertDRepToCIP129 } from "@helpers/dRep";
+import { convertDRep } from "@helpers/dRep";
 import { functionWaitedAssert, waitedLoop } from "@helpers/waitedLoop";
 import { Locator, Page, expect } from "@playwright/test";
 import { IDRep } from "@types";
@@ -156,8 +156,12 @@ export default class DRepDirectoryPage {
         const cip105DRepListFE = await this.getAllListedCIP105DRepIds();
         const cip129DRepListFE = await this.getAllListedCIP129DRepIds();
 
-        const cip129DRepListApi = dRepList.map((dRep) =>
-          convertDRepToCIP129(dRep.drepId, dRep.isScriptBased)
+        const cip129DRepListApi = dRepList.map(
+          (dRep) => convertDRep(dRep.drepId, dRep.isScriptBased).cip129
+        );
+
+        const cip105DRepListApi = dRepList.map(
+          (dRep) => convertDRep(dRep.drepId, dRep.isScriptBased).cip105
         );
 
         for (let i = 0; i <= cip105DRepListFE.length - 1; i++) {
@@ -165,8 +169,8 @@ export default class DRepDirectoryPage {
             message: `Cip129 dRep Id from Api:${cip129DRepListApi[i]} is not equal to ${await cip129DRepListFE[i].textContent()} on sort ${option}`,
           }).toHaveText(cip129DRepListApi[i]);
           await expect(cip105DRepListFE[i], {
-            message: `Cip105 dRep Id from Api:${dRepList[i].view} is not equal to ${await cip105DRepListFE[i].textContent()}  on sort ${option}`,
-          }).toHaveText(`(CIP-105) ${dRepList[i].view}`);
+            message: `Cip105 dRep Id from Api:${cip105DRepListApi} is not equal to ${await cip105DRepListFE[i].textContent()}  on sort ${option}`,
+          }).toHaveText(`(CIP-105) ${cip105DRepListApi[i]}`);
         }
       },
       { name: `frontend sort validation of ${option}` }


### PR DESCRIPTION
## List of changes

- Refactor the `convertDRepTo129` helper function to convert `convertDRep`, supporting both CIP-129 and CIP-105 using `dRepView`.  
- Add a mock dRep response of script-based dRep and use it to verify the conversion of script dRep for CIP-129 and CIP-105 in dRep details.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
