### PR TITLE
fix(#3733): blank page when dRep have @value in uri or label  references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ changes.
 
 ### Fixed
 
+- Fix blank page on dRep details when link or identity references contain objects: { @value: ... } not strings [Issue 3733](https://github.com/IntersectMBO/govtool/issues/3733)
 - Fix missing off chain references in DRep details [Issue 3490](https://github.com/IntersectMBO/govtool/issues/3490)
 - Fix blank screen and type error on linkReferences when navigating to edit dRep page that has no links [Issue 3714](https://github.com/IntersectMBO/govtool/issues/3714)
 - Fix adding two link input fields when editing the dRep form when no links are present initially [Issue 3709](https://github.com/IntersectMBO/govtool/issues/3709)

--- a/govtool/backend/sql/list-dreps.sql
+++ b/govtool/backend/sql/list-dreps.sql
@@ -95,7 +95,7 @@ HasNonDeregisterVotingAnchor AS (
     EXISTS (
       SELECT 1
       FROM drep_registration dr_sub
-      WHERE 
+      WHERE
         dr_sub.drep_hash_id = dr.drep_hash_id
         AND dr_sub.voting_anchor_id IS NULL
         AND COALESCE(dr_sub.deposit, 0) >= 0
@@ -129,12 +129,24 @@ DRepData AS (
     off_chain_vote_drep_data.image_hash,
     COALESCE(
       (
-        SELECT jsonb_agg(ref)
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'uri',   COALESCE(
+                      CASE WHEN jsonb_typeof(ref->'uri') = 'string' THEN ref->>'uri' END,
+                      ref->'uri'->>'@value'
+                    ),
+            '@type', ref->>'@type',
+            'label', COALESCE(
+                      CASE WHEN jsonb_typeof(ref->'label') = 'string' THEN ref->>'label' END,
+                      ref->'label'->>'@value'
+                    )
+          )
+        )
         FROM jsonb_array_elements(
-          CASE 
-            WHEN (ocvd.json::jsonb)->'body'->'references' IS NOT NULL 
-            THEN (ocvd.json::jsonb)->'body'->'references' 
-            ELSE '[]'::jsonb 
+          CASE
+            WHEN (ocvd.json::jsonb)->'body'->'references' IS NOT NULL
+            THEN (ocvd.json::jsonb)->'body'->'references'
+            ELSE '[]'::jsonb
           END
         ) AS ref
         WHERE ref->>'@type' = 'Identity'
@@ -143,12 +155,24 @@ DRepData AS (
     ) AS identity_references,
     COALESCE(
       (
-        SELECT jsonb_agg(ref)
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'uri',   COALESCE(
+                      CASE WHEN jsonb_typeof(ref->'uri') = 'string' THEN ref->>'uri' END,
+                      ref->'uri'->>'@value'
+                    ),
+            '@type', ref->>'@type',
+            'label', COALESCE(
+                      CASE WHEN jsonb_typeof(ref->'label') = 'string' THEN ref->>'label' END,
+                      ref->'label'->>'@value'
+                    )
+          )
+        )
         FROM jsonb_array_elements(
-          CASE 
-            WHEN (ocvd.json::jsonb)->'body'->'references' IS NOT NULL 
-            THEN (ocvd.json::jsonb)->'body'->'references' 
-            ELSE '[]'::jsonb 
+          CASE
+            WHEN (ocvd.json::jsonb)->'body'->'references' IS NOT NULL
+            THEN (ocvd.json::jsonb)->'body'->'references'
+            ELSE '[]'::jsonb
           END
         ) AS ref
         WHERE ref->>'@type' = 'Link'
@@ -185,7 +209,7 @@ DRepData AS (
     LEFT JOIN FetchError fetch_error ON fetch_error.voting_anchor_id = leva.voting_anchor_id
     LEFT JOIN HasNonDeregisterVotingAnchor hndva ON hndva.drep_hash_id = dh.id
     LEFT JOIN off_chain_vote_data ocvd ON ocvd.voting_anchor_id = leva.voting_anchor_id
-    LEFT JOIN off_chain_vote_drep_data ON off_chain_vote_drep_data.off_chain_vote_data_id = ocvd.id 
+    LEFT JOIN off_chain_vote_drep_data ON off_chain_vote_drep_data.off_chain_vote_data_id = ocvd.id
     LEFT JOIN voting_procedure ON voting_procedure.drep_voter = dh.id
     LEFT JOIN tx voting_procedure_transaction ON voting_procedure_transaction.id = voting_procedure.tx_id
     LEFT JOIN block voting_procedure_block ON voting_procedure_block.id = voting_procedure_transaction.block_id
@@ -244,10 +268,10 @@ DRepData AS (
     (
       SELECT jsonb_agg(ref)
       FROM jsonb_array_elements(
-        CASE 
-          WHEN (ocvd.json::jsonb)->'body'->'references' IS NOT NULL 
-          THEN (ocvd.json::jsonb)->'body'->'references' 
-          ELSE '[]'::jsonb 
+        CASE
+          WHEN (ocvd.json::jsonb)->'body'->'references' IS NOT NULL
+          THEN (ocvd.json::jsonb)->'body'->'references'
+          ELSE '[]'::jsonb
         END
       ) AS ref
       WHERE ref->>'@type' = 'Identity'
@@ -255,10 +279,10 @@ DRepData AS (
     (
       SELECT jsonb_agg(ref)
       FROM jsonb_array_elements(
-        CASE 
-          WHEN (ocvd.json::jsonb)->'body'->'references' IS NOT NULL 
-          THEN (ocvd.json::jsonb)->'body'->'references' 
-          ELSE '[]'::jsonb 
+        CASE
+          WHEN (ocvd.json::jsonb)->'body'->'references' IS NOT NULL
+          THEN (ocvd.json::jsonb)->'body'->'references'
+          ELSE '[]'::jsonb
         END
       ) AS ref
       WHERE ref->>'@type' = 'Link'


### PR DESCRIPTION
## List of changes

- Fix blank page on dRep details when link or identity references contain objects `{ @value: ... }` not strings

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3733)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works


## For own Verification
This sql can be used to extract the exact dRep data that was problematic for us and some other one with standard uri/label definitions. 
```SQL
SELECT
  dh.view AS drep_view,
  off_chain_vote_drep_data.given_name,
  jsonb_agg(
    jsonb_build_object(
    'uri',   COALESCE(
               CASE WHEN jsonb_typeof(ref->'uri') = 'string' THEN ref->>'uri' END,
               ref->'uri'->>'@value'
             ),
    '@type', ref->>'@type',
    'label', COALESCE(
               CASE WHEN jsonb_typeof(ref->'label') = 'string' THEN ref->>'label' END,
               ref->'label'->>'@value'
             )
  )
  ) AS link_references
FROM drep_hash dh
JOIN drep_registration dr ON dr.drep_hash_id = dh.id
JOIN voting_anchor va ON va.id = dr.voting_anchor_id
JOIN off_chain_vote_data ocvd ON ocvd.voting_anchor_id = va.id
JOIN off_chain_vote_drep_data ON off_chain_vote_drep_data.off_chain_vote_data_id = ocvd.id
CROSS JOIN LATERAL (
  SELECT ref
  FROM jsonb_array_elements(
    COALESCE((ocvd.json::jsonb)->'body'->'references', '[]'::jsonb)
  ) AS ref
  WHERE ref->>'@type' = 'Link'
) sub
WHERE dh.view = 'drep1jnmmkfwpta0yuwjchw0gu6csh75vy62088egy9n67d0zc7sn83m' OR dh.view = 'drep160v90f47eeqscq9aglzh8qxv8plskgxjtj9qgplgsz0kwskskjs'
GROUP BY dh.view, off_chain_vote_drep_data.given_name;
```

Before:
<img width="1173" alt="image" src="https://github.com/user-attachments/assets/44306f31-45c9-4a8a-962f-35855c9daa43" />

After:
<img width="1182" alt="image" src="https://github.com/user-attachments/assets/bd76e9a0-196b-413c-a67e-19c4dfb148fc" />
