### PR TITLE
Update GOVERNANCE_ACTION_SUBMISSION.md

### DIFF
--- a/docs/GOVERNANCE_ACTION_SUBMISSION.md
+++ b/docs/GOVERNANCE_ACTION_SUBMISSION.md
@@ -134,7 +134,7 @@ const buildProtocolParameterChangeGovernanceAction: (
   protocolParameterChangeProps: ProtocolParameterChangeProps
 ) => Promise<VotingProposalBuilder | undefined>;
 
-const buildHardForkInitiationGovernanceAction: (
+const buildHardForkGovernanceAction: (
   hardForkInitiationProps: HardForkInitiationProps
 ) => Promise<VotingProposalBuilder | undefined>;
 
@@ -210,7 +210,7 @@ const {
   buildSignSubmitConwayCertTx,
   buildNewInfoGovernanceAction,
   buildProtocolParameterChangeGovernanceAction,
-  buildHardForkInitiationGovernanceAction,
+  buildHardForkGovernanceAction,
   buildTreasuryGovernanceAction,
   buildNewConstitutionGovernanceAction,
   buildUpdateCommitteeGovernanceAction,
@@ -241,7 +241,7 @@ govActionBuilder = await buildProtocolParameterChangeGovernanceAction({
 });
 
 // hash of the previous Governance Action, index of the previous Governance Action, url of the metadata, hash of the metadata, and the major and minor numbers of the hard fork initiation
-govActionBuilder = await buildHardForkInitiationGovernanceAction({
+govActionBuilder = await buildHardForkGovernanceAction({
   prevGovernanceActionHash,
   prevGovernanceActionIndex,
   url,


### PR DESCRIPTION
I believe that “buildHardForkInitiationGovernanceAction” is a remnant of refactoring that did not take place, and the correct function name should be “buildHardForkGovernanceAction”.

https://github.com/IntersectMBO/govtool/blob/c5b9232b47f6484937c5d5e19c5220a5c0bc64cf/govtool/frontend/src/context/wallet.tsx#L262
<img width="586" alt="image" src="https://github.com/user-attachments/assets/c66584b5-3074-48ae-aba7-904c929231e6" />

