### PR TITLE
fix: update the content of the red banner displayed on GovTool

### DIFF
--- a/govtool/frontend/src/components/organisms/MaintenanceEndingBanner/MaintenanceEndingBanner.tsx
+++ b/govtool/frontend/src/components/organisms/MaintenanceEndingBanner/MaintenanceEndingBanner.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography, IconButton } from "@mui/material";
+import { Box, Typography, IconButton, Link } from "@mui/material";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import { Trans, useTranslation } from "react-i18next";
@@ -101,7 +101,18 @@ export const MaintenanceEndingBanner = () => {
             />
           </Typography>
           <Typography variant="caption" color="common.white">
-            {t("system.maintenanceEnding.description3")}
+            {t("system.maintenanceEnding.description3")}{" "}
+            <Link
+              variant="caption"
+              fontWeight={600}
+              color="common.white"
+              href="https://docs.gov.tools/overview/important-updates/the-future-of-govtool-why-it-matters-and-what-comes-next"
+              target="_blank"
+              rel="noopener noreferrer"
+              data-testid="govtool-future-link"
+            >
+              {t("system.maintenanceEnding.linkText")}
+            </Link>
           </Typography>
         </Box>
       </Box>

--- a/govtool/frontend/src/i18n/locales/en.json
+++ b/govtool/frontend/src/i18n/locales/en.json
@@ -755,10 +755,11 @@
     "title": "This tool is connected to {{networkName}}",
     "bootstrappingWarning": "Govtool is in the Bootstrapping phase. Some features are not available. <docs>Learn more</docs>",
     "maintenanceEnding": {
-      "title": "⚠️ GovTool Maintenance Ending Soon",
-      "description1": "GovTool has not been included in the 2025 Cardano budget.",
-      "description2": "Unless alternative support is secured, <0>maintenance will end in June 2025.</0>",
-      "description3": "We remain committed to transparency and will keep you updated."
+      "title": "⚠️ Funding for GovTool is at risk",
+      "description1": "GovTool was not included in the current Cardano budget.",
+      "description2": "Without new support, active development and <0>maintenance will end in June 2025.</0>",
+      "description3": "Learn what this means and what’s next:",
+      "linkText": "The future of GovTool"
     }
   },
   "tooltips": {


### PR DESCRIPTION
Cherry picking [hotfix](https://github.com/IntersectMBO/govtool/pull/3704)