### PR TITLE
hotfix: Parse metadata validation metadata when is missing in db-sync

### DIFF
--- a/govtool/frontend/src/components/organisms/DashboardGovernanceActionDetails.tsx
+++ b/govtool/frontend/src/components/organisms/DashboardGovernanceActionDetails.tsx
@@ -49,7 +49,9 @@ export const DashboardGovernanceActionDetails = () => {
     fullProposalId ?? "",
     !state?.proposal || !state?.vote,
   );
-  const proposal = (data ?? state)?.proposal;
+  const [extendedProposal, setExtendedProposal] = useState<ProposalData>(
+    (data ?? state)?.proposal as ProposalData,
+  );
   const vote = (data ?? state)?.vote;
 
   const [isValidating, setIsValidating] = useState(false);
@@ -60,11 +62,21 @@ export const DashboardGovernanceActionDetails = () => {
     const validate = async () => {
       setIsValidating(true);
 
-      const { status } = await validateMetadata({
+      const { status, metadata } = await validateMetadata({
         standard: MetadataStandard.CIP108,
-        url: proposal?.url ?? "",
-        hash: proposal?.metadataHash ?? "",
+        url: extendedProposal?.url ?? "",
+        hash: extendedProposal?.metadataHash ?? "",
       });
+
+      if (metadata) {
+        setExtendedProposal((prevProposal) => ({
+          ...(prevProposal || {}),
+          ...(metadata as Pick<
+            ProposalData,
+            "title" | "abstract" | "motivation" | "rationale"
+          >),
+        }));
+      }
 
       metadataStatus.current = status;
       setIsValidating(false);
@@ -95,7 +107,7 @@ export const DashboardGovernanceActionDetails = () => {
       <Breadcrumbs
         elementOne={t("govActions.title")}
         elementOnePath={PATHS.dashboardGovernanceActions}
-        elementTwo={proposal?.title ?? ""}
+        elementTwo={extendedProposal?.title ?? ""}
         isDataMissing={metadataStatus?.current ?? null}
       />
       <Link
@@ -141,9 +153,9 @@ export const DashboardGovernanceActionDetails = () => {
           >
             <CircularProgress />
           </Box>
-        ) : proposal ? (
+        ) : extendedProposal ? (
           <GovernanceActionDetailsCard
-            proposal={proposal}
+            proposal={extendedProposal}
             vote={vote}
             isVoter={
               voter?.isRegisteredAsDRep || voter?.isRegisteredAsSoleVoter

--- a/govtool/frontend/src/components/organisms/ValidatedGovernanceActionCard.tsx
+++ b/govtool/frontend/src/components/organisms/ValidatedGovernanceActionCard.tsx
@@ -17,36 +17,47 @@ type ActionTypeProps = Omit<
   onClick?: () => void;
   inProgress?: boolean;
 };
-export const ValidatedGovernanceActionCard = ({
-  url,
-  metadataHash,
-  ...props
-}: ActionTypeProps) => {
+export const ValidatedGovernanceActionCard = (props: ActionTypeProps) => {
   const [isValidating, setIsValidating] = useState(false);
   const metadataStatus = useRef<MetadataValidationStatus | undefined>();
   const { validateMetadata } = useValidateMutation();
+  const [extendedProposal, setExtendedProposal] = useState<ProposalData>(
+    props as ProposalData,
+  );
 
   useEffect(() => {
     const validate = async () => {
       setIsValidating(true);
 
-      const { status } = await validateMetadata({
+      const { status, metadata } = await validateMetadata({
         standard: MetadataStandard.CIP108,
-        url: url ?? "",
-        hash: metadataHash ?? "",
+        url: props?.url ?? "",
+        hash: props?.metadataHash ?? "",
       });
 
       metadataStatus.current = status;
+
+      if (metadata) {
+        setExtendedProposal(
+          (prevProposal) =>
+            ({
+              ...(prevProposal || {}),
+              ...(metadata as Pick<
+                ProposalData,
+                "title" | "abstract" | "motivation" | "rationale"
+              >),
+            } as ProposalData),
+        );
+      }
+
       setIsValidating(false);
     };
     validate();
-  }, []);
+  }, [props?.url, props?.metadataHash]);
 
   return (
     <GovernanceActionCard
-      {...props}
-      url={url}
-      metadataHash={metadataHash}
+      {...extendedProposal}
       isValidating={isValidating}
       metadataStatus={metadataStatus.current}
     />

--- a/govtool/frontend/src/components/organisms/ValidatedGovernanceVotedOnCard.tsx
+++ b/govtool/frontend/src/components/organisms/ValidatedGovernanceVotedOnCard.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 
 import { useValidateMutation } from "@/hooks/mutations";
-import { MetadataStandard, VotedProposal } from "@/models";
+import { MetadataStandard, ProposalData, VotedProposal } from "@/models";
 import { GovernanceVotedOnCard } from "../molecules";
 
 type Props = {
@@ -15,18 +15,33 @@ export const ValidatedGovernanceVotedOnCard = ({
   const [isValidating, setIsValidating] = useState(false);
   const metadataStatus = useRef<MetadataValidationStatus | undefined>();
   const { validateMetadata } = useValidateMutation();
+  const [extendedVotedProposal, setExtendedVotedProposal] =
+    useState<VotedProposal>(votedProposal);
 
   useEffect(() => {
     const validate = async () => {
       setIsValidating(true);
 
-      const { status } = await validateMetadata({
+      const { status, metadata } = await validateMetadata({
         standard: MetadataStandard.CIP108,
         url: votedProposal.proposal.url,
         hash: votedProposal.proposal.metadataHash,
       });
 
       metadataStatus.current = status;
+
+      if (metadata) {
+        setExtendedVotedProposal((prevProposal) => ({
+          ...(prevProposal || {}),
+          proposal: {
+            ...(prevProposal.proposal || {}),
+            ...(metadata as Pick<
+              ProposalData,
+              "title" | "abstract" | "motivation" | "rationale"
+            >),
+          },
+        }));
+      }
       setIsValidating(false);
     };
     validate();
@@ -34,7 +49,7 @@ export const ValidatedGovernanceVotedOnCard = ({
 
   return (
     <GovernanceVotedOnCard
-      votedProposal={votedProposal}
+      votedProposal={extendedVotedProposal}
       inProgress={inProgress}
       isValidating={isValidating}
       metadataStatus={metadataStatus.current}

--- a/govtool/metadata-validation/src/app.service.ts
+++ b/govtool/metadata-validation/src/app.service.ts
@@ -7,7 +7,7 @@ import * as jsonld from 'jsonld';
 import { ValidateMetadataDTO } from '@dto';
 import { LoggerMessage, MetadataValidationStatus } from '@enums';
 import { validateMetadataStandard, parseMetadata, getStandard } from '@utils';
-import { MetadataStandard, ValidateMetadataResult } from '@types';
+import { /* MetadataStandard, */ ValidateMetadataResult } from '@types';
 
 @Injectable()
 export class AppService {
@@ -57,12 +57,13 @@ export class AppService {
         throw MetadataValidationStatus.INCORRECT_FORMAT;
       }
 
-      if (
-        standard === MetadataStandard.CIP108 &&
-        !Array.isArray(parsedData.authors)
-      ) {
-        throw MetadataValidationStatus.INCORRECT_FORMAT;
-      }
+      // TODO: Uncomment this when gov action: 7f320409d9998712ff3a3cdf0c9439e1543f236a3d746766f78f1fdbe1e06bf8#0 expires
+      // if (
+      //   standard === MetadataStandard.CIP108 &&
+      //   !Array.isArray(parsedData.authors)
+      // ) {
+      //   throw MetadataValidationStatus.INCORRECT_FORMAT;
+      // }
 
       if (!parsedData?.body) {
         throw MetadataValidationStatus.INCORRECT_FORMAT;


### PR DESCRIPTION
# THIS PR IS TO BE REVERTED

Once gov action: `gov_action10ueqgzwenxr39le68n0se9peu92r7gm2846xwehh3u0ahc0qd0uqqyljxu5` expires we need to revert this PR as it provides workaround that is against the CIP-108 standard