### PR TITLE
Fix: navbar governance action dependent test

### DIFF
--- a/tests/govtool-frontend/playwright/lib/pages/outcomesPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/outcomesPage.ts
@@ -251,13 +251,21 @@ export default class OutComesPage {
     return outcomeStatus.some((status) => filters.includes(status));
   }
 
-  async shouldAccessPage() {
+  async shouldAccessPage(isLoggedIn = false) {
     await this.page.goto("/");
 
     if (isMobile(this.page)) {
       await this.page.getByTestId("open-drawer-button").click();
+    } else {
+      if (!isLoggedIn) {
+        await this.page.getByTestId("governance-actions").click();
+      }
     }
     await this.page.getByTestId("governance-actions-outcomes-link").click();
+
+    if (!isMobile(this.page) && !isLoggedIn) {
+      await this.page.getByTestId("governance-actions").click();
+    }
 
     await expect(this.page.getByText(/outcomes/i)).toHaveCount(2);
   }

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.spec.ts
@@ -44,7 +44,7 @@ test("4A_2. Should access Governance Actions page without connecting wallet", as
   await page.goto("/");
   await page.getByTestId("move-to-governance-actions-button").click();
 
-  await expect(page.getByText(/Governance actions/i)).toHaveCount(1);
+  await expect(page.getByText(/Governance actions/i)).toHaveCount(2);
 });
 
 test("4B_2. Should restrict voting for users who are not registered as DReps (without wallet connected)", async ({

--- a/tests/govtool-frontend/playwright/tests/9-outcomes/outcomes.loggedin.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/9-outcomes/outcomes.loggedin.spec.ts
@@ -25,7 +25,7 @@ test.describe("Outcomes page", () => {
   });
 
   test("9A_2. Should access Outcomes page in connected state", async () => {
-    await outcomePage.shouldAccessPage();
+    await outcomePage.shouldAccessPage(true);
   });
   test.describe("outcome sorting and filtering", () => {
     test("9C_1B. Should filter Governance Action Type on governance actions page", async () => {


### PR DESCRIPTION
## List of changes

- Update the navbar navigation test on the disconnect state to expand the governance action drop-down before clicking on proposal/live-voting/outcomes
- Update the governance action counts for the proposal visibility test in the disconnected state
- Fix governance action navigation test through the navbar link for outcomes

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
