### PR TITLE
Fix network metrics type and add test for network total stakes and info

### DIFF
--- a/tests/govtool-backend/lib/govtool_api.py
+++ b/tests/govtool-backend/lib/govtool_api.py
@@ -92,6 +92,12 @@ class GovToolApi:
 
     def network_metrics(self) -> Response:
         return self.__get("/network/metrics")
+    
+    def network_total_stake(self) -> Response:
+        return self.__get("/network/total-stake")
+    
+    def network_info(self) -> Response:
+        return self.__get("/network/info")
 
     def get_transaction_status(self, tx_id) -> Response:
         return self.__get("/transaction/status", tx_id)

--- a/tests/govtool-backend/models/TestData.py
+++ b/tests/govtool-backend/models/TestData.py
@@ -128,13 +128,16 @@ class TxStatus(TypedDict):
 
 
 class NetworkMetrics(TypedDict):
-    currentTime: str
-    currentEpoch: int
-    currentBlock: int
     uniqueDelegators: int
     totalDelegations: int
     totalGovernanceActions: int
     totalDRepVotes: int
     totalRegisteredDReps: int
-    alwaysAbstainVotingPower: int
-    alwaysNoConfidenceVotingPower: int
+    totalDRepDistr: int
+    totalActiveDReps: int
+    totalInactiveDReps: int
+    totalActiveCIP119CompliantDReps: int
+    totalRegisteredDirectVoters: int
+    noOfCommitteeMembers: int
+    quorumNumerator: int
+    quorumDenominator: int

--- a/tests/govtool-backend/models/TestData.py
+++ b/tests/govtool-backend/models/TestData.py
@@ -141,3 +141,15 @@ class NetworkMetrics(TypedDict):
     noOfCommitteeMembers: int
     quorumNumerator: int
     quorumDenominator: int
+
+class NetworkTotalStake(TypedDict):
+    totalStakeControlledByDReps: int
+    totalStakeControlledBySPOs: int
+    alwaysAbstainVotingPower: int
+    alwaysNoConfidenceVotingPower: int
+
+class NetworkInfo(TypedDict):
+    currentTime: str
+    epochNo: int
+    blockNo: int
+    networkName: str

--- a/tests/govtool-backend/test_cases/test_misc.py
+++ b/tests/govtool-backend/test_cases/test_misc.py
@@ -1,7 +1,7 @@
 import allure
 
 from lib.assertions import assert_data_type
-from models.TestData import EpochParam, NetworkMetrics, TxStatus
+from models.TestData import EpochParam, NetworkInfo, NetworkMetrics, NetworkTotalStake, TxStatus
 
 
 def validate_epoch_param(epoch_param):
@@ -10,6 +10,12 @@ def validate_epoch_param(epoch_param):
 
 def validate_network_metrics(network_metrics):
     assert_data_type(NetworkMetrics, network_metrics)
+    
+def validate_network_total_stake(network_total_stake):
+    assert_data_type(NetworkTotalStake, network_total_stake)
+    
+def validate_network_info(network_info):
+    assert_data_type(NetworkInfo, network_info)
 
 
 @allure.story("Misc")
@@ -22,6 +28,16 @@ def test_get_epoch_param(govtool_api):
 def test_get_network_metrics(govtool_api):
     network_metrics = govtool_api.network_metrics().json()
     validate_network_metrics(network_metrics)
+    
+@allure.story("Misc")
+def test_get_network_total_stake(govtool_api):
+    network_total_stake = govtool_api.network_total_stake().json()
+    validate_network_total_stake(network_total_stake)
+    
+@allure.story("Misc")
+def test_get_network_info(govtool_api):
+    network_info = govtool_api.network_info().json()
+    validate_network_info(network_info)
 
 
 @allure.story("Misc")


### PR DESCRIPTION
## List of changes

- Fix network metrics response type
- Add backend test to check the response type of network total stakes and network info

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
