### PR TITLE
(fix#3828): unification of sections 'Receiving Address' and 'Amount' in Treasury Withdrawal Governance Action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ changes.
 
 ### Changed
 - Adjust top menu (navbar) layout when wallet is not connected [Issue-3682](https://github.com/IntersectMBO/govtool/issues/3682)
+- Unification of sections 'Receiving Address' and 'Amount' in Treasury Withdrawal Governance Action [Issue-3828](https://github.com/IntersectMBO/govtool/issues/3828)
 
 ### Removed
 

--- a/govtool/frontend/src/components/molecules/GovernanceActionCardTreasuryWithdrawalElement.tsx
+++ b/govtool/frontend/src/components/molecules/GovernanceActionCardTreasuryWithdrawalElement.tsx
@@ -1,10 +1,7 @@
-import { Box } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
-import { Typography, CopyButton } from "@atoms";
 import { correctVoteAdaFormat } from "@utils";
-
-import { useScreenDimension } from "@/hooks";
+import { GovernanceActionCardElement } from "./GovernanceActionCardElement";
 
 type Props = {
   receivingAddress: string;
@@ -16,87 +13,22 @@ export const GovernanceActionCardTreasuryWithdrawalElement = ({
   amount,
 }: Props) => {
   const { t } = useTranslation();
-  const { isMobile } = useScreenDimension();
+
   return (
-    <Box
-      sx={{
-        display: "flex",
-        mb: "4px",
-        flexDirection: "column",
-      }}
-    >
-      <Box sx={{ display: "flex", flexDirection: isMobile ? "column" : "row" }}>
-        <Typography
-          data-testid="receiving-address-label"
-          sx={{
-            width: "160px",
-            fontSize: 14,
-            fontWeight: 600,
-            lineHeight: "20px",
-            color: "neutralGray",
-          }}
-        >
-          {t("govActions.receivingAddress")}
-        </Typography>
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            overflow: "hidden",
-            flexDirection: "row",
-          }}
-        >
-          <Typography
-            data-testid="receiving-address"
-            sx={{
-              ml: isMobile ? 0 : 8,
-              color: "primaryBlue",
-              fontSize: 16,
-              fontWeight: 400,
-              lineHeight: "20px",
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-            }}
-          >
-            {receivingAddress}
-          </Typography>
-          <Box ml={1}>
-            <CopyButton text={receivingAddress} variant="blueThin" />
-          </Box>
-        </Box>
-      </Box>
-      <Box
-        sx={{
-          display: "flex",
-          flexDirection: isMobile ? "column" : "row",
-          mt: "6px",
-        }}
-      >
-        <Typography
-          sx={{
-            width: "160px",
-            fontSize: 14,
-            fontWeight: 600,
-            lineHeight: "20px",
-            color: "neutralGray",
-          }}
-          data-testid="amount-label"
-        >
-          {t("govActions.amount")}
-        </Typography>
-        <Typography
-          data-testid="amount"
-          sx={{
-            ml: isMobile ? 0 : 8,
-            fontSize: 16,
-            fontWeight: 400,
-            lineHeight: "20px",
-          }}
-        >
-          ₳ {correctVoteAdaFormat(amount) ?? 0}
-        </Typography>
-      </Box>
-    </Box>
+    <>
+      <GovernanceActionCardElement
+        label={t("govActions.receivingAddress")}
+        text={receivingAddress}
+        textVariant="oneLine"
+        dataTestId="receiving-address-label"
+        isCopyButton
+      />
+      <GovernanceActionCardElement
+        label={t("govActions.amount")}
+        text={`₳ ${correctVoteAdaFormat(amount) ?? 0}`}
+        textVariant="oneLine"
+        dataTestId="amount"
+      />
+    </>
   );
 };


### PR DESCRIPTION
## List of changes

- Change: Unification of sections 'Receiving Address' and 'Amount' in Treasury Withdrawal Governance Action

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3828)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Changes
![image](https://github.com/user-attachments/assets/e9ccaeb5-1cec-46e1-9a03-9b0d69561c46)
![image](https://github.com/user-attachments/assets/224c228b-5f0d-4ae6-8bca-611abc958cef)
![image](https://github.com/user-attachments/assets/1b7f35ca-e48c-4753-a17b-4b80ec6cb3ab)

