### PR TITLE
fix: normalise contracting type comparison to lowercase

### DIFF
--- a/tests/govtool-frontend/playwright/tests/12-proposal-budget-submission/proposalBudgetSubmission.loggedin.pb.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/12-proposal-budget-submission/proposalBudgetSubmission.loggedin.pb.spec.ts
@@ -305,7 +305,7 @@ test.describe("Budget proposal 01 wallet", () => {
           await budgetProposalSubmissionPage.currentPage
             .getByTestId(`${contractingType}-button`)
             .click();
-          if (contractingType === "Other") {
+          if (contractingType === "other") {
             await budgetProposalSubmissionPage.otherDescriptionInput.fill(
               faker.lorem.paragraph(2)
             );


### PR DESCRIPTION
## List of changes

- fix: normalise contracting type comparison to lowercase

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
