### PR TITLE
chore: add outcomes and pdf-ui version tags to sentry

### DIFF
--- a/govtool/frontend/src/components/organisms/RegisterAsDRepSteps/WhatRetirementMeans.tsx
+++ b/govtool/frontend/src/components/organisms/RegisterAsDRepSteps/WhatRetirementMeans.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import * as Sentry from "@sentry/react";
 
 import { Typography } from "@atoms";
@@ -34,10 +34,6 @@ export const WhatRetirementMeans = ({
     onClickCancel();
     closeModal();
   };
-
-  useEffect(() => {
-    Sentry.setTag("component_name", "WhatRetirementMeans");
-  }, []);
 
   const retireAsDrep = useCallback(async () => {
     try {

--- a/govtool/frontend/src/context/appContext.tsx
+++ b/govtool/frontend/src/context/appContext.tsx
@@ -39,9 +39,6 @@ const AppContext = createContext<AppContextType | null>(null);
  * @param children - The child components to render.
  */
 const AppContextProvider = ({ children }: PropsWithChildren) => {
-  useEffect(() => {
-    Sentry.setTag("component_name", "AppContextProvider");
-  }, []);
   const { fetchEpochParams, epochParams } = useGetEpochParams();
   const { fetchNetworkInfo, networkInfo } = useGetNetworkInfo();
 

--- a/govtool/frontend/src/context/governanceAction.tsx
+++ b/govtool/frontend/src/context/governanceAction.tsx
@@ -4,7 +4,6 @@ import {
   createContext,
   useContext,
   useCallback,
-  useEffect,
 } from "react";
 import { NodeObject } from "jsonld";
 import { blake2bHex } from "blakejs";
@@ -42,10 +41,6 @@ const GovernanceActionProvider = ({ children }: PropsWithChildren) => {
    * @param {GovActionMetadata} govActionMetadata - The metadata of the governance action.
    * @returns The JSON-LD representation of the governance action.
    */
-
-  useEffect(() => {
-    Sentry.setTag("component_name", "GovernanceActionProvider");
-  }, []);
 
   const createGovernanceActionJsonLD = useCallback(
     async (govActionMetadata: GovActionMetadata) => {

--- a/govtool/frontend/src/main.tsx
+++ b/govtool/frontend/src/main.tsx
@@ -54,6 +54,12 @@ Sentry.init({
   },
 });
 
+Sentry.setTag("pdf_ui_version", pkg.dependencies["@intersect.mbo/pdf-ui"]);
+Sentry.setTag(
+  "govtool_outcomes_pillar_ui_version",
+  pkg.dependencies["@intersect.mbo/govtool-outcomes-pillar-ui"],
+);
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## List of changes

- Add outcomes and pdf-ui version tags to sentry

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/1613)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
