### PR TITLE
fixes layer caching when workflow is manually triggered

### DIFF
--- a/.github/workflows/build-from-main.yml
+++ b/.github/workflows/build-from-main.yml
@@ -243,7 +243,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ github.sha }}-${{ github.run_number}}
           restore-keys: |
             ${{ runner.os }}-buildx-
 


### PR DESCRIPTION
## List of changes

- Fix layer caching when workflow is manually triggered

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ x ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
