### PR TITLE
chore: add missing icons to the nginx

### DIFF
--- a/govtool/frontend/nginx.conf
+++ b/govtool/frontend/nginx.conf
@@ -3,28 +3,6 @@ server {
   root /usr/share/nginx/html;
   error_page 503 @maintenance;
 
-  gzip on;
-  gzip_static on;
-  gzip_vary on;
-  gzip_proxied any;
-  gzip_comp_level 6;
-  gzip_buffers 16 8k;
-  gzip_http_version 1.1;
-  gzip_types text/plain text/css application/javascript application/json application/xml application/xml+rss text/javascript;
-
-  location ~* \.(?:css|js|jpg|jpeg|gif|png|ico|svg|woff2?)$ {
-    expires 1y;
-    add_header Cache-Control "public, max-age=31536000, immutable";
-    try_files $uri =404;
-
-    brotli_static on;
-    
-    types {
-      application/javascript js;
-      text/css css;
-    }
-  }
-  
   location / {
     index index.html;
     try_files $uri $uri /index.html;


### PR DESCRIPTION
Get rid of the unneded gzipping strategies that removes support for the svgs