### PR TITLE
fix: unnecessary  addition character appended on wallet.json

### DIFF
--- a/tests/govtool-frontend/playwright/lib/helpers/file.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/file.ts
@@ -1,4 +1,5 @@
-import { readFile, rm, writeFile } from "fs";
+import { faker } from "@faker-js/faker";
+import { readFile, rename, rm, writeFile } from "fs";
 const path = require("path");
 
 const mockFolderPath = path.resolve(__dirname, "../_mock");
@@ -18,6 +19,27 @@ export async function createFile(fileName: string, data?: any) {
       }
     )
   );
+}
+
+export async function renameFile(currentPath: string, newPath: string) {
+  await new Promise<void>((resolve, reject) =>
+    rename(currentPath, newPath, (err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    })
+  );
+}
+
+export async function atomicWriteFile(fileName: string, data: any) {
+  const actualFilePath = `${mockFolderPath}/${fileName}`;
+  const tempFileName = `${faker.person.firstName()}-${faker.string.uuid()}.json`;
+  const tmpPath = `${mockFolderPath}/${tempFileName}`;
+
+  await createFile(tempFileName, data);
+  await renameFile(tmpPath, actualFilePath);
 }
 
 export async function getFile(fileName: string): Promise<any> {

--- a/tests/govtool-frontend/playwright/lib/walletManager.ts
+++ b/tests/govtool-frontend/playwright/lib/walletManager.ts
@@ -1,6 +1,6 @@
 import { StaticWallet } from "@types";
 import { LockInterceptor } from "./lockInterceptor";
-import { createFile, getFile } from "@helpers/file";
+import { atomicWriteFile, createFile, getFile } from "@helpers/file";
 const path = require("path");
 
 const baseFilePath = path.resolve(__dirname, "./_mock");
@@ -73,7 +73,7 @@ class WalletManager {
         wallet.givenName = givenName;
       }
     });
-    await createFile("wallets.json", wallets);
+    await atomicWriteFile("wallets.json", wallets);
   }
 }
 export default WalletManager.getInstance();


### PR DESCRIPTION
## List of changes

- Fix unnecessary addition characters that are appended to the wallet.json file while updating the file. 

## Checklist

- [related issue](https://intersectmbo.github.io/govtool-test-reports/dev/govtool-frontend/21/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
