### PR TITLE
fix(#3193): allow casting same vote with updated rationale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,13 @@ changes.
 
 ### Fixed
 
+- allow casting same vote with a different rationale [Issue 3191](https://github.com/IntersectMBO/govtool/issues/3191)
+
 ### Changed
 
 ### Removed
 
 ## [v2.0.16](https://github.com/IntersectMBO/govtool/releases/tag/v2.0.16) 2025-03-17
-
 
 ### Added
 

--- a/govtool/frontend/src/hooks/forms/useVoteActionForm.tsx
+++ b/govtool/frontend/src/hooks/forms/useVoteActionForm.tsx
@@ -69,8 +69,7 @@ export const useVoteActionForm = ({
     txHash !== null &&
     index !== undefined &&
     index !== null &&
-    !areFormErrors &&
-    previousVote?.vote !== vote;
+    !areFormErrors;
 
   const confirmVote = useCallback(
     async (values: VoteActionFormValues) => {


### PR DESCRIPTION
## List of changes

- allow casting same vote with updated rationale

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3191)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
