### PR TITLE
[hotfix] Add info box to authors section on gov actions explaining the special case of MLabs withdrawal

### DIFF
--- a/govtool/frontend/src/i18n/locales/en.json
+++ b/govtool/frontend/src/i18n/locales/en.json
@@ -482,6 +482,12 @@
     "additionalInformationAboutYourVote": "Additional information about your vote",
     "provideNewContextAboutYourVote": "Provide new context about your vote",
     "rationale": "Rationale",
+    "safeModeInfoBox": {
+      "title": "How this Author got verified?",
+      "line1": "A metadata formatting issue caused only part of the data to be signed, preventing automatic verification — the signature is valid and can be manually confirmed.",
+      "line2": "<0>Govtool have manually verified the signature confirming this Treasury action is genuinely coming from Intersect</0> and has marked it accordingly to make it explicit to DReps.",
+      "link": "More details"
+    },
     "seeExternalData": "See external data",
     "selectDifferentOption": "Select a different option to change your vote",
     "showVotes": "Show votes",


### PR DESCRIPTION
Working only for `3cf29192a0ee1a77985054072edcdb566ac14707730637c4635d8fb6813cb4c9`
<img width="1444" height="612" alt="image" src="https://github.com/user-attachments/assets/9c1e2116-d31b-44ab-94d6-50c995069cf8" />

<img width="1453" height="564" alt="image" src="https://github.com/user-attachments/assets/ad502ae8-a7cf-4dc4-883a-30109aead3e4" />
