### PR TITLE
(fix#3142): Fix missing page titles on subpages: DRep details and Gov Actions details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ changes.
 - Fix blank screen and type error on linkReferences when navigating to edit dRep page that has no links [Issue 3714](https://github.com/IntersectMBO/govtool/issues/3714)
 - Fix adding two link input fields when editing the dRep form when no links are present initially [Issue 3709](https://github.com/IntersectMBO/govtool/issues/3709)
 - Fix images in Governance Action Details are displayed at full width and height without cropping or clipping [Issue 3837](https://github.com/IntersectMBO/govtool/issues/3837)
+- Fix missing page titles on subpages: DRep details and Gov Actions details [Issue 3142](https://github.com/IntersectMBO/govtool/issues/3142)
 
 ### Changed
 - Adjust top menu (navbar) layout when wallet is not connected [Issue-3682](https://github.com/IntersectMBO/govtool/issues/3682)

--- a/govtool/frontend/src/pages/Dashboard.tsx
+++ b/govtool/frontend/src/pages/Dashboard.tsx
@@ -60,7 +60,7 @@ export const Dashboard = () => {
     items.reduce<string | null>(
       (result, item) =>
         result ??
-        (targetPath === item.navTo
+        (targetPath === item.navTo || targetPath.startsWith(`${item.navTo}/`)
           ? item.label
           : item.childNavItems
           ? findNavItem(item.childNavItems, targetPath)


### PR DESCRIPTION
## List of changes

- Fix missing page titles on subpages: DRep details  and Gov Actions details

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3142)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Changes
![image](https://github.com/user-attachments/assets/61c7a3d3-9828-4296-90c0-23f6783e74e2)
![image](https://github.com/user-attachments/assets/7000b737-9a5c-4d03-8263-7e06051b6d1e)

