### PR TITLE
feat: add script to remove oldest report  from govtool-test-reports repository

### DIFF
--- a/.github/scripts/remove_oldest_report.sh
+++ b/.github/scripts/remove_oldest_report.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ -d "gh-pages/$REPORT_NAME" ]; then
+    cd gh-pages/$REPORT_NAME
+    # Find the oldest numerical directory
+    oldest_dir=$(find . -maxdepth 1 -type d -regex './[0-9]+' | sort -n | head -1)
+    if [ -n "$oldest_dir" ]; then
+        echo "Removing oldest report directory: $oldest_dir"
+        rm -rf "$oldest_dir"
+    else
+        echo "No report directories found to remove"
+    fi
+    cd ../../
+else
+    echo "Report directory does not exist yet"
+fi

--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -115,6 +115,12 @@ jobs:
           path: gh-pages
           repository: ${{vars.GH_PAGES}}
           ssh-key: ${{ secrets.DEPLOY_KEY }}
+        
+      - name: Remove oldest report to save space
+        if: ${{success()}}
+        run: |
+          chmod +x .github/scripts/remove_oldest_report.sh
+            .github/scripts/remove_oldest_report.sh
 
       - name: Register report
         id: register-project

--- a/.github/workflows/test_integration_playwright.yml
+++ b/.github/workflows/test_integration_playwright.yml
@@ -33,7 +33,7 @@ on:
   workflow_run:
     workflows: ["Build and deploy GovTool test stack"]
     types: [completed]
-    branches: 
+    branches:
       - test
       - infra/test-chores
 
@@ -153,12 +153,19 @@ jobs:
           repository: ${{vars.GH_PAGES}}
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
+      - name: Remove oldest report to save space
+        if: ${{success()}}
+        run: |
+          chmod +x .github/scripts/remove_oldest_report.sh
+           .github/scripts/remove_oldest_report.sh
+
       - name: Register report
         id: register-project
         if: ${{success()}}
         run: |
           chmod +x .github/scripts/register_report.sh
           .github/scripts/register_report.sh
+          
       - if: steps.register-project.outputs.project_exists != 'true'
         uses: JamesIves/github-pages-deploy-action@v4
         with:


### PR DESCRIPTION
## List of changes

- Add script to remove oldest report from govtool-test-reports repository to save space

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
