### PR TITLE
fix: comment count issue

### DIFF
--- a/tests/govtool-frontend/playwright/tests/11-proposal-budget/proposalBudget.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/11-proposal-budget/proposalBudget.spec.ts
@@ -247,19 +247,22 @@ test("11E. Should view comments with count indications on a budget proposal", as
 
   const actualTotalComments =
     await budgetDiscussionDetailsPage.totalComments.textContent();
-  const expectedTotalComments =
-    proposalResponse.data.attributes.prop_comments_number.toString();
+  let expectedTotalComments =
+    proposalResponse.data.attributes.prop_comments_number;
   const isEqual = actualTotalComments === expectedTotalComments;
 
   const currentPageUrl = budgetDiscussionDetailsPage.currentPage.url();
 
   const proposalId = extractProposalIdFromUrl(currentPageUrl);
+  if (expectedTotalComments > 99) {
+    expectedTotalComments = "99+";
+  }
 
   await expect(
     budgetDiscussionDetailsPage.totalComments,
     !isEqual &&
       `Total comments do not match in ${environments.frontendUrl}/budget_discussion/${proposalId}`
-  ).toHaveText(expectedTotalComments);
+  ).toHaveText(expectedTotalComments.toString());
 });
 
 test.describe("Restricted access to interact budget proposal", () => {

--- a/tests/govtool-frontend/playwright/tests/8-proposal-discussion/proposalDiscussion.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/8-proposal-discussion/proposalDiscussion.spec.ts
@@ -293,8 +293,12 @@ test.describe("Mocked proposal", () => {
   });
 
   test("8F. Should display all comments with count indication.", async () => {
+    let commentCount = mockProposal.data.attributes.prop_comments_number;
+    if (commentCount > 99) {
+      commentCount = "99+";
+    }
     await expect(proposalDiscussionDetailsPage.commentCount).toHaveText(
-      mockProposal.data.attributes.prop_comments_number.toString(),
+      commentCount.toString(),
       { timeout: 60_000 }
     );
   });


### PR DESCRIPTION
## List of changes

-  fix: update comment count display to show "99+" for counts exceeding 99

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
