### PR TITLE
Prevent github status publish on test-stack deployment failure

### DIFF
--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -162,7 +162,7 @@ jobs:
 
   publish-status:
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && needs.backend-tests.result != 'skipped'
     needs: [backend-tests, publish-report]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_integration_playwright.yml
+++ b/.github/workflows/test_integration_playwright.yml
@@ -202,7 +202,7 @@ jobs:
 
   publish-status:
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && needs.integration-tests.result != 'skipped'
     needs: [integration-tests, publish-report]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## List of changes

- Prevent publishing Github status when test stack deployment failed

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
