### PR TITLE
fix(#3615): add scroll to markdown tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ changes.
 
 - Fix app crash on unhandled wallet error [Issue 3123](https://github.com/IntersectMBO/govtool/issues/3123)
 - Preserve new lines in markdown text [Issue 2712](https://github.com/IntersectMBO/govtool/issues/2712)
+- Add scroll to markdown tables [Issue 3615](https://github.com/IntersectMBO/govtool/issues/3615)
 
 ### Changed
 

--- a/govtool/frontend/src/components/molecules/tableMarkdown.css
+++ b/govtool/frontend/src/components/molecules/tableMarkdown.css
@@ -1,7 +1,10 @@
 table {
+  display: block;
+  overflow-x: auto;
   margin: 32px 0;
   border-spacing: 0;
   border-collapse: collapse;
+  max-width: 100%;
 }
 
 table thead {


### PR DESCRIPTION
## List of changes

- add scroll to markdown tables

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3615)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
