### PR TITLE
feat(#3682): adjust top menu layout when wallet is not connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ changes.
 - Fix adding two link input fields when editing the dRep form when no links are present initially [Issue 3709](https://github.com/IntersectMBO/govtool/issues/3709)
 
 ### Changed
+- Adjust top menu (navbar) layout when wallet is not connected [Issue-3682](https://github.com/IntersectMBO/govtool/issues/3682)
 
 ### Removed
 

--- a/govtool/frontend/src/components/atoms/Link.tsx
+++ b/govtool/frontend/src/components/atoms/Link.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { forwardRef, MouseEvent } from "react";
 import { NavLink } from "react-router-dom";
 import { Typography } from "@mui/material";
 import { useCardano } from "@context";
@@ -6,51 +6,54 @@ import { useCardano } from "@context";
 type LinkProps = {
   dataTestId?: string;
   isConnectWallet?: boolean;
-  label: string;
+  label: React.ReactNode;
   navTo: string;
-  onClick?: () => void;
+  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
   size?: "small" | "big";
 };
 
-export const Link: FC<LinkProps> = ({ ...props }) => {
-  const {
-    dataTestId,
-    isConnectWallet,
-    label,
-    navTo,
-    size = "small",
-    onClick,
-  } = props;
-  const { disconnectWallet } = useCardano();
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ ...props }, ref) => {
+    const {
+      dataTestId,
+      isConnectWallet,
+      label,
+      navTo,
+      size = "small",
+      onClick,
+    } = props;
+    const { disconnectWallet } = useCardano();
 
-  const fontSize = {
-    small: 14,
-    big: 22,
-  }[size];
+    const fontSize = {
+      small: 14,
+      big: 22,
+    }[size];
 
-  return (
-    <NavLink
-      data-testid={dataTestId}
-      to={navTo}
-      style={{
-        textDecoration: "none",
-      }}
-      onClick={() => {
-        if (!isConnectWallet) disconnectWallet();
-        if (onClick) onClick();
-      }}
-    >
-      {({ isActive }) => (
-        <Typography
-          sx={{
-            fontSize,
-            fontWeight: isActive && navTo !== "" ? 600 : 500,
-            color: isActive && navTo !== "" ? "#FF640A" : "textBlack",
-          }}
-        >
-          {label}
-        </Typography>
-      )}
-    </NavLink>
-  );
-};
+    return (
+      <NavLink
+        data-testid={dataTestId}
+        to={navTo}
+        style={{
+          textDecoration: "none",
+        }}
+        onClick={(e) => {
+          if (!isConnectWallet) disconnectWallet();
+          if (onClick) onClick(e);
+        }}
+        ref={ref}
+      >
+        {({ isActive }) => (
+          <Typography
+            sx={{
+              fontSize,
+              fontWeight: isActive && navTo !== "" ? 600 : 500,
+              color: isActive && navTo !== "" ? "#FF640A" : "textBlack",
+            }}
+          >
+            {label}
+          </Typography>
+        )}
+      </NavLink>
+    );
+  },
+);

--- a/govtool/frontend/src/consts/navItems.tsx
+++ b/govtool/frontend/src/consts/navItems.tsx
@@ -13,7 +13,18 @@ import {
   // USER_PATHS
 } from "./paths";
 
-export const NAV_ITEMS = [
+export type NavItem = {
+  dataTestId: string;
+  navTo: string;
+  label: string;
+  newTabLink: string | null;
+};
+export type NavMenuItem = {
+  dataTestId: string;
+  label: string;
+  childNavItems?: Array<NavItem>;
+};
+export const NAV_ITEMS: Array<NavItem | NavMenuItem> = [
   {
     dataTestId: "dashboard-link",
     navTo: PATHS.home,
@@ -24,6 +35,7 @@ export const NAV_ITEMS = [
     dataTestId: "drep-directory-link",
     navTo: PATHS.dRepDirectory,
     label: i18n.t("dRepDirectory.title"),
+    newTabLink: null,
   },
   {
     dataTestId: "budget-discussion-link",
@@ -32,22 +44,28 @@ export const NAV_ITEMS = [
     newTabLink: null,
   },
   {
-    dataTestId: "proposed-governance-actions-link",
-    navTo: PDF_PATHS.proposalDiscussion,
-    label: i18n.t("proposalDiscussion.title"),
-    newTabLink: null,
-  },
-  {
-    dataTestId: "governance-actions-link",
-    navTo: PATHS.governanceActions,
-    label: i18n.t("govActions.navTitle"),
-    newTabLink: null,
-  },
-  {
-    dataTestId: "governance-actions-outcomes-link",
-    label: i18n.t("govActions.outcomes.title"),
-    navTo: OUTCOMES_PATHS.governanceActionsOutcomes,
-    newTabLink: null,
+    dataTestId: "governance-actions",
+    label: i18n.t("govActions.title"),
+    childNavItems: [
+      {
+        dataTestId: "proposed-governance-actions-link",
+        navTo: PDF_PATHS.proposalDiscussion,
+        label: i18n.t("proposalDiscussion.title"),
+        newTabLink: null,
+      },
+      {
+        dataTestId: "governance-actions-link",
+        navTo: PATHS.governanceActions,
+        label: i18n.t("govActions.navTitle"),
+        newTabLink: null,
+      },
+      {
+        dataTestId: "governance-actions-outcomes-link",
+        label: i18n.t("govActions.outcomes.title"),
+        navTo: OUTCOMES_PATHS.governanceActionsOutcomes,
+        newTabLink: null,
+      },
+    ],
   },
   {
     dataTestId: "guides-link",

--- a/govtool/frontend/src/i18n/locales/en.json
+++ b/govtool/frontend/src/i18n/locales/en.json
@@ -45,7 +45,7 @@
   "dashboard": {
     "headingOne": "Your Participation",
     "headingTwo": "See Active Governance Actions",
-    "title": "Dashboard",
+    "title": "Home",
     "cards": {
       "drepName": "Drep_name",
       "showTransaction": "Show Transaction",


### PR DESCRIPTION
## List of changes

- Change top menu (navbar) layout when wallet is not connected

<img width="1138" alt="image" src="https://github.com/user-attachments/assets/3c9cd98d-fe87-49ff-a9ed-83d74f89ad36" />
<img width="469" alt="image" src="https://github.com/user-attachments/assets/4b152dfd-fc74-4682-9f8f-56c9a3227b9a" />


## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3682)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
