### PR TITLE
Fix: proposal search case

### DIFF
--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.spec.ts
@@ -203,6 +203,7 @@ test("4H. Should verify none of the displayed governance actions have expired", 
     async () => {
       const proposalCards = await govActionsPage.getAllProposals();
       for (const proposalCard of proposalCards) {
+        await expect(proposalCard).toBeVisible();
         const expiryDateEl = proposalCard.getByTestId("expiry-date");
         const expiryDateTxt = await expiryDateEl.innerText();
         const expiryDate = extractExpiryDateFromText(expiryDateTxt);

--- a/tests/govtool-frontend/playwright/tests/8-proposal-discussion/proposalDiscussion.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/8-proposal-discussion/proposalDiscussion.spec.ts
@@ -156,7 +156,9 @@ test("8C. Should search the list of proposed governance actions.", async ({
         const proposalTitle = await proposalCard
           .locator('[data-testid^="proposal-"][data-testid$="-title"]')
           .innerText();
-        expect(proposalTitle.trim()).toContain(proposalName.trim());
+        expect(proposalTitle.toLowerCase().trim()).toContain(
+          proposalName.toLowerCase().trim()
+        );
       }
     },
     {


### PR DESCRIPTION
## List of changes

- Make a proposal search by title, case-insensitive
- Add an assertion to validate the proposal card before the proposal card-related test

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
