### PR TITLE
Fix outcome titles test IDs, and Add metadata test failure message

### DIFF
--- a/tests/govtool-frontend/playwright/lib/pages/outcomesPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/outcomesPage.ts
@@ -11,9 +11,14 @@ export default class OutComesPage {
   readonly filterBtn = this.page.getByTestId("filters-button");
   readonly sortBtn = this.page.getByTestId("sort-button");
   readonly showMoreBtn = this.page.getByTestId("show-more-button");
+  readonly metadataErrorLearnMoreBtn = this.page.getByTestId(
+    "metadata-error-learn-more"
+  );
 
   //inputs
   readonly searchInput = this.page.getByTestId("search-input");
+
+  readonly title = this.page.getByTestId("single-action-title");
 
   constructor(private readonly page: Page) {}
 

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.spec.ts
@@ -324,9 +324,15 @@ test.describe("Invalid Live voting Metadata", () => {
       await governanceActionPage.goto();
       await governanceActionPage.viewFirstProposal();
 
-      await expect(page.getByRole("heading", { name: type })).toBeVisible({
-        timeout: 60_000,
-      });
+      const governanceActionTitle = await page
+        .getByTestId("governance-action-details-card-header")
+        .textContent();
+
+      await expect(
+        page.getByTestId("governance-action-details-card-header"),
+        governanceActionTitle.toLowerCase() !== type.toLowerCase() &&
+          `The URL "${url}" and hash "${hash}" do not match the expected properties for type "${type}".`
+      ).toHaveText(type, { timeout: 60_000, ignoreCase: true });
       await expect(page.getByText("Learn more")).toBeVisible();
       await expect(page.getByTestId("external-modal-button")).toBeVisible();
     });

--- a/tests/govtool-frontend/playwright/tests/9-outcomes/outcomes.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/9-outcomes/outcomes.spec.ts
@@ -435,8 +435,16 @@ test.describe("Invalid Outcome Metadata", () => {
       const outcomePage = new OutComesPage(page);
       await outcomePage.goto();
       await outcomePage.viewFirstOutcomes();
+      const outcomeTitle = await outcomePage.title.textContent();
 
-      await expect(outcomePage.title).toHaveText(type, { timeout: 60_000 });
+      await expect(
+        outcomePage.title,
+        outcomeTitle.toLowerCase() !== type.toLowerCase() &&
+          `The URL "${url}" and hash "${hash}" do not match the expected properties for type "${type}".`
+      ).toHaveText(type, {
+        ignoreCase: true,
+        timeout: 60_000,
+      });
       await expect(outcomePage.metadataErrorLearnMoreBtn).toBeVisible();
     });
   });

--- a/tests/govtool-frontend/playwright/tests/9-outcomes/outcomes.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/9-outcomes/outcomes.spec.ts
@@ -152,7 +152,9 @@ test.describe("Outcome details dependent test", () => {
           const title = await outcomeCard
             .locator('[data-testid$="-card-title"]')
             .textContent();
-          expect(title.toLowerCase()).toContain(governanceActionTitle.toLowerCase());
+          expect(title.toLowerCase()).toContain(
+            governanceActionTitle.toLowerCase()
+          );
         }
       },
       { name: "search by title" }
@@ -434,10 +436,8 @@ test.describe("Invalid Outcome Metadata", () => {
       await outcomePage.goto();
       await outcomePage.viewFirstOutcomes();
 
-      await expect(page.getByRole("heading", { name: type })).toBeVisible({
-        timeout: 60_000,
-      });
-      await expect(page.getByText("Learn more")).toBeVisible();
+      await expect(outcomePage.title).toHaveText(type, { timeout: 60_000 });
+      await expect(outcomePage.metadataErrorLearnMoreBtn).toBeVisible();
     });
   });
 });


### PR DESCRIPTION
## List of changes

- Update testId for governance action / outcome title / learnMore button for invalid metadata
- Add proper message with hash and URL for failure in metadata invalid test

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
