### PR TITLE
(fix#3881): update how we display SPO votes

### DIFF
--- a/govtool/frontend/src/components/molecules/VotesSubmitted.tsx
+++ b/govtool/frontend/src/components/molecules/VotesSubmitted.tsx
@@ -117,6 +117,11 @@ export const VotesSubmitted = ({
     : poolNoVotes
     ? 100
     : undefined;
+  const poolNotVotedVotes =
+    typeof networkTotalStake?.totalStakeControlledBySPOs === "number"
+      ? networkTotalStake.totalStakeControlledBySPOs -
+        (poolYesVotes + poolNoVotes + poolAbstainVotes)
+      : undefined;
 
   const ccYesVotesPercentage = noOfCommitteeMembers
     ? (ccYesVotes / noOfCommitteeMembers) * 100
@@ -200,6 +205,7 @@ export const VotesSubmitted = ({
             noVotes={poolNoVotes}
             noVotesPercentage={poolNoVotesPercentage}
             abstainVotes={poolAbstainVotes}
+            notVotedVotes={poolNotVotedVotes}
             threshold={
               (() => {
                 const votingThresholdKey = getGovActionVotingThresholdKey({

--- a/govtool/frontend/src/components/molecules/VotesSubmitted.tsx
+++ b/govtool/frontend/src/components/molecules/VotesSubmitted.tsx
@@ -109,14 +109,17 @@ export const VotesSubmitted = ({
     100 - (dRepYesVotesPercentage ?? 0) - (dRepNoVotesPercentage ?? 0);
 
   const poolYesVotesPercentage =
-    poolYesVotes + poolNoVotes
-      ? (poolYesVotes / (poolYesVotes + poolNoVotes)) * 100
+    typeof poolYesVotes === "number" &&
+    typeof networkTotalStake?.totalStakeControlledBySPOs === "number" &&
+    networkTotalStake.totalStakeControlledBySPOs > 0
+      ? (poolYesVotes / networkTotalStake.totalStakeControlledBySPOs) * 100
       : undefined;
-  const poolNoVotesPercentage = poolYesVotesPercentage
-    ? 100 - poolYesVotesPercentage
-    : poolNoVotes
-    ? 100
-    : undefined;
+  const poolNoVotesPercentage =
+    typeof poolNoVotes === "number" &&
+    typeof networkTotalStake?.totalStakeControlledBySPOs === "number" &&
+    networkTotalStake.totalStakeControlledBySPOs > 0
+      ? (poolNoVotes / networkTotalStake.totalStakeControlledBySPOs) * 100
+      : undefined;
   const poolNotVotedVotes =
     typeof networkTotalStake?.totalStakeControlledBySPOs === "number"
       ? networkTotalStake.totalStakeControlledBySPOs -


### PR DESCRIPTION
## List of changes

- add 'not voted' stake for SPO's pool
- fix SPO's pool calculation % based on the whole group (yes/no/abstain/not-voted)

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3881)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Changes
<img width="1426" height="718" alt="image" src="https://github.com/user-attachments/assets/ecc211a7-6329-4504-836f-2f301eeb1a61" />

