### PR TITLE
Fix: update govaction loader network references

### DIFF
--- a/gov-action-loader/frontend/src/App.vue
+++ b/gov-action-loader/frontend/src/App.vue
@@ -70,8 +70,8 @@ export default {
   data() {
     return {
       tab: null,
-      selectedNetwork: 'Sanchonet', // Default selection
-      networkOptions: ['Sanchonet', 'Preview', 'Preprod'],
+      selectedNetwork: 'Preview', // Default selection
+      networkOptions: ['Preview', 'Preprod'],
       walletInfo: {
         address: null,
         balance: null,

--- a/gov-action-loader/frontend/src/views/BulkLoad.vue
+++ b/gov-action-loader/frontend/src/views/BulkLoad.vue
@@ -9,7 +9,7 @@ import { prepareErrorMessage } from '../utils'
       <!--For displaying the title and description-->
       <div class="mb-4">
         <div class="text-h5">Governance Action Bulk Loader</div>
-        <div class="text-grey mt-1">Submit to load the required number of a given action to sanchonet.</div>
+        <div class="text-grey mt-1">Submit to load the required number of a given action to preview.</div>
       </div>
 
       <!--For selecting the action type and number of proposals-->

--- a/gov-action-loader/frontend/src/views/BulkLoad.vue
+++ b/gov-action-loader/frontend/src/views/BulkLoad.vue
@@ -9,7 +9,7 @@ import { prepareErrorMessage } from '../utils'
       <!--For displaying the title and description-->
       <div class="mb-4">
         <div class="text-h5">Governance Action Bulk Loader</div>
-        <div class="text-grey mt-1">Submit to load the required number of a given action to preview.</div>
+        <div class="text-grey mt-1">Submit to load the required number of a given action to {{ selectedNetwork.toLowerCase() }}.</div>
       </div>
 
       <!--For selecting the action type and number of proposals-->
@@ -68,6 +68,9 @@ import { prepareErrorMessage } from '../utils'
 import { submitMultipleProposals } from '../api'
 
 export default {
+  props: {
+    selectedNetwork: String,
+  },
   data() {
     return {
       actionTypes: ['Constitution', 'Info', 'Withdrawal', 'No-Confidence', 'Update-Committee', 'Hardfork', 'Update-Parameters'],

--- a/gov-action-loader/frontend/src/views/SpecificLoad.vue
+++ b/gov-action-loader/frontend/src/views/SpecificLoad.vue
@@ -7,7 +7,7 @@ import config from '../config'
       <!-- Helper title and subtext -->
       <div class="mb-4">
         <div class="text-h5">Specific Governance Action Loader</div>
-        <div class="text-grey mt-1">Fill in the details according to specific action submit to sanchonet.</div>
+        <div class="text-grey mt-1">Fill in the details according to specific action submit to preview.</div>
       </div>
       <!-- Form for action loader -->
       <div class="mt-8">

--- a/gov-action-loader/frontend/src/views/SpecificLoad.vue
+++ b/gov-action-loader/frontend/src/views/SpecificLoad.vue
@@ -7,7 +7,7 @@ import config from '../config'
       <!-- Helper title and subtext -->
       <div class="mb-4">
         <div class="text-h5">Specific Governance Action Loader</div>
-        <div class="text-grey mt-1">Fill in the details according to specific action submit to preview.</div>
+        <div class="text-grey mt-1">Fill in the details according to specific action submit to {{ selectedNetwork.toLowerCase() }}.</div>
       </div>
       <!-- Form for action loader -->
       <div class="mt-8">


### PR DESCRIPTION
## List of changes

- Remove sanchonet 
- Make the preview the default network
- Use selected network on subtitle instead of hardcoded

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
