### PR TITLE
fix: InitOptions type connected with changes: "Added Sentiment Feedback Option to Feedback Modal"

### DIFF
--- a/govtool/frontend/src/context/usersnapContext.tsx
+++ b/govtool/frontend/src/context/usersnapContext.tsx
@@ -83,34 +83,34 @@ export const UsersnapProvider = ({
             ...initParams,
             customFields: {
               sentiment_score: {
-                type: 'rating',
+                type: "rating",
                 label: t("feedback.sentimentScore"),
                 required: true,
-                options: [1, 2, 3, 4, 5]
+                options: [1, 2, 3, 4, 5],
               },
               additional_notes: {
-                type: 'textarea',
+                type: "textarea",
                 label: t("feedback.additionalNotes"),
-                required: false
-              }
+                required: false,
+              },
             },
             feedbackTypes: [
               {
-                id: 'bug',
+                id: "bug",
                 label: t("feedback.reportBug"),
-                description: t("feedback.reportBugDescription")
+                description: t("feedback.reportBugDescription"),
               },
               {
-                id: 'idea',
+                id: "idea",
                 label: t("feedback.suggestIdea"),
-                description: t("feedback.suggestIdeaDescription")
+                description: t("feedback.suggestIdeaDescription"),
               },
               {
-                id: 'sentiment',
+                id: "sentiment",
                 label: t("feedback.sentimentFeedback"),
-                description: t("feedback.sentimentFeedbackDescription")
-              }
-            ]
+                description: t("feedback.sentimentFeedbackDescription"),
+              },
+            ],
           });
           setUsersnapApi(api);
         } catch (error) {


### PR DESCRIPTION
- Fix InitOption type that occurs after merging the forked pull request 

## Checklist

- [related pull request](https://github.com/IntersectMBO/govtool/pull/3656)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
