### PR TITLE
Fix: wrap governance action expiry test with function waited assertion

### DIFF
--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.spec.ts
@@ -199,15 +199,19 @@ test("4H. Should verify none of the displayed governance actions have expired", 
   const govActionsPage = new GovernanceActionsPage(page);
   await govActionsPage.goto();
 
-  const proposalCards = await govActionsPage.getAllProposals();
-
-  for (const proposalCard of proposalCards) {
-    const expiryDateEl = proposalCard.getByTestId("expiry-date");
-    const expiryDateTxt = await expiryDateEl.innerText();
-    const expiryDate = extractExpiryDateFromText(expiryDateTxt);
-    const today = new Date();
-    expect(today <= expiryDate).toBeTruthy();
-  }
+  await functionWaitedAssert(
+    async () => {
+      const proposalCards = await govActionsPage.getAllProposals();
+      for (const proposalCard of proposalCards) {
+        const expiryDateEl = proposalCard.getByTestId("expiry-date");
+        const expiryDateTxt = await expiryDateEl.innerText();
+        const expiryDate = extractExpiryDateFromText(expiryDateTxt);
+        const today = new Date();
+        expect(today <= expiryDate).toBeTruthy();
+      }
+    },
+    { name: "verify none expired governance actions" }
+  );
 });
 
 test("4K. Should display correct vote counts on governance details page for disconnect state", async ({


### PR DESCRIPTION
## List of changes

- Add a retry mechanism for getting all governance actions  on expiry governance action test

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
