### PR TITLE
Solve get-network-metrics returning 500 on preview

### DIFF
--- a/govtool/backend/sql/get-network-metrics.sql
+++ b/govtool/backend/sql/get-network-metrics.sql
@@ -189,6 +189,7 @@ CommitteeThreshold AS (
     where
             ( c.gov_action_proposal_id = (Select id from LatestGovAction))
         OR  ( c.gov_action_proposal_id IS NULL)
+            order by gov_action_proposal_id nulls last
 )
 SELECT
     UniqueDelegators.count AS unique_delegators,


### PR DESCRIPTION
## List of changes

- Fix network-metrics returning  500 on preview network

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
