### PR TITLE
(fix#3615) fix  invalid css file for markdown tables

### DIFF
--- a/govtool/frontend/src/components/molecules/tableMarkdown.css
+++ b/govtool/frontend/src/components/molecules/tableMarkdown.css
@@ -1,28 +1,26 @@
-.markdown {
-  & table {
-    display: block;
-    overflow-x: auto;
-    margin: 32px 0;
-    border-spacing: 0;
-    border-collapse: collapse;
-    max-width: 100%;
+.markdown table {
+  display: block;
+  overflow-x: auto;
+  margin: 32px 0;
+  border-spacing: 0;
+  border-collapse: collapse;
+  max-width: 100%;
+}
 
-    & thead {
-      background-color: #d6e2ff80;
-    }
+.markdown thead {
+  background-color: #d6e2ff80;
+}
 
-    & th,
-    & td {
-      padding: 6px 13px;
-      border: 1px solid #d6e2ff;
-    }
+.markdown th,
+.markdown td {
+  padding: 6px 13px;
+  border: 1px solid #d6e2ff;
+}
 
-    & td > :last-child {
-      margin-bottom: 0;
-    }
+.markdown td > :last-child {
+  margin-bottom: 0;
+}
 
-    & tr:nth-child(2n) {
-      background-color: #d6e2ff80;
-    }
-  }
+.markdown tr:nth-child(2n) {
+  background-color: #d6e2ff80;
 }


### PR DESCRIPTION
It seems that the changes from from https://github.com/IntersectMBO/govtool/pull/3630 never affected the tables.

- [related issue](https://github.com/IntersectMBO/govtool/issues/3615)