### PR TITLE
fix(#3918): disappearing governance actions for the same tx hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ changes.
 
 ### Fixed
 
+- Fix disappearing proposals in the governance actions list for the same tx hashes [Issue 3918](https://github.com/IntersectMBO/govtool/issues/3918)
+
 ### Changed
 
 ### Removed

--- a/govtool/frontend/src/components/organisms/DashboardGovernanceActions.tsx
+++ b/govtool/frontend/src/components/organisms/DashboardGovernanceActions.tsx
@@ -88,8 +88,12 @@ export const DashboardGovernanceActions = () => {
   const prevFilters = usePrevious(queryFilters);
   const prevSorting = usePrevious(chosenSorting);
 
-  const stableFilters = isAdjusting ? prevFilters ?? queryFilters : queryFilters;
-  const stableSorting = isAdjusting ? prevSorting ?? chosenSorting : chosenSorting;
+  const stableFilters = isAdjusting
+    ? prevFilters ?? queryFilters
+    : queryFilters;
+  const stableSorting = isAdjusting
+    ? prevSorting ?? chosenSorting
+    : chosenSorting;
 
   const { proposals, isProposalsLoading } = useGetProposalsQuery({
     filters: stableFilters,
@@ -109,7 +113,9 @@ export const DashboardGovernanceActions = () => {
       const filteredActions = proposalCategory.actions.filter((action) => {
         const hasVote = votes?.some((voteCategory) =>
           voteCategory.actions.some(
-            (voteAction) => voteAction.proposal.txHash === action.txHash,
+            (voteAction) =>
+              voteAction.proposal.txHash === action.txHash &&
+              voteAction.proposal.index === action.index,
           ),
         );
 


### PR DESCRIPTION
## List of changes

- fix by comparing the additional cert index over the GAs under the same tx hash

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3918)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
