### PR TITLE
feat(#3619): CIP-129 support for gov_actions hashes in Live Voting (governance actions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ changes.
 ## [Unreleased]
 
 ### Added
+- Add CIP-129 support for gov_actions hashes in Live Voting (governance actions) [Issue 3619](https://github.com/IntersectMBO/govtool/issues/3619)
 
 ### Fixed
 

--- a/govtool/backend/.gitignore
+++ b/govtool/backend/.gitignore
@@ -1,3 +1,6 @@
 # other
 .vscode
 dev-config.json
+
+# Tool version management file (e.g., asdf version manager)
+.tool-versions

--- a/govtool/frontend/.gitignore
+++ b/govtool/frontend/.gitignore
@@ -7,3 +7,6 @@
 /yarn-error.log
 .env
 coverage
+
+# Tool version management file (e.g., asdf version manager)
+.tool-versions

--- a/govtool/frontend/src/components/organisms/DashboardGovernanceActionDetails.tsx
+++ b/govtool/frontend/src/components/organisms/DashboardGovernanceActionDetails.tsx
@@ -99,8 +99,8 @@ export const DashboardGovernanceActionDetails = () => {
 
   useEffect(() => {
     const isProposalNotFound =
-      (error as AxiosError)?.response?.data ===
-      `Proposal with id: ${fullProposalId} not found`;
+      error instanceof AxiosError &&
+      error.response?.data.match(/Proposal with id: .* not found/);
     if (isProposalNotFound && fullProposalId) {
       navigate(
         OUTCOMES_PATHS.governanceActionOutcomes.replace(":id", fullProposalId),

--- a/govtool/frontend/src/pages/GovernanceActionDetails.tsx
+++ b/govtool/frontend/src/pages/GovernanceActionDetails.tsx
@@ -94,8 +94,8 @@ export const GovernanceActionDetails = () => {
 
   useEffect(() => {
     const isProposalNotFound =
-      (error as AxiosError)?.response?.data ===
-      `Proposal with id: ${fullProposalId} not found`;
+      error instanceof AxiosError &&
+      error.response?.data.match(/Proposal with id: .* not found/);
     if (isProposalNotFound && fullProposalId) {
       navigate(
         OUTCOMES_PATHS.governanceActionOutcomes.replace(":id", fullProposalId),

--- a/govtool/frontend/src/services/requests/getProposal.ts
+++ b/govtool/frontend/src/services/requests/getProposal.ts
@@ -7,10 +7,10 @@ export const getProposal = async (
   proposalId: string,
   drepId?: string,
 ): Promise<VotedProposal> => {
-  const isCIP129Identifier = proposalId.includes("gov_action");
+  const isCIP129Identifier = proposalId.startsWith("gov_action");
   if (isCIP129Identifier) {
-    const { txID } = decodeCIP129Identifier(proposalId);
-    proposalId = txID;
+    const { txID, index } = decodeCIP129Identifier(proposalId);
+    proposalId = `${txID}#${parseInt(index, 16)}`;
   }
 
   const encodedHash = encodeURIComponent(proposalId);

--- a/govtool/frontend/src/utils/getGovActionId.ts
+++ b/govtool/frontend/src/utils/getGovActionId.ts
@@ -9,8 +9,10 @@ export const getShortenedGovActionId = (
   const firstPart = txHash.slice(0, 4);
   const lastPart = txHash.slice(-4);
 
-  return `${firstPart}...${lastPart}#${index}`;
+  return txHash.startsWith("gov_action")
+    ? `${firstPart}...${lastPart}`
+    : `${firstPart}...${lastPart}#${index}`;
 };
 
 export const getFullGovActionId = (txHash: string, index: number | string) =>
-  `${txHash}#${index}`;
+  (txHash.startsWith("gov_action") ? txHash : `${txHash}#${index}`);

--- a/govtool/frontend/src/utils/tests/getGovActionId.test.ts
+++ b/govtool/frontend/src/utils/tests/getGovActionId.test.ts
@@ -28,6 +28,13 @@ describe("getShortenedGovActionId", () => {
     const result = getShortenedGovActionId(txHash, index);
     expect(result).toBe("#1");
   });
+
+  it("should handle a hash starting with 'gov_action' correctly", () => {
+    const txHash = "gov_action_1234567890abcdef";
+    const index = 7;
+    const result = getShortenedGovActionId(txHash, index);
+    expect(result).toBe("gov_...cdef");
+  });
 });
 
 describe("getFullGovActionId", () => {
@@ -36,5 +43,12 @@ describe("getFullGovActionId", () => {
     const index = 10;
     const result = getFullGovActionId(txHash, index);
     expect(result).toBe("1234567890abcdef1234567890abcdef#10");
+  });
+
+  it("should return the full id without index if txHash starts with 'gov_action'", () => {
+    const txHash = "gov_action_1234567890abcdef";
+    const index = 5;
+    const result = getFullGovActionId(txHash, index);
+    expect(result).toBe("gov_action_1234567890abcdef");
   });
 });

--- a/govtool/metadata-validation/.gitignore
+++ b/govtool/metadata-validation/.gitignore
@@ -54,3 +54,6 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Tool version management file (e.g., asdf version manager)
+.tool-versions


### PR DESCRIPTION
## List of changes

- Add CIP-129 support for gov_actions hashes in Live Voting (governance actions)

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3619)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [x] I have added tests that prove my fix is effective or that my feature works
