### PR TITLE
Revert "(fix) Hotfix for calculations on SPOs on gov actions"

### DIFF
--- a/govtool/backend/sql/get-network-total-stake.sql
+++ b/govtool/backend/sql/get-network-total-stake.sql
@@ -67,16 +67,8 @@ TotalStakeControlledByActiveDReps AS (
         AND COALESCE(rd.deposit, 0) >= 0
         AND ((DRepActivity.epoch_no - GREATEST(COALESCE(lve.epoch_no, 0), COALESCE(rd.epoch_no, 0))) <= DRepActivity.drep_activity)
 ),
--- it's a hotfix for duplication issue https://github.com/IntersectMBO/cardano-db-sync/issues/1986
-LatestPoolStat AS (
-    SELECT DISTINCT ON (pool_hash_id) *
-    FROM
-        pool_stat
-    WHERE
-        epoch_no = (SELECT MAX(no) FROM epoch)
-),
 TotalStakeControlledBySPOs AS (
-    SELECT SUM(ps.stake)::bigint AS total FROM LatestPoolStat ps WHERE ps.epoch_no = (SELECT no FROM CurrentEpoch)
+    SELECT SUM(ps.stake)::bigint AS total FROM pool_stat ps WHERE ps.epoch_no = (SELECT no FROM CurrentEpoch)
 ),
 AlwaysAbstainVotingPower AS (
     SELECT COALESCE((SELECT amount FROM drep_hash

--- a/govtool/frontend/src/components/molecules/VotesSubmitted.tsx
+++ b/govtool/frontend/src/components/molecules/VotesSubmitted.tsx
@@ -109,17 +109,14 @@ export const VotesSubmitted = ({
     100 - (dRepYesVotesPercentage ?? 0) - (dRepNoVotesPercentage ?? 0);
 
   const poolYesVotesPercentage =
-    typeof poolYesVotes === "number" &&
-    typeof networkTotalStake?.totalStakeControlledBySPOs === "number" &&
-    networkTotalStake.totalStakeControlledBySPOs > 0
-      ? (poolYesVotes / networkTotalStake.totalStakeControlledBySPOs) * 100
+    poolYesVotes + poolNoVotes
+      ? (poolYesVotes / (poolYesVotes + poolNoVotes)) * 100
       : undefined;
-  const poolNoVotesPercentage =
-    typeof poolNoVotes === "number" &&
-    typeof networkTotalStake?.totalStakeControlledBySPOs === "number" &&
-    networkTotalStake.totalStakeControlledBySPOs > 0
-      ? (poolNoVotes / networkTotalStake.totalStakeControlledBySPOs) * 100
-      : undefined;
+  const poolNoVotesPercentage = poolYesVotesPercentage
+    ? 100 - poolYesVotesPercentage
+    : poolNoVotes
+    ? 100
+    : undefined;
 
   const ccYesVotesPercentage = noOfCommitteeMembers
     ? (ccYesVotes / noOfCommitteeMembers) * 100


### PR DESCRIPTION
Reverts IntersectMBO/govtool#3878

We are reverting the changes since the dbsync was able to fix it on their end. 