### PR TITLE
Fix: flaky test 8F  and 3M_1

### DIFF
--- a/tests/govtool-frontend/playwright/lib/forms/dRepForm.ts
+++ b/tests/govtool-frontend/playwright/lib/forms/dRepForm.ts
@@ -232,6 +232,8 @@ export default class DRepForm {
         `${dRepInfo.paymentAddress} is an invalid paymentAddress`,
     }).toBeHidden({ timeout: 60_000 });
     await expect(this.continueBtn).toBeEnabled();
+    // Wait for the form to settle after validation
+    await this.form.waitForTimeout(500);
   }
 
   async inValidateForm(dRepInfo: IDRepInfo) {
@@ -329,5 +331,7 @@ export default class DRepForm {
     }).toBeVisible();
 
     await expect(this.continueBtn).toBeDisabled();
+    // Wait for the form to settle after validation
+    await this.form.waitForTimeout(500);
   }
 }

--- a/tests/govtool-frontend/playwright/tests/8-proposal-discussion/proposalDiscussion.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/8-proposal-discussion/proposalDiscussion.spec.ts
@@ -294,7 +294,8 @@ test.describe("Mocked proposal", () => {
 
   test("8F. Should display all comments with count indication.", async () => {
     await expect(proposalDiscussionDetailsPage.commentCount).toHaveText(
-      mockProposal.data.attributes.prop_comments_number.toString()
+      mockProposal.data.attributes.prop_comments_number.toString(),
+      { timeout: 60_000 }
     );
   });
 });


### PR DESCRIPTION
## List of changes

- Add wait time for the form after validation to settle the validation message
- Increase timeout for comment count 

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
