### PR TITLE
fix(#3591): remove canonicalization from the governance action metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ changes.
 
 ### Removed
 
+- Remove additional canonicalization of the metadata [Issue 3591](https://github.com/IntersectMBO/govtool/issues/3591)
+
 ## [v2.0.20](https://github.com/IntersectMBO/govtool/releases/tag/v2.0.20) 2025-04-16
 
 ### Added

--- a/govtool/metadata-validation/src/app.service.ts
+++ b/govtool/metadata-validation/src/app.service.ts
@@ -2,7 +2,6 @@ import { Injectable, Logger } from '@nestjs/common';
 import { catchError, finalize, firstValueFrom } from 'rxjs';
 import { HttpService } from '@nestjs/axios';
 import * as blake from 'blakejs';
-import * as jsonld from 'jsonld';
 
 import { ValidateMetadataDTO } from '@dto';
 import { LoggerMessage, MetadataValidationStatus } from '@enums';
@@ -81,29 +80,7 @@ export class AppService {
       const hashedMetadata = blake.blake2bHex(rawData, undefined, 32);
 
       if (hashedMetadata !== hash) {
-        // Optionally validate on a parsed metadata
-        const hashedParsedMetadata = blake.blake2bHex(
-          JSON.stringify(parsedData, null, 2),
-          undefined,
-          32,
-        );
-        if (hashedParsedMetadata !== hash) {
-          // Optional support for the canonized data hash
-          // Validate canonized data hash
-          const canonizedMetadata = await jsonld.canonize(JSON.parse(rawData), {
-            safe: false,
-          });
-
-          const hashedCanonizedMetadata = blake.blake2bHex(
-            canonizedMetadata,
-            undefined,
-            32,
-          );
-
-          if (hashedCanonizedMetadata !== hash) {
-            throw MetadataValidationStatus.INVALID_HASH;
-          }
-        }
+        throw MetadataValidationStatus.INVALID_HASH;
       }
     } catch (error) {
       Logger.error(LoggerMessage.METADATA_VALIDATION_ERROR, error);


### PR DESCRIPTION
## List of changes

- Remvoe optional support for the original CIP-108 standard where the canonicalization were required

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3591)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
