### PR TITLE
Fix: handle ipfs link for vote context validation

### DIFF
--- a/govtool/frontend/src/hooks/queries/useGetVoteContextTextFromFile.ts
+++ b/govtool/frontend/src/hooks/queries/useGetVoteContextTextFromFile.ts
@@ -10,6 +10,10 @@ export const useGetVoteContextTextFromFile = (url: string | undefined,
   const { dRepID } = useCardano();
   const { voter } = useGetVoterInfo();
 
+  if (url && url.startsWith("ipfs://")) {
+      url = url.replace("ipfs://", "https://ipfs.io/ipfs/");
+  }
+
   const { data, isLoading } = useQuery(
   [QUERY_KEYS.useGetVoteContextFromFile, url],
   () => getVoteContextTextFromFile(url, contextHash),


### PR DESCRIPTION
Metadata validation service doesn't support `ipfs://...` links. 

## List of changes
- Fix metadata validation url for ipfs links

## Checklist
- https://github.com/IntersectMBO/govtool/issues/3934
- [x] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
