### PR TITLE
fix: update test IDs for budget discussion form components and related tests

### DIFF
--- a/tests/govtool-frontend/playwright/lib/pages/budgetDiscussionSubmissionPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/budgetDiscussionSubmissionPage.ts
@@ -83,9 +83,9 @@ export default class BudgetDiscussionSubmissionPage {
   readonly suplimentaryEndorsementInput = this.page.getByTestId(
     "supplementary-endorsement-input"
   );
-  readonly productRoadmapDescriptionInput = this.page.getByLabel(
-    "Please explain how your"
-  ); // BUG missing test Ids
+  readonly productRoadmapDescriptionInput = this.page.getByTestId(
+    "proposal-roadmap-description-input"
+  );
 
   // proposal-details
   readonly proposalNameInput = this.page.getByTestId("proposal-name-input");
@@ -123,12 +123,10 @@ export default class BudgetDiscussionSubmissionPage {
   readonly venderDetailsInput = this.page.getByLabel("Please provide further"); //BUG missing test Ids
 
   // select
-  readonly proposalCommittee = this.page
-    .getByLabel("Is this proposal being")
-    .first(); // BUG incorrect position of testId
-  readonly countryOfIncorporationBtn = this.page
-    .getByLabel("Country of Incorporation *")
-    .first(); // BUG incorrect position of testId
+  readonly proposalCommittee = this.page.getByTestId("proposal-committee");
+  readonly countryOfIncorporationBtn = this.page.getByTestId(
+    "country-of-incorporation"
+  );
   readonly publicChampionSelect = this.page.getByTestId(
     "proposal-public-champion"
   );
@@ -264,8 +262,8 @@ export default class BudgetDiscussionSubmissionPage {
   ) {
     await this.proposalCommittee.click();
     await this.page
-      .getByRole("option", { name: proposalOwnership.companyType })
-      .click(); //BUG missing testId
+      .getByTestId(`${proposalOwnership.companyType.toLowerCase()}-submission`)
+      .click();
 
     await this.contactDetailsInput.fill(proposalOwnership.contactDetails);
 
@@ -787,13 +785,9 @@ export default class BudgetDiscussionSubmissionPage {
 
     // further information
     for (let i = 0; i < proposalInformations.furtherInformation.length; i++) {
-      //BUG missing testId
-      await expect(
-        this.currentPage.getByRole("link", {
-          name: proposalInformations.furtherInformation[i].prop_link_text,
-          exact: true,
-        })
-      ).toBeVisible();
+      await expect(this.currentPage.getByTestId(`link-${i}-label`)).toHaveText(
+        proposalInformations.furtherInformation[i].prop_link_text
+      );
     }
 
     // administration and auditing

--- a/tests/govtool-frontend/playwright/lib/pages/budgetDiscussionSubmissionPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/budgetDiscussionSubmissionPage.ts
@@ -51,13 +51,8 @@ export default class BudgetDiscussionSubmissionPage {
   readonly verifyIdentityBtn = this.page.getByTestId("verify-identity-button");
   readonly saveDraftBtn = this.page.getByTestId("draft-button");
   readonly submitBtn = this.page.getByTestId("submit-button");
-  readonly countryOfIncorporationBtn = this.page.getByTestId(
-    "country-of-incorporation"
-  );
 
-  readonly agreeCheckbox = this.page.getByLabel(
-    "I agree to the information in"
-  ); //BUG missing test Ids
+  readonly agreeCheckbox = this.page.getByTestId("agree-checkbox");
   readonly submitCheckbox = this.page.getByTestId("submit-checkbox");
 
   // input
@@ -65,18 +60,18 @@ export default class BudgetDiscussionSubmissionPage {
   readonly linkUrlInput = this.page.getByTestId("link-0-url-input");
 
   // proposal-ownership
-  readonly companyNameInput = this.page.getByLabel("Company Name *"); //BUG missing test Ids
-  readonly companyDomainNameInput = this.page.getByLabel(
-    "Company Domain Name *"
-  ); //BUG missing test Ids
-  readonly groupNameInput = this.page.getByLabel("Group Name *"); //BUG missing test Ids
-  readonly groupTypeInput = this.page.getByLabel("Type of Group *"); //BUG missing test Ids
-  readonly keyInformationOfGroupInput = this.page.getByLabel(
-    "Key Information to Identify"
-  ); //BUG missing test Ids
-  readonly contactDetailsInput = this.page.getByLabel(
-    "Please provide your preferred"
-  ); //BUG missing test Ids
+  readonly companyNameInput = this.page.getByTestId("company-name-input");
+  readonly companyDomainNameInput = this.page.getByTestId(
+    "company-domain-input"
+  );
+  readonly groupNameInput = this.page.getByTestId("group-name-input");
+  readonly groupTypeInput = this.page.getByTestId("group-type-input");
+  readonly keyInformationOfGroupInput = this.page.getByTestId(
+    "group-identity-information-input"
+  );
+  readonly contactDetailsInput = this.page.getByTestId(
+    "provide-preferred-input"
+  );
 
   // problem-statements
   readonly problemStatementInput = this.page.getByTestId(
@@ -93,51 +88,47 @@ export default class BudgetDiscussionSubmissionPage {
   ); // BUG missing test Ids
 
   // proposal-details
-  readonly proposalNameInput = this.page.getByLabel(
-    "What is your proposed name to"
-  ); //BUG missing testId
+  readonly proposalNameInput = this.page.getByTestId("proposal-name-input");
   readonly proposalDescriptionInput = this.page.getByTestId(
     "proposal-description-input"
   );
   readonly proposalKeyDependenciesInput = this.page.getByTestId(
     "key-dependencies-input"
   );
-  readonly proposalMaintainAndSupportInput = this.page.getByLabel(
-    "How will this proposal be"
-  ); //BUG missing testId
+  readonly proposalMaintainAndSupportInput = this.page.getByTestId(
+    "proposal-maintain-and-support-input"
+  );
   readonly milestonesInput = this.page.getByTestId(
     "key-proposal-deliverables-input"
   );
   readonly teamSizeAndDurationInput = this.page.getByTestId(
     "resourcing-duration-estimates-input"
   );
-  readonly previousExperienceInput = this.page.getByLabel(
-    "Please provide previous"
-  ); //BUG missing testId
-  readonly otherDescriptionInput = this.page.getByLabel(
-    "Please describe what you have"
+  readonly previousExperienceInput = this.page.getByTestId(
+    "proposal-previous-experience-input"
+  );
+  readonly otherDescriptionInput = this.page.getByTestId(
+    "other-contract-description"
   );
 
   // costing
-  readonly adaAmountInput = this.page.getByLabel("ADA Amount *"); //BUG missing test Ids
-  readonly usaToAdaCnversionRateInput = this.page.getByLabel(
-    "USD to ADA Conversion Rate *"
-  ); //BUG missing test Ids
-  readonly preferredCurrencyInput = this.page.getByLabel(
-    "Amount in preferred currency *"
+  readonly adaAmountInput = this.page.getByTestId("ada-amount-input");
+  readonly usaToAdaCnversionRateInput = this.page.getByTestId(
+    "usd-ada-conversion-input"
+  );
+  readonly preferredCurrencyInput = this.page.getByTestId(
+    "preferred-currency-amount-input"
   );
   readonly costBreakdownInput = this.page.getByTestId("cost-breakdown-input");
   readonly venderDetailsInput = this.page.getByLabel("Please provide further"); //BUG missing test Ids
 
   // select
-  readonly beneficiaryCountrySelect = this.page.getByTestId(
-    "beneficiary-country-of-residence"
-  );
-  readonly beneficiaryNationalitySelect = this.page.getByTestId(
-    "beneficiary-nationality"
-  );
-
-  readonly companyTypeSelect = this.page.getByTestId("beneficiary-type");
+  readonly proposalCommittee = this.page
+    .getByLabel("Is this proposal being")
+    .first(); // BUG incorrect position of testId
+  readonly countryOfIncorporationBtn = this.page
+    .getByLabel("Country of Incorporation *")
+    .first(); // BUG incorrect position of testId
   readonly publicChampionSelect = this.page.getByTestId(
     "proposal-public-champion"
   );
@@ -234,9 +225,9 @@ export default class BudgetDiscussionSubmissionPage {
 
   // costing
   readonly adaAmountContent = this.page.getByTestId("ada-amount-content");
-  readonly adaToUsdConversionRateContent = this.page.getByTestId(
+  readonly usdToAdaConversionRateContent = this.page.getByTestId(
     "usd-to-ada-conversion-rate-content"
-  ); // BUG typo
+  );
   readonly preferredCurrencyContent = this.page.getByTestId(
     "preferred-currency-content"
   );
@@ -271,7 +262,7 @@ export default class BudgetDiscussionSubmissionPage {
     proposalOwnership: BudgetProposalOwnershipProps,
     isNaviagted = true
   ) {
-    await this.companyTypeSelect.click();
+    await this.proposalCommittee.click();
     await this.page
       .getByRole("option", { name: proposalOwnership.companyType })
       .click(); //BUG missing testId
@@ -772,7 +763,7 @@ export default class BudgetDiscussionSubmissionPage {
     await expect(this.adaAmountContent).toHaveText(
       `₳ ${formatWithThousandSeparator(proposalInformations.costing.adaAmount)}`
     );
-    await expect(this.adaToUsdConversionRateContent).toHaveText(
+    await expect(this.usdToAdaConversionRateContent).toHaveText(
       proposalInformations.costing.usdToAdaConversionRate.toString()
     );
 
@@ -836,7 +827,7 @@ export default class BudgetDiscussionSubmissionPage {
     proposalOwnership: BudgetProposalOwnershipProps,
     isValid: boolean = true
   ) {
-    const companyTypeSelectContent = await this.companyTypeSelect.textContent();
+    const companyTypeSelectContent = await this.proposalCommittee.textContent();
 
     if (isValid) {
       if (proposalOwnership.companyType === "Company") {

--- a/tests/govtool-frontend/playwright/lib/pages/outcomesPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/outcomesPage.ts
@@ -437,7 +437,6 @@ export default class OutComesPage {
       "**/governance-actions?search=&filters=&sort=**"
     );
 
-
     await this.goto();
     await actionsResponsePromise;
 

--- a/tests/govtool-frontend/playwright/tests/11-proposal-budget/proposalBudget.dRep.pb.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/11-proposal-budget/proposalBudget.dRep.pb.spec.ts
@@ -61,7 +61,9 @@ test.describe("Budget proposal dRep behaviour", () => {
       await budgetDiscussionDetailsPage.voteOnPoll(choice);
       await budgetDiscussionDetailsPage.changePollVote();
 
-      await expect(budgetDiscussionDetailsPage.pollYesBtn).not.toBeVisible({timeout: 60_000});
+      await expect(budgetDiscussionDetailsPage.pollYesBtn).not.toBeVisible({
+        timeout: 60_000,
+      });
       await expect(budgetDiscussionDetailsPage.pollNoBtn).not.toBeVisible();
 
       // vote must be changed

--- a/tests/govtool-frontend/playwright/tests/12-proposal-budget-submission/proposalBudgetSubmission.loggedin.pb.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/12-proposal-budget-submission/proposalBudgetSubmission.loggedin.pb.spec.ts
@@ -62,7 +62,7 @@ test.describe("Budget proposal 01 wallet", () => {
       test("12D_1. Should verify all field of “proposal ownership” section", async () => {
         // default field
         await expect(
-          budgetProposalSubmissionPage.companyTypeSelect
+          budgetProposalSubmissionPage.proposalCommittee
         ).toBeVisible();
 
         await expect(
@@ -70,7 +70,7 @@ test.describe("Budget proposal 01 wallet", () => {
         ).toBeVisible();
 
         // company type field
-        await budgetProposalSubmissionPage.companyTypeSelect.click();
+        await budgetProposalSubmissionPage.proposalCommittee.click();
         await budgetProposalSubmissionPage.currentPage
           .getByRole("option", { name: CompanyEnum.Company })
           .click(); //BUG missing testId
@@ -86,7 +86,7 @@ test.describe("Budget proposal 01 wallet", () => {
         ).toBeVisible();
 
         // group type field
-        await budgetProposalSubmissionPage.companyTypeSelect.click();
+        await budgetProposalSubmissionPage.proposalCommittee.click();
         await budgetProposalSubmissionPage.currentPage
           .getByRole("option", { name: CompanyEnum.Group })
           .click(); //BUG missing testId
@@ -436,7 +436,7 @@ test("12C. Should save and view draft proposal", async ({ browser }) => {
 
   await budgetSubmissionPage.viewLastDraft();
 
-  await expect(budgetSubmissionPage.companyTypeSelect).toHaveText(
+  await expect(budgetSubmissionPage.proposalCommittee).toHaveText(
     draftProposalOwnership.companyType
   );
 

--- a/tests/govtool-frontend/playwright/tests/12-proposal-budget-submission/proposalBudgetSubmission.loggedin.pb.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/12-proposal-budget-submission/proposalBudgetSubmission.loggedin.pb.spec.ts
@@ -72,8 +72,8 @@ test.describe("Budget proposal 01 wallet", () => {
         // company type field
         await budgetProposalSubmissionPage.proposalCommittee.click();
         await budgetProposalSubmissionPage.currentPage
-          .getByRole("option", { name: CompanyEnum.Company })
-          .click(); //BUG missing testId
+          .getByTestId("company-submission")
+          .click();
 
         await expect(
           budgetProposalSubmissionPage.companyNameInput
@@ -88,8 +88,8 @@ test.describe("Budget proposal 01 wallet", () => {
         // group type field
         await budgetProposalSubmissionPage.proposalCommittee.click();
         await budgetProposalSubmissionPage.currentPage
-          .getByRole("option", { name: CompanyEnum.Group })
-          .click(); //BUG missing testId
+          .getByTestId("group-submission")
+          .click();
         await expect(budgetProposalSubmissionPage.groupNameInput).toBeVisible();
         await expect(budgetProposalSubmissionPage.groupTypeInput).toBeVisible();
         await expect(


### PR DESCRIPTION
## List of changes

- Update missing testIds of the budget proposal form

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
