### PR TITLE
feat(#2243): add epochParams and ada holder balance to Proposal pillar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ changes.
 ### Added
 
 - Add Proposal discussion context that manages username [Issue 3341](https://github.com/IntersectMBO/govtool/issues/3341)
+- Add epochParams and ada holder balance to Proposal Discussion Pillar [Issue 2243](https://github.com/IntersectMBO/govtool/issues/2243)
 
 ### Fixed
 

--- a/govtool/frontend/src/pages/ProposalDiscussion.tsx
+++ b/govtool/frontend/src/pages/ProposalDiscussion.tsx
@@ -2,6 +2,7 @@ import React, { ComponentProps, Suspense } from "react";
 import { Box, CircularProgress } from "@mui/material";
 import "@intersect.mbo/pdf-ui/style";
 import {
+  useAppContext,
   useCardano,
   useGovernanceActions,
   useProposalDiscussion,
@@ -9,13 +10,18 @@ import {
 import { useValidateMutation } from "@/hooks/mutations";
 import { useScreenDimension } from "@/hooks/useScreenDimension";
 import { Footer, TopNav } from "@/components/organisms";
-import { useGetDRepVotingPowerList, useGetVoterInfo } from "@/hooks";
+import {
+  useGetAdaHolderVotingPowerQuery,
+  useGetDRepVotingPowerList,
+  useGetVoterInfo,
+} from "@/hooks";
 
 const ProposalDiscussion = React.lazy(
   () => import("@intersect.mbo/pdf-ui/cjs"),
 );
 
 export const ProposalDiscussionPillar = () => {
+  const { epochParams } = useAppContext();
   const { pagePadding } = useScreenDimension();
   const { validateMetadata } = useValidateMutation();
   const { walletApi, ...context } = useCardano();
@@ -23,6 +29,7 @@ export const ProposalDiscussionPillar = () => {
   const { createGovernanceActionJsonLD, createHash } = useGovernanceActions();
   const { fetchDRepVotingPowerList } = useGetDRepVotingPowerList();
   const { username, setUsername } = useProposalDiscussion();
+  const { votingPower } = useGetAdaHolderVotingPowerQuery(context.stakeKey);
 
   return (
     <Box
@@ -74,6 +81,8 @@ export const ProposalDiscussionPillar = () => {
             fetchDRepVotingPowerList={fetchDRepVotingPowerList}
             username={username}
             setUsername={setUsername}
+            epochParams={epochParams}
+            votingPower={votingPower}
           />
         </Suspense>
       </Box>

--- a/govtool/frontend/src/types/@intersect.mbo.d.ts
+++ b/govtool/frontend/src/types/@intersect.mbo.d.ts
@@ -4,41 +4,44 @@ enum MetadataValidationStatus {
   INVALID_HASH = "INVALID_HASH",
   INCORRECT_FORMAT = "INCORRECT_FORMAT",
 }
-
-type ProposalDiscussionProps = {
-  pdfApiUrl: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  walletAPI: any;
-  pathname: string;
-  locale?: string;
-  validateMetadata: ({
-    url,
-    hash,
-    standard,
-  }: {
-    url: string;
-    hash: string;
-    standard: "CIP108";
-  }) => Promise<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    | { status?: MetadataValidationStatus; metadata?: any; valid: boolean }
-    | undefined
-  >;
-  fetchDRepVotingPowerList: (
-    identifiers: string[],
-  ) => Promise<DRepVotingPowerListResponse>;
-  username: string;
-  setUsername: (username: string) => void;
-};
-
-type GovernanceActionsOutcomesProps = {
-  apiUrl?: string;
-  ipfsGateway?: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  walletAPI?: any;
-};
-
 declare module "@intersect.mbo/pdf-ui/cjs" {
+  import { EpochParams } from "@/models";
+
+  type ProposalDiscussionProps = {
+    pdfApiUrl: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    walletAPI: any;
+    pathname: string;
+    locale?: string;
+    validateMetadata: ({
+      url,
+      hash,
+      standard,
+    }: {
+      url: string;
+      hash: string;
+      standard: "CIP108";
+    }) => Promise<
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      | { status?: MetadataValidationStatus; metadata?: any; valid: boolean }
+      | undefined
+    >;
+    fetchDRepVotingPowerList: (
+      identifiers: string[],
+    ) => Promise<DRepVotingPowerListResponse>;
+    epochParams?: EpochParams;
+    votingPower: number;
+    username: string;
+    setUsername: (username: string) => void;
+  };
+
+  type GovernanceActionsOutcomesProps = {
+    apiUrl?: string;
+    ipfsGateway?: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    walletAPI?: any;
+  };
+
   export default function ProposalDiscussion(
     props: ProposalDiscussionProps,
   ): JSX.Element;


### PR DESCRIPTION
## List of changes

- add epochParams and ada holder balance to Proposal pillar

New properties passed to PDF:
```tsx
          <ProposalDiscussion
            pdfApiUrl={import.meta.env.VITE_PDF_API_URL}
            walletAPI={{
              ...context,
              ...walletApi,
              createGovernanceActionJsonLD,
              createHash,
              voter,
            }}
            pathname={window.location.pathname}
            validateMetadata={
              validateMetadata as ComponentProps<
                typeof ProposalDiscussion
              >["validateMetadata"]
            }
            fetchDRepVotingPowerList={fetchDRepVotingPowerList}
            // New properties passed
            epochParams={epochParams}
            votingPower={votingPower}
          />
```

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2243)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
