### PR TITLE
test: add outcome test on loggedIn state

### DIFF
--- a/tests/govtool-frontend/playwright/lib/pages/outcomeDetailsPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/outcomeDetailsPage.ts
@@ -1,7 +1,14 @@
 import environments from "@constants/environments";
 import { formatWithThousandSeparator } from "@helpers/adaFormat";
-import { Page, Response } from "@playwright/test";
-import { outcomeProposal, VoterType } from "@types";
+import { Browser, expect, Page, Response } from "@playwright/test";
+import { outcomeProposal, outcomeType } from "@types";
+import OutComesPage from "./outcomesPage";
+import {
+  areCCVoteTotalsDisplayed,
+  areDRepVoteTotalsDisplayed,
+  areSPOVoteTotalsDisplayed,
+} from "@helpers/featureFlag";
+import { parseVotingPowerAndPercentage } from "@helpers/index";
 
 export default class OutcomeDetailsPage {
   readonly dRepYesVotes = this.page.getByTestId("DReps-yes-votes-submitted");
@@ -80,5 +87,227 @@ export default class OutcomeDetailsPage {
       sPosAutoAbstain,
       sPosNoConfidence,
     };
+  }
+
+  async shouldDisplayCorrectVotingResults(
+    browser: Browser,
+    isLoggedIn = false
+  ) {
+    await Promise.all(
+      Object.keys(outcomeType).map(async (filterKey) => {
+        const outcomePage = new OutComesPage(this.page);
+        const {
+          govActionDetailsPage,
+          metricsResponsePromise,
+          outcomeResponsePromise,
+        } = await outcomePage.navigateToFilteredProposalDetail(
+          browser,
+          filterKey,
+          isLoggedIn
+        );
+
+        const outcomeResponse = await outcomeResponsePromise;
+        const proposalToCheck = (await outcomeResponse.json())[0];
+
+        const metricsResponse = await metricsResponsePromise;
+
+        const { autoAbstain, noConfidence, sPosAutoAbstain, sPosNoConfidence } =
+          await govActionDetailsPage.getSposAndDRepAbstainNoConfidence(
+            metricsResponse
+          );
+
+        const currentPageUrl = govActionDetailsPage.currentPage.url();
+
+        // check dRep votes
+        if (await areDRepVoteTotalsDisplayed(proposalToCheck)) {
+          await govActionDetailsPage.dRepExpandButton.click();
+
+          await expect(
+            govActionDetailsPage.dRepResultData.getByRole("row", {
+              name: "Yes",
+            }),
+            {
+              message: `DRep "Yes" voting power checked for ${currentPageUrl}`,
+            }
+          ).toHaveText(
+            `Yes${formatWithThousandSeparator(proposalToCheck.yes_votes, false)}`,
+            {
+              timeout: 60_000,
+            }
+          ); //BUG missing testIds
+
+          await expect(
+            govActionDetailsPage.dRepResultData.getByRole("row", {
+              name: "Auto-Abstain",
+            }),
+            {
+              message: `DRep "Auto-Abstain" voting power checked for ${currentPageUrl}`,
+            }
+          ).toHaveText(`Auto-Abstain${autoAbstain}`); //BUG missing testIds
+          await expect(
+            govActionDetailsPage.dRepResultData.getByRole("row", {
+              name: "No Confidence",
+            }),
+            {
+              message: `DRep "No Confidence" voting power checked for ${currentPageUrl}`,
+            }
+          ).toHaveText(`No Confidence${noConfidence}`); //BUG missing testIds
+          await expect(
+            govActionDetailsPage.dRepResultData.getByRole("row", {
+              name: "Explicit",
+            }),
+            {
+              message: `DRep "Explicit" voting power checked for ${currentPageUrl}`,
+            }
+          ).toHaveText(
+            `Explicit${formatWithThousandSeparator(proposalToCheck.abstain_votes, false)}`
+          );
+
+          await expect(
+            govActionDetailsPage.dRepResultData
+              .getByRole("row", {
+                name: "No",
+              })
+              .first(),
+            {
+              message: `DRep "No" voting power checked for ${currentPageUrl}`,
+            }
+          ).toHaveText(
+            `No${formatWithThousandSeparator(proposalToCheck.no_votes, false)}`
+          ); //BUG missing testIds
+        }
+
+        // check sPos votes
+        if (await areSPOVoteTotalsDisplayed(proposalToCheck)) {
+          await govActionDetailsPage.sPosExpandButton.click();
+          const totalSposNoVotes =
+            filterKey === "NoConfidence"
+              ? proposalToCheck.pool_no_votes
+              : parseInt(sPosNoConfidence.replace(/,/g, "")) * 1000000 +
+                parseInt(proposalToCheck.pool_no_votes);
+
+          const totalSposYesVotesForNoConfidence =
+            parseInt(sPosNoConfidence.replace(/,/g, "")) * 1000000 +
+            parseInt(proposalToCheck.pool_yes_votes);
+
+          const totalSposYesVotes =
+            filterKey === "NoConfidence"
+              ? totalSposYesVotesForNoConfidence
+              : proposalToCheck.pool_yes_votes;
+          await expect(
+            govActionDetailsPage.sPosResultData.getByRole("row", {
+              name: "Yes",
+            }),
+            {
+              message: `SPos "Yes" voting power checked for ${currentPageUrl}`,
+            }
+          ).toHaveText(
+            `Yes${formatWithThousandSeparator(totalSposYesVotes, false)}`,
+            {
+              timeout: 60_000,
+            }
+          ); //BUG missing testIds
+
+          await expect(
+            govActionDetailsPage.sPosResultData.getByRole("row", {
+              name: "Auto-Abstain",
+            }),
+            {
+              message: `SPos "Auto-Abstain" voting power checked for ${currentPageUrl}`,
+            }
+          ).toHaveText(`Auto-Abstain${sPosAutoAbstain}`); //BUG missing testIds
+          await expect(
+            govActionDetailsPage.sPosResultData.getByRole("row", {
+              name: "No Confidence",
+            }),
+            {
+              message: `SPos "No Confidence" voting power checked for ${currentPageUrl}`,
+            }
+          ).toHaveText(`No Confidence${sPosNoConfidence}`); //BUG missing testIds
+          await expect(
+            govActionDetailsPage.sPosResultData.getByRole("row", {
+              name: "Explicit",
+            }),
+            {
+              message: `SPos "Explicit" voting power checked for ${currentPageUrl}`,
+            }
+          ).toHaveText(
+            `Explicit${formatWithThousandSeparator(proposalToCheck.pool_abstain_votes, false)}`
+          ); //BUG missing testIds
+          await expect(
+            govActionDetailsPage.sPosResultData
+              .getByRole("row", {
+                name: "No",
+              })
+              .first(),
+            {
+              message: `SPos "No" voting power checked for ${currentPageUrl}`,
+            }
+          ).toHaveText(
+            `No${formatWithThousandSeparator(totalSposNoVotes, false)}`
+          ); //BUG missing testIds
+        }
+
+        // check ccCommittee votes
+        if (areCCVoteTotalsDisplayed(proposalToCheck)) {
+          const ccYesVoteSubmittedText =
+            await govActionDetailsPage.ccCommitteeYesVotes.textContent();
+
+          const { percentage: yesPercentage } = parseVotingPowerAndPercentage(
+            ccYesVoteSubmittedText
+          );
+
+          await expect(govActionDetailsPage.ccCommitteeYesVotes, {
+            message: `CC "Yes" vote count checked for ${currentPageUrl}`,
+          }).toHaveText(`${proposalToCheck.cc_yes_votes} - ${yesPercentage}`);
+          await expect(
+            govActionDetailsPage.cCResultData.getByRole("row", {
+              name: "Abstain Votes",
+            }),
+            {
+              message: `CC "Abstain" vote count checked for ${currentPageUrl}`,
+            }
+          ).toHaveText(`Abstain Votes${proposalToCheck.pool_abstain_votes}`); //BUG missing testIds
+
+          const noPercentage = 100 - parseFloat(yesPercentage.replace("%", ""));
+          await expect(govActionDetailsPage.ccCommitteeNoVotes, {
+            message: `CC "No" vote count checked for ${currentPageUrl}`,
+          }).toHaveText(
+            `${proposalToCheck.cc_no_votes} - ${noPercentage.toFixed(2)}%`
+          );
+        }
+      })
+    );
+  }
+
+  async verifyInvalidOutcomeMetadata({
+    outcomeResponse,
+    type,
+    url,
+    hash,
+  }: {
+    outcomeResponse: outcomeProposal;
+    type: string;
+    url: string;
+    hash: string;
+  }) {
+    await this.page.route(/.*\/governance-actions\/[a-f0-9]{64}\?.*/, (route) =>
+      route.fulfill({ body: JSON.stringify([outcomeResponse]) })
+    );
+
+    const outcomePage = new OutComesPage(this.page);
+    await outcomePage.goto();
+    await outcomePage.viewFirstOutcomes();
+    const outcomeTitle = await outcomePage.title.textContent();
+
+    await expect(
+      outcomePage.title,
+      outcomeTitle.toLowerCase() !== type.toLowerCase() &&
+        `The URL "${url}" and hash "${hash}" do not match the expected properties for type "${type}".`
+    ).toHaveText(type, {
+      ignoreCase: true,
+      timeout: 60_000,
+    });
+    await expect(outcomePage.metadataErrorLearnMoreBtn).toBeVisible();
   }
 }

--- a/tests/govtool-frontend/playwright/tests/9-outcomes/outcomes.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/9-outcomes/outcomes.loggedin.spec.ts
@@ -1,4 +1,6 @@
+import { user01AuthFile } from "@constants/auth";
 import { InvalidMetadata } from "@constants/index";
+import { user01Wallet } from "@constants/staticWallets";
 import { test } from "@fixtures/walletExtension";
 import { setAllureEpic } from "@helpers/allure";
 import OutcomeDetailsPage from "@pages/outcomeDetailsPage";
@@ -11,25 +13,29 @@ test.beforeEach(async () => {
   await setAllureEpic("9. Outcomes");
 });
 
+test.use({
+  storageState: user01AuthFile,
+  wallet: user01Wallet,
+});
+
 test.describe("Outcomes page", () => {
   let outcomePage: OutComesPage;
   test.beforeEach(async ({ page }) => {
     outcomePage = new OutComesPage(page);
   });
 
-  test("9A_1. Should access Outcomes page in disconnect state", async () => {
+  test("9A_2. Should access Outcomes page in connected state", async () => {
     await outcomePage.shouldAccessPage();
   });
-
   test.describe("outcome sorting and filtering", () => {
-    test("9C_1A. Should filter Governance Action Type on governance actions page in disconnect state", async () => {
+    test("9C_1B. Should filter Governance Action Type on governance actions page", async () => {
       test.slow();
       await outcomePage.goto();
 
       await outcomePage.filterOutcomes();
     });
 
-    test("9C_2A. Should sort Governance Action Type on outcomes page in disconnect state", async () => {
+    test("9C_2B. Should sort Governance Action Type on outcomes page", async () => {
       test.slow();
 
       await outcomePage.goto({ sort: "oldestFirst" });
@@ -37,18 +43,18 @@ test.describe("Outcomes page", () => {
       await outcomePage.sortOutcomes();
     });
 
-    test("9C_3A. Should filter and sort Governance Action Type on outcomes page in disconnect state", async () => {
+    test("9C_3B. Should filter and sort Governance Action Type on outcomes page", async () => {
       await outcomePage.filterAndSortOutcomes();
     });
   });
 
-  test("9E_1. Should verify all of the displayed governance actions have expired in disconnect state", async () => {
+  test("9E_2. Should verify all of the displayed governance actions have expired", async () => {
     await outcomePage.goto();
 
     await outcomePage.verifyAllOutcomesAreExpired();
   });
 
-  test("9F_1. Should load more Outcomes on show more in disconnect state", async () => {
+  test("9F_2. Should load more Outcomes on show more", async () => {
     await outcomePage.VerifyLoadMoreOutcomes();
   });
 
@@ -66,14 +72,14 @@ test.describe("Outcomes page", () => {
       currentPage = page;
     });
 
-    test("9B_1. Should search outcomes proposal by title and id in disconnect state", async () => {
+    test("9B_2. Should search outcomes proposal by title and id", async () => {
       // search by id
       await outcomePage.searchOutcomesById(governanceActionId);
 
       await outcomePage.searchOutcomesByTitle(governanceActionTitle);
     });
 
-    test("9D_1. Should copy governanceActionId in disconnect state", async ({
+    test("9D_2. Should copy governanceActionId in disconnect state", async ({
       context,
     }) => {
       await context.grantPermissions(["clipboard-read", "clipboard-write"]);
@@ -83,17 +89,18 @@ test.describe("Outcomes page", () => {
 });
 
 test.describe("Outcome details", () => {
-  test("9G_1. Should display correct vote counts on outcome details page in disconnect state", async ({
+  test("9G_2. Should display correct vote counts on outcome details page", async ({
     browser,
     page,
   }) => {
     const outcomeDetailPage = new OutcomeDetailsPage(page);
-    await outcomeDetailPage.shouldDisplayCorrectVotingResults(browser);
+
+    await outcomeDetailPage.shouldDisplayCorrectVotingResults(browser, true);
   });
 
   test.describe("Invalid Outcome Metadata", () => {
     InvalidMetadata.forEach(({ type, reason, url, hash }, index) => {
-      test(`9H_${index + 1}A: Should display "${type}" message in outcomes when ${reason}`, async ({
+      test(`9H_${index + 1}B: Should display "${type}" message in outcomes when ${reason}`, async ({
         page,
       }) => {
         const outcomeResponse = {


### PR DESCRIPTION
## List of changes

- Split out the outcome test on pages
- Add similar test cases for both loggedin and logged out in outcomes
- Fix Spos voting power issue and update the CC vote percentage
- Add proper message for voting power checked by providing the outcome URL on voting power test

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
