### PR TITLE
Added Sentiment Feedback Option to Feedback Modal

### DIFF
--- a/govtool/frontend/src/context/usersnapContext.tsx
+++ b/govtool/frontend/src/context/usersnapContext.tsx
@@ -6,6 +6,7 @@ import React, {
   useMemo,
 } from "react";
 import { InitOptions, WidgetApi, loadSpace } from "@usersnap/browser";
+import { useTranslation } from "react-i18next";
 
 type WidgetValues = {
   assignee?: string;
@@ -65,6 +66,7 @@ export const UsersnapProvider = ({
   children,
 }: UsersnapProviderProps) => {
   const [usersnapApi, setUsersnapApi] = useState<UsersnapAPI | null>(null);
+  const { t } = useTranslation();
 
   const openFeedbackWindow = useCallback(() => {
     if (usersnapApi) {
@@ -82,31 +84,31 @@ export const UsersnapProvider = ({
             customFields: {
               sentiment_score: {
                 type: 'rating',
-                label: 'How would you rate your experience?',
+                label: t("feedback.sentimentScore"),
                 required: true,
                 options: [1, 2, 3, 4, 5]
               },
               additional_notes: {
                 type: 'textarea',
-                label: 'Additional Notes',
+                label: t("feedback.additionalNotes"),
                 required: false
               }
             },
             feedbackTypes: [
               {
                 id: 'bug',
-                label: 'Report a Bug',
-                description: 'Something is not working as expected'
+                label: t("feedback.reportBug"),
+                description: t("feedback.reportBugDescription")
               },
               {
                 id: 'idea',
-                label: 'Suggest a New Idea',
-                description: 'Share your ideas for improvement'
+                label: t("feedback.suggestIdea"),
+                description: t("feedback.suggestIdeaDescription")
               },
               {
                 id: 'sentiment',
-                label: 'Share Your Experience',
-                description: 'Rate your experience and provide feedback'
+                label: t("feedback.sentimentFeedback"),
+                description: t("feedback.sentimentFeedbackDescription")
               }
             ]
           });
@@ -117,7 +119,7 @@ export const UsersnapProvider = ({
       }
     };
     initUsersnapSpace();
-  }, [initParams, API_KEY]);
+  }, [initParams, API_KEY, t]);
 
   const value = useMemo(() => ({ openFeedbackWindow }), [openFeedbackWindow]);
 

--- a/govtool/frontend/src/context/usersnapContext.tsx
+++ b/govtool/frontend/src/context/usersnapContext.tsx
@@ -77,7 +77,39 @@ export const UsersnapProvider = ({
       if (API_KEY) {
         try {
           const api = await loadSpace(API_KEY);
-          api.init(initParams);
+          api.init({
+            ...initParams,
+            customFields: {
+              sentiment_score: {
+                type: 'rating',
+                label: 'How would you rate your experience?',
+                required: true,
+                options: [1, 2, 3, 4, 5]
+              },
+              additional_notes: {
+                type: 'textarea',
+                label: 'Additional Notes',
+                required: false
+              }
+            },
+            feedbackTypes: [
+              {
+                id: 'bug',
+                label: 'Report a Bug',
+                description: 'Something is not working as expected'
+              },
+              {
+                id: 'idea',
+                label: 'Suggest a New Idea',
+                description: 'Share your ideas for improvement'
+              },
+              {
+                id: 'sentiment',
+                label: 'Share Your Experience',
+                description: 'Rate your experience and provide feedback'
+              }
+            ]
+          });
           setUsersnapApi(api);
         } catch (error) {
           console.error(error);

--- a/govtool/frontend/src/i18n/locales/en.json
+++ b/govtool/frontend/src/i18n/locales/en.json
@@ -844,10 +844,13 @@
     "title": "Feedback",
     "reportBug": "Report a Bug",
     "suggestIdea": "Suggest a New Idea",
-    "sentimentFeedback": "Share Your Experience",
+    "sentimentFeedback": "Sentiment Feedback",
     "sentimentScore": "How would you rate your experience?",
     "additionalNotes": "Additional Notes",
-    "submit": "Submit Feedback"
+    "submit": "Submit Feedback",
+    "reportBugDescription": "Something is not working as expected",
+    "suggestIdeaDescription": "Share your ideas for improvement",
+    "sentimentFeedbackDescription": "Rate your experience and provide feedback"
   },
   "filter": "Filter",
   "goBack": "Go back",

--- a/govtool/frontend/src/i18n/locales/en.json
+++ b/govtool/frontend/src/i18n/locales/en.json
@@ -109,8 +109,8 @@
         "noDelegationDescription": "Find a DRep to vote on your behalf.",
         "noDelegationActionButton": "View DRep Directory",
         "dRepDelegationTitle": "Your Voting Power of <strong>₳{{ada}}</strong>\nis Delegated to:",
-        "noConfidenceDelegationTitle": "You have delegated your Voting Power <strong>₳{{ada}}</strong>\nto “No Confidence”",
-        "abstainDelegationTitle": "You have delegated your Voting Power <strong>₳{{ada}}</strong>\nto “Abstain”",
+        "noConfidenceDelegationTitle": "You have delegated your Voting Power <strong>₳{{ada}}</strong>\nto \"No Confidence\"",
+        "abstainDelegationTitle": "You have delegated your Voting Power <strong>₳{{ada}}</strong>\nto \"Abstain\"",
         "abstainDescription": "You have selected to apply your Voting Power to Abstain on every vote.",
         "noDescription": "You have selected to apply your Voting Power to No Confidence on every vote.",
         "inProgress": {
@@ -268,8 +268,8 @@
     "abstainCardDefaultTitle": "Abstain from Every Vote",
     "automatedVotingOptions": "Automated Voting Options",
     "editBtn": "Edit DRep data",
-    "delegatedToAbstainTitle": "You have delegated ₳{{ada}} to “Abstain”",
-    "delegatedToNoConfidenceTitle": "You have delegated ₳{{ada}} to “No Confidence”",
+    "delegatedToAbstainTitle": "You have delegated ₳{{ada}} to \"Abstain\"",
+    "delegatedToNoConfidenceTitle": "You have delegated ₳{{ada}} to \"No Confidence\"",
     "delegatedToAbstainDescription": "You have selected to apply your Voting Power to Abstain on every vote.",
     "delegatedToNoConfidenceDescription": "You have selected to apply your Voting Power to No Confidence on every vote.",
     "delegationOptions": "Delegation Options",
@@ -414,7 +414,7 @@
     "chooseHowToVote": "Choose how you want to vote:",
     "contextAboutYourVote": "Context about your vote",
     "dataMissing": "Data Missing",
-    "dataMissingTooltipExplanation": "Please click “View Details” for more information.",
+    "dataMissingTooltipExplanation": "Please click \"View Details\" for more information.",
     "details": "Governance Details:",
     "expiresDateWithEpoch": "Expires: <0>{{date}}</0> <1>(Epoch {{epoch}})</1>",
     "expiryDate": "Expiry date:",
@@ -641,7 +641,7 @@
     },
     "pendingValidation": {
       "title": "GovTool Is Checking Your Data",
-      "message": "GovTool will read the URL that you supplied and make a check to see if it’s identical with the information that you entered on the form."
+      "message": "GovTool will read the URL that you supplied and make a check to see if it's identical with the information that you entered on the form."
     }
   },
   "dRepData": {
@@ -679,7 +679,7 @@
       "description": "Looks like you have already successfully completed your registration and you currently are a DRep.\n\nYou can view your details in the DRep Directory.",
       "viewDetails": "View your DRep details"
     },
-    "becomeADRep": "Become a DRep",
+    "becomeADrep": "Become a DRep",
     "descriptionStepTwo": "By clicking register you create your DRep ID within your wallet and become a DRep.\n\nOnce the registration has completed your DRep ID will be shown on your dashboard. You will be able to share your DRep ID so that other ada holders can delegate their voting power to you.",
     "headingStepTwo": "Confirm DRep registration",
     "register": "Register",
@@ -706,7 +706,7 @@
     }
   },
   "retirement": {
-    "notADRep": {
+    "notADrep": {
       "title": "You are not a DRep",
       "description": "Looks like you cannot retire, because currently you are not a DRep."
     },
@@ -754,7 +754,7 @@
       },
       "noConfidence": {
         "heading": "No confidence",
-        "paragraphOne": "If you don’t have trust in the current constitutional committee you signal ‘No-confidence’. By voting ‘No’ means you don’t want governance actions to be ratified."
+        "paragraphOne": "If you don't have trust in the current constitutional committee you signal 'No-confidence'. By voting 'No' means you don't want governance actions to be ratified."
       },
       "todRep": {
         "heading": "Delegation to DRep",
@@ -767,7 +767,7 @@
     },
     "expiryDate": {
       "heading": "Expiry Date",
-      "paragraphOne": "The date when the governance action will expiry if it doesn’t reach ratification thresholds.",
+      "paragraphOne": "The date when the governance action will expiry if it doesn't reach ratification thresholds.",
       "paragraphTwo": "IMPORTANT: If the governance action is ratified before the expiry date it will be considered ratified and it will not be available to vote on afterwards."
     },
     "submissionDate": {
@@ -781,7 +781,7 @@
     }
   },
   "wallet": {
-    "cantSeeWalletQuestion": "Can’t see your wallet? Check what wallets are currently compatible with GovTool ",
+    "cantSeeWalletQuestion": "Can't see your wallet? Check what wallets are currently compatible with GovTool ",
     "chooseWallet": "Choose the wallet you want to connect with:",
     "connect": "Connect",
     "connectWallet": "Connect Wallet",
@@ -818,7 +818,7 @@
     },
     "intersectWebsite": {
       "title": "Intersect website",
-      "description": "Intersect is a member-based organization for the Cardano ecosystem — putting the community at the center of Cardano’s development",
+      "description": "Intersect is a member-based organization for the Cardano ecosystem — putting the community at the center of Cardano's development",
       "link": "Intersect website"
     }
   },
@@ -840,7 +840,15 @@
   "cip129DrepId": "(CIP-129) DRep ID",
   "cip105DRepId": "Legacy DRep ID (CIP-105)",
   "email": "Email",
-  "feedback": "Feedback",
+  "feedback": {
+    "title": "Feedback",
+    "reportBug": "Report a Bug",
+    "suggestIdea": "Suggest a New Idea",
+    "sentimentFeedback": "Share Your Experience",
+    "sentimentScore": "How would you rate your experience?",
+    "additionalNotes": "Additional Notes",
+    "submit": "Submit Feedback"
+  },
   "filter": "Filter",
   "goBack": "Go back",
   "goToMainnet": "Go to Mainnet",

--- a/tests/govtool-frontend/playwright/tests/10-user-snap/userSnap.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/10-user-snap/userSnap.spec.ts
@@ -187,4 +187,27 @@ test.describe("Submit Usersnap", () => {
 
     await expect(page.getByText("Thank you!")).toBeVisible();
   });
+
+  test("10F. Should submit sentiment feedback", async ({ page }) => {
+    // Intercept Usersnap submit API
+    await interceptUsersnap(page);
+    await interceptBucket(page);
+
+    await page
+      .getByRole("button", { name: "Share Your Experience" })
+      .click();
+
+    // Select a rating
+    await page.getByLabel("How would you rate your experience?").click();
+    await page.getByRole("button", { name: "4" }).click();
+
+    // Add additional notes
+    await page
+      .getByPlaceholder("Additional Notes")
+      .fill(faker.lorem.paragraph(2));
+
+    await page.getByRole("button", { name: "Submit Feedback" }).click();
+
+    await expect(page.getByText("Thank you!")).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Description

This PR adds a third option to the Usersnap feedback modal, allowing users to provide sentiment feedback about their experience with the application. The new option includes a required 1-5 rating scale and an optional freeform text field for additional comments.

## Changes

- Added a new "Share Your Experience" option in the Usersnap feedback modal
- Implemented a required 1-5 rating scale for sentiment scoring
- Added an optional text field for additional feedback notes
- Added comprehensive test coverage for the new sentiment feedback functionality

## Testing
- Added test case `10F. Should submit sentiment feedback` to verify:
  - Opening the sentiment feedback option
  - Selecting a rating
  - Adding additional notes
  - Submitting the feedback
  - Verifying the success message
  
## Related Issues
Closes #3535
