### PR TITLE
fix: commit status undefined group_name issue

### DIFF
--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -105,6 +105,7 @@ jobs:
     needs: backend-tests
     outputs:
       report_number: ${{ steps.report-details.outputs.report_number }}
+      group_name: ${{ steps.set-deployment-url.outputs.group_name }}
     steps:
       - uses: actions/checkout@v4
       - name: Download results
@@ -188,6 +189,7 @@ jobs:
           TEST_STATUS: ${{ needs.backend-tests.outputs.status }}
           REPORT_NUMBER: ${{ needs.publish-report.outputs.report_number }}
           GITHUB_TOKEN: ${{ github.token }}
+          GROUP_NAME: ${{ needs.publish-report.outputs.group_name }}
 
 env:
   BASE_URL: https://${{github.event.schedule && 'be.preview.gov.tools' || inputs.deployment ||  'govtool.cardanoapi.io/api' }}

--- a/.github/workflows/test_integration_playwright.yml
+++ b/.github/workflows/test_integration_playwright.yml
@@ -145,6 +145,7 @@ jobs:
     needs: integration-tests
     outputs:
       report_number: ${{ steps.report-details.outputs.report_number }}
+      group_name: ${{ steps.set-deployment-url.outputs.group_name }}
     steps:
       - uses: actions/checkout@v4
       - name: Download report
@@ -218,7 +219,7 @@ jobs:
         with:
           name: allure-results
           path: allure-results
-          
+
       - name: Set Commit Status
         if: always() && !github.event.schedule
         run: |
@@ -229,6 +230,7 @@ jobs:
           TEST_STATUS: ${{ needs.integration-tests.outputs.status }}
           REPORT_NUMBER: ${{ needs.publish-report.outputs.report_number }}
           GITHUB_TOKEN: ${{ github.token }}
+          GROUP_NAME: ${{ needs.publish-report.outputs.group_name }}
 env:
   HOST_URL: https://${{ github.event.schedule && 'preview.gov.tools' || (inputs.deployment || 'govtool.cardanoapi.io')  }}
   DEPLOYMENT: ${{ github.event.schedule && 'preview.gov.tools' || inputs.deployment ||  'govtool.cardanoapi.io'}}


### PR DESCRIPTION

## List of changes

- Add group_name output to publish-report steps in backend and integration workflows

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
