### PR TITLE
(fix#3954): Incorrect Display of New Committee Parameters in Governance Action Details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ changes.
 ### Fixed
 
 - Fix disappearing proposals in the governance actions list for the same tx hashes [Issue 3918](https://github.com/IntersectMBO/govtool/issues/3918)
+- Fix incorrect display of new committee parameters in Governance Action details [Issue 3954](https://github.com/IntersectMBO/govtool/issues/3954)
 
 ### Changed
 

--- a/govtool/frontend/src/i18n/locales/en.json
+++ b/govtool/frontend/src/i18n/locales/en.json
@@ -479,7 +479,7 @@
     "membersToBeRemovedFromTheCommittee": "Members to be removed from the Committee",
     "membersToBeAddedToTheCommittee": "Members to be added to the Committee",
     "changeToTermsOfExistingMembers": "Change to terms of existing members",
-    "changeToTermsEpochs": "To {{epochTo}} epoch {{epochFrom}} epoch",
+    "changeToTermsEpochs": "To {{epochTo}} epoch, from {{epochFrom}} epoch",
     "newThresholdValue": "New threshold value",
     "protocolParamsDetails": {
       "existing": "Existing",


### PR DESCRIPTION
## List of changes

- Fix incorrect Display of New Committee Parameters in Governance Action Details (based on [govtool-outcomes-pilar](https://github.com/IntersectMBO/govtool-outcomes-pillar/commit/7b79330371da216062f48d49d671c86f3f4bf495#diff-f292d404e9ed1a31adfe76bc298e626f942a937b1387561341c05abffc6e967eL35) and [govtool-outcomes-pilar](https://github.com/IntersectMBO/govtool-outcomes-pillar/commit/ddff3c6d04b48e0b37ada8d0b52702fabaf5ed1b))

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3954)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Changes
<img width="1452" height="806" alt="image" src="https://github.com/user-attachments/assets/f31060fd-19c4-4779-ac5a-bc6147c786de" />

https://p80-z78acf3c2-zded6a792-gtw.z937eb260.rustrocks.fr/outcomes/governance_actions/77cc6292907df30d4340aa389dda453ea03aae1aa18a71c1856ac10851498188#0
<img width="1640" height="941" alt="image" src="https://github.com/user-attachments/assets/c1ff52fa-0021-41d8-9d43-dcb0102b1695" />


## Additional Context
>The values to be added and removed are constitutional committee cold credentials, some of these credentials are script-based some of these are key-based when encoded like this (Bech32) following the CIP-129 standard it is hard to tell which are script-based and which are >key-based we can use [govIdInspector](https://cardanoscan.io/govIdInspector) to inspect these and check them

>To determine which type of credential is being using check [govIdInspector](https://preview.cardanoscan.io/govIdInspector) which is an implementation of [CIP-129](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0129)
where for an id the tool will say Type: SCRIPT for script-based and Type: ADDRESS for key-based
or alternatively for CC cold credentials, it is 12 prefix to hex encoded key hash AND 13 prefix to hex encoded script hash
