### PR TITLE
fix(#3714): type error on linkReferences when editing dRep page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ changes.
 ### Fixed
 
 - Fix missing off chain references in DRep details [Issue 3490](https://github.com/IntersectMBO/govtool/issues/3490)
+- Fix blank screen and type error on linkReferences when navigating to edit dRep page that has no links [Issue 3714](https://github.com/IntersectMBO/govtool/issues/3714)
 
 ### Changed
 

--- a/govtool/frontend/src/components/organisms/EditDRepInfoSteps/EditDRepForm.tsx
+++ b/govtool/frontend/src/components/organisms/EditDRepInfoSteps/EditDRepForm.tsx
@@ -49,8 +49,8 @@ export const EditDRepForm = ({
         qualifications: data?.qualifications ?? "",
         paymentAddress: data?.paymentAddress ?? "",
         image: data?.image ?? "",
-        linkReferences: data.linkReferences ?? [getEmptyReference("Link")],
-        identityReferences: data.identityReferences ?? [
+        linkReferences: data?.linkReferences ?? [getEmptyReference("Link")],
+        identityReferences: data?.identityReferences ?? [
           getEmptyReference("Identity"),
         ],
       });


### PR DESCRIPTION
## List of changes

- Fix blank screen and type error on linkReferences when navigating to edit dRep page that has no links

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3714)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
