### PR TITLE
fix(#3709): edit dRep form adds two link input fields instead of one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ changes.
 
 - Fix missing off chain references in DRep details [Issue 3490](https://github.com/IntersectMBO/govtool/issues/3490)
 - Fix blank screen and type error on linkReferences when navigating to edit dRep page that has no links [Issue 3714](https://github.com/IntersectMBO/govtool/issues/3714)
+- Fix adding two link input fields when editing the dRep form when no links are present initially [Issue 3709](https://github.com/IntersectMBO/govtool/issues/3709)
 
 ### Changed
 

--- a/govtool/frontend/src/components/organisms/EditDRepInfoSteps/EditDRepForm.tsx
+++ b/govtool/frontend/src/components/organisms/EditDRepInfoSteps/EditDRepForm.tsx
@@ -4,6 +4,7 @@ import { Box } from "@mui/material";
 
 import { useCardano } from "@context";
 import {
+  defaultEditDRepInfoValues,
   useEditDRepInfoForm,
   useGetDRepDetailsQuery,
   useTranslation,
@@ -44,15 +45,21 @@ export const EditDRepForm = ({
 
       reset({
         ...data,
-        objectives: data?.objectives ?? "",
-        motivations: data?.motivations ?? "",
-        qualifications: data?.qualifications ?? "",
-        paymentAddress: data?.paymentAddress ?? "",
-        image: data?.image ?? "",
-        linkReferences: data?.linkReferences ?? [getEmptyReference("Link")],
-        identityReferences: data?.identityReferences ?? [
-          getEmptyReference("Identity"),
-        ],
+        objectives: data?.objectives ?? defaultEditDRepInfoValues.objectives,
+        motivations: data?.motivations ?? defaultEditDRepInfoValues.motivations,
+        qualifications:
+          data?.qualifications ?? defaultEditDRepInfoValues.qualifications,
+        paymentAddress:
+          data?.paymentAddress ?? defaultEditDRepInfoValues.paymentAddress,
+        image: data?.image ?? defaultEditDRepInfoValues.image,
+        linkReferences:
+          Array.isArray(data?.linkReferences) && data.linkReferences.length > 0
+            ? data.linkReferences
+            : defaultEditDRepInfoValues.linkReferences,
+        identityReferences:
+          Array.isArray(data?.identityReferences) && data.identityReferences.length > 0
+            ? data.identityReferences
+            : defaultEditDRepInfoValues.identityReferences,
       });
     }
   }, [yourselfDRep, loadUserData]);
@@ -74,9 +81,3 @@ export const EditDRepForm = ({
     </Box>
   );
 };
-
-const getEmptyReference = (type: "Link" | "Identity") => ({
-  "@type": type,
-  uri: "",
-  label: "",
-});


### PR DESCRIPTION
## List of changes

- Fix adding two link input fields when editing the dRep form when no links are present initially

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3709)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
