### PR TITLE
(fix) Hotfix for calculations on SPOs on gov actions

### DIFF
--- a/govtool/backend/sql/get-network-total-stake.sql
+++ b/govtool/backend/sql/get-network-total-stake.sql
@@ -67,8 +67,16 @@ TotalStakeControlledByActiveDReps AS (
         AND COALESCE(rd.deposit, 0) >= 0
         AND ((DRepActivity.epoch_no - GREATEST(COALESCE(lve.epoch_no, 0), COALESCE(rd.epoch_no, 0))) <= DRepActivity.drep_activity)
 ),
+-- it's a hotfix for duplication issue https://github.com/IntersectMBO/cardano-db-sync/issues/1986
+LatestPoolStat AS (
+    SELECT DISTINCT ON (pool_hash_id) *
+    FROM
+        pool_stat
+    WHERE
+        epoch_no = (SELECT MAX(no) FROM epoch)
+),
 TotalStakeControlledBySPOs AS (
-    SELECT SUM(ps.stake)::bigint AS total FROM pool_stat ps WHERE ps.epoch_no = (SELECT no FROM CurrentEpoch)
+    SELECT SUM(ps.stake)::bigint AS total FROM LatestPoolStat ps WHERE ps.epoch_no = (SELECT no FROM CurrentEpoch)
 ),
 AlwaysAbstainVotingPower AS (
     SELECT COALESCE((SELECT amount FROM drep_hash

--- a/govtool/frontend/src/components/molecules/VotesSubmitted.tsx
+++ b/govtool/frontend/src/components/molecules/VotesSubmitted.tsx
@@ -109,14 +109,17 @@ export const VotesSubmitted = ({
     100 - (dRepYesVotesPercentage ?? 0) - (dRepNoVotesPercentage ?? 0);
 
   const poolYesVotesPercentage =
-    poolYesVotes + poolNoVotes
-      ? (poolYesVotes / (poolYesVotes + poolNoVotes)) * 100
+    typeof poolYesVotes === "number" &&
+    typeof networkTotalStake?.totalStakeControlledBySPOs === "number" &&
+    networkTotalStake.totalStakeControlledBySPOs > 0
+      ? (poolYesVotes / networkTotalStake.totalStakeControlledBySPOs) * 100
       : undefined;
-  const poolNoVotesPercentage = poolYesVotesPercentage
-    ? 100 - poolYesVotesPercentage
-    : poolNoVotes
-    ? 100
-    : undefined;
+  const poolNoVotesPercentage =
+    typeof poolNoVotes === "number" &&
+    typeof networkTotalStake?.totalStakeControlledBySPOs === "number" &&
+    networkTotalStake.totalStakeControlledBySPOs > 0
+      ? (poolNoVotes / networkTotalStake.totalStakeControlledBySPOs) * 100
+      : undefined;
 
   const ccYesVotesPercentage = noOfCommitteeMembers
     ? (ccYesVotes / noOfCommitteeMembers) * 100


### PR DESCRIPTION
https://github.com/IntersectMBO/cardano-db-sync/issues/1986

Those are two currently live gov actions votes:
<img width="1424" alt="image" src="https://github.com/user-attachments/assets/a9893926-6e2b-4f0d-9100-9b607ed1efe5" />
<img width="1425" alt="image" src="https://github.com/user-attachments/assets/6c15194a-7d34-4881-b6d2-1d1bf24970cb" />