### PR TITLE
fix(#3615): wrap the markdown table styles around markdown class

### DIFF
--- a/govtool/frontend/src/components/molecules/GovernanceActionCardElement.tsx
+++ b/govtool/frontend/src/components/molecules/GovernanceActionCardElement.tsx
@@ -147,6 +147,7 @@ export const GovernanceActionCardElement = ({
 
     return (
       <Markdown
+        className="markdown"
         components={markdownComponents}
         remarkPlugins={[remarkMath, remarkGfm]}
         rehypePlugins={[rehypeKatex]}

--- a/govtool/frontend/src/components/molecules/tableMarkdown.css
+++ b/govtool/frontend/src/components/molecules/tableMarkdown.css
@@ -1,26 +1,28 @@
-table {
-  display: block;
-  overflow-x: auto;
-  margin: 32px 0;
-  border-spacing: 0;
-  border-collapse: collapse;
-  max-width: 100%;
-}
+.markdown {
+  & table {
+    display: block;
+    overflow-x: auto;
+    margin: 32px 0;
+    border-spacing: 0;
+    border-collapse: collapse;
+    max-width: 100%;
 
-table thead {
-  background-color: #d6e2ff80;
-}
+    & thead {
+      background-color: #d6e2ff80;
+    }
 
-table th,
-table td {
-  padding: 6px 13px;
-  border: 1px solid #d6e2ff;
-}
+    & th,
+    & td {
+      padding: 6px 13px;
+      border: 1px solid #d6e2ff;
+    }
 
-table td > :last-child {
-  margin-bottom: 0;
-}
+    & td > :last-child {
+      margin-bottom: 0;
+    }
 
-table tr:nth-child(2n) {
-  background-color: #d6e2ff80;
+    & tr:nth-child(2n) {
+      background-color: #d6e2ff80;
+    }
+  }
 }


### PR DESCRIPTION
## List of changes

- wrap the markdown table styles around markdown class

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3615)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
