### PR TITLE
(fix#3326): Typo on Voting panel dates

### DIFF
--- a/govtool/frontend/src/components/molecules/VoteActionForm.tsx
+++ b/govtool/frontend/src/components/molecules/VoteActionForm.tsx
@@ -144,7 +144,10 @@ export const VoteActionForm = ({
               sx={{ lineHeight: "18px", alignSelf: "start" }}
             >
               {t("govActions.castVoteDeadline", {
-                date: expiryDate,
+                date: formatDisplayDate(
+                  expiryDate ?? "",
+                  "yyyy-MM-dd HH:mm:ss",
+                ),
                 epoch: expiryEpochNo,
               })}
             </Typography>

--- a/govtool/frontend/src/i18n/locales/en.json
+++ b/govtool/frontend/src/i18n/locales/en.json
@@ -432,7 +432,7 @@
     },
     "backToGovActions": "Back to Governance Actions",
     "castVote": "<0>You voted {{vote}} on this proposal</0>\non {{date}} (Epoch {{epoch}})",
-    "castVoteDeadline": "You can change your vote up to {{date}} (Epoch {{epoch}})",
+    "castVoteDeadline": "You can change your vote up to {{date}} (UTC, Epoch {{epoch}})",
     "changeVote": "Change vote",
     "changeYourVote": "Change your vote",
     "chooseHowToVote": "Choose how you want to vote:",


### PR DESCRIPTION
## List of changes

- Fix date format in voting panel.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Changes
I added *UTC* to the parentheses because previously `Z` meant Zulu/UTC time.
<img width="1416" alt="image" src="https://github.com/user-attachments/assets/701c7f2d-53f0-4ca7-9e13-2d2040dd686f" />
<img width="504" alt="image" src="https://github.com/user-attachments/assets/c90f5c96-ca82-4d52-aac6-2b820e59363b" />
