### PR TITLE
fix: wrong metadata status background on voted on card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ changes.
 
 ### Fixed
 
+- Fix invalid metadata status background on voted on card
+
 ### Changed
 
 ### Removed

--- a/govtool/frontend/src/components/molecules/GovernanceVotedOnCard.tsx
+++ b/govtool/frontend/src/components/molecules/GovernanceVotedOnCard.tsx
@@ -56,6 +56,10 @@ export const GovernanceVotedOnCard = ({
     bech32Prefix: "gov_action",
   });
 
+  // When no status provided into the metadataStatus prop,
+  // we consider it as a valid
+  const isMetadataValid = metadataStatus === undefined;
+
   return (
     <Box
       sx={{
@@ -67,13 +71,13 @@ export const GovernanceVotedOnCard = ({
         justifyContent: "space-between",
         boxShadow: "0px 4px 15px 0px #DDE3F5",
         borderRadius: "20px",
-        backgroundColor: !metadataStatus
+        backgroundColor: !isMetadataValid
           ? "rgba(251, 235, 235, 0.50)"
           : "rgba(255, 255, 255, 0.3)",
         // TODO: To decide if voted on cards can be actually in progress
         border: inProgress
           ? "1px solid #FFCBAD"
-          : !metadataStatus
+          : !isMetadataValid
           ? "1px solid #F6D5D5"
           : "1px solid #C0E4BA",
       }}


### PR DESCRIPTION
## List of changes

-  wrong metadata status background on voted on card

## Checklist

- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
