### PR TITLE
chore: add status_times to outcome mock data

### DIFF
--- a/tests/govtool-frontend/playwright/lib/_mock/outcome.json
+++ b/tests/govtool-frontend/playwright/lib/_mock/outcome.json
@@ -36,6 +36,12 @@
       "enacted_epoch": null,
       "dropped_epoch": 857,
       "expired_epoch": 856
+    },
+    "status_times": {
+      "ratified_time": null,
+      "enacted_time": null,
+      "dropped_time": "2025-03-25T23:59:10",
+      "expired_time": "2025-03-24T23:58:49"
     }
   }
 ]


### PR DESCRIPTION
## List of changes

- Add status_time API response on outcome mock data

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
