### PR TITLE
(fix#3879): broken parameters on Live Voting page

### DIFF
--- a/govtool/frontend/src/components/molecules/GovernanceActionNewCommitteeDetailsTabContent.tsx
+++ b/govtool/frontend/src/components/molecules/GovernanceActionNewCommitteeDetailsTabContent.tsx
@@ -13,6 +13,12 @@ type CCMember = {
   newExpirationEpoch?: number;
 };
 
+function isArrayOfStrings(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
 export const GovernanceActionNewCommitteeDetailsTabContent = ({
   details,
 }: Pick<ProposalData, "details">) => {
@@ -37,6 +43,10 @@ export const GovernanceActionNewCommitteeDetailsTabContent = ({
       expirationEpoch: member.expirationEpoch,
       newExpirationEpoch: member.newExpirationEpoch,
     }));
+
+  const membersToBeRemoved = isArrayOfStrings(details?.membersToBeRemoved)
+    ? details.membersToBeRemoved
+    : [];
 
   return (
     <Box>
@@ -78,7 +88,7 @@ export const GovernanceActionNewCommitteeDetailsTabContent = ({
           ))}
         </Box>
       )}
-      {(details?.membersToBeRemoved as string[]).length > 0 && (
+      {membersToBeRemoved.length > 0 && (
         <Box mb="32px">
           <Typography
             sx={{
@@ -93,8 +103,8 @@ export const GovernanceActionNewCommitteeDetailsTabContent = ({
           >
             {t("govActions.membersToBeRemoved")}
           </Typography>
-          {(details?.membersToBeRemoved as string[]).map((hash) => (
-            <Box display="flex" flexDirection="row">
+          {membersToBeRemoved.map((hash) => (
+            <Box display="flex" flexDirection="row" key={hash}>
               <Typography
                 sx={{
                   fontSize: 16,

--- a/govtool/frontend/src/components/organisms/DrawerMobile.tsx
+++ b/govtool/frontend/src/components/organisms/DrawerMobile.tsx
@@ -90,6 +90,7 @@ export const DrawerMobile = ({
                     <MenuNavItem
                       closeDrawer={() => setIsDrawerOpen(false)}
                       navItem={navItem}
+                      key={navItem.label}
                     />
                   );
                 }


### PR DESCRIPTION
## List of changes

- Fix broken parameters on Live Voting page when `membersToBeRemoved` contained odd values

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Explanation
The problem was having a null value in `membersToBeRemoved`, where we expect to have an array of strings:
<img width="770" alt="image" src="https://github.com/user-attachments/assets/aca09995-c9d7-41c6-b992-717c39684e5d" />

Now even with such values, the site works:
<img width="1422" alt="image" src="https://github.com/user-attachments/assets/0b806460-d1db-4bc0-a288-1fab6b0f8101" />
