### PR TITLE
Update Vote Anchor Related Voting Tests.

### DIFF
--- a/govtool/frontend/src/components/molecules/VoteActionForm.tsx
+++ b/govtool/frontend/src/components/molecules/VoteActionForm.tsx
@@ -275,7 +275,7 @@ export const VoteActionForm = ({
               border: !showWholeVoteContext ? "1px solid #E1E1E1" : "none",
               borderRadius: "4px",
               backgroundColor: !showWholeVoteContext ? fadedPurple.c50 : "transparent",
-              padding: 2,
+              padding: 2
             }}
               >
                 <Typography
@@ -292,6 +292,7 @@ export const VoteActionForm = ({
                   WebkitLineClamp: 2,
                 }),
               }}
+                  data-testid="vote-rationale-context"
                 >
                   {finalVoteContextText}
                 </Typography>
@@ -316,7 +317,7 @@ export const VoteActionForm = ({
             }}
                     disableRipple
                     variant="text"
-                    data-testid="external-modal-button"
+                    data-testid="show-more-button"
                   >
                     <Typography
                       variant="body2"

--- a/govtool/frontend/src/components/organisms/VoteContext/VoteContextChoice.tsx
+++ b/govtool/frontend/src/components/organisms/VoteContext/VoteContextChoice.tsx
@@ -70,6 +70,7 @@ export const VoteContextChoice = ({
           variant="outlined"
           onClick={handleLetGovToolStore}
           sx={{ width: isMobile ? "100%" : "259px", whiteSpace: "nowrap", height: "48px", fontWeight: "500" }}
+          data-testid="govtool-pins-data-to-ipfs-option-button"
         >
           {t("createGovernanceAction.govToolPinsDataToIPFS")}
         </Button>
@@ -77,6 +78,7 @@ export const VoteContextChoice = ({
           variant="outlined"
           onClick={handleStoreItMyself}
           sx={{ width: isMobile ? "100%" : "287px", whiteSpace: "nowrap", height: "48px", fontWeight: "500" }}
+          data-testid="download-and-store-yourself-option-button"
         >
           {t("createGovernanceAction.downloadAndStoreYourself")}
         </Button>

--- a/tests/govtool-frontend/playwright/lib/helpers/waitedLoop.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/waitedLoop.ts
@@ -9,7 +9,7 @@ export async function waitedLoop(
   const startTime = Date.now();
   while (Date.now() - startTime < timeout) {
     if (await conditionFn()) return true;
-    Logger.info("Retring the function");
+    Logger.info("Retrying the function");
     await new Promise((resolve) => setTimeout(resolve, interval));
   }
   return false;
@@ -36,9 +36,10 @@ export async function functionWaitedAssert(
     } catch (error) {
       if (Date.now() - startTime >= timeout) {
         const errorMessage = options.message || error.message;
+        console.log(errorMessage);
         expect(false, { message: errorMessage }).toBe(true);
       }
-      Logger.info(`Retring the function ${name}`);
+      Logger.info(`Retrying the function ${name}`);
       await new Promise((resolve) => setTimeout(resolve, interval));
     }
   }

--- a/tests/govtool-frontend/playwright/lib/pages/governanceActionDetailsPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/governanceActionDetailsPage.ts
@@ -21,7 +21,6 @@ export default class GovernanceActionDetailsPage {
   readonly externalModalBtn = this.page.getByTestId("external-modal-button");
   readonly governanceActionId = this.page.getByText("Governance Action ID:");
 
-  readonly contextBtn = this.page.getByTestId("provide-context-button");
   readonly metadataDownloadBtn = this.page.getByTestId(
     "metadata-download-button"
   );
@@ -172,5 +171,6 @@ export default class GovernanceActionDetailsPage {
   async reVote() {
     await this.noVoteRadio.click();
     await this.changeVoteBtn.click();
+    await this.confirmModalBtn.click();
   }
 }

--- a/tests/govtool-frontend/playwright/lib/pages/governanceActionDetailsPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/governanceActionDetailsPage.ts
@@ -79,7 +79,7 @@ export default class GovernanceActionDetailsPage {
   }
 
   @withTxConfirmation
-  async vote(context?: string, isAlreadyVoted: boolean = false) {
+  async vote(context?: string, isAlreadyVoted: boolean = false , useIPFSforStorage : boolean = false ){
     if (!isAlreadyVoted) {
       await this.yesVoteRadio.click();
     }
@@ -87,30 +87,33 @@ export default class GovernanceActionDetailsPage {
     await this.voteBtn.click()
 
     if (context) {
-      // await this.contextBtn.click();
       await this.contextInput.fill(context);
 
       this.confirmModalBtn.click()
 
-      await this.downloadAndStoreYourselfOptionBtn.click()
-      
-      await this.page.getByRole("checkbox").click();
-      await this.confirmModalBtn.click();
+      if (useIPFSforStorage) {
+        await this.govtoolPinsDatatoIpfsBtn.click()
+      } else {
 
-      this.metadataDownloadBtn.click();
-      const voteMetadata = await this.downloadVoteMetadata();
-      const url = await metadataBucketService.uploadMetadata(
-        voteMetadata.name,
-        voteMetadata.data
-      );
-
-      await this.metadataUrlInput.fill(url);
+        await this.downloadAndStoreYourselfOptionBtn.click()
+        await this.page.getByRole("checkbox").click();
+        await this.confirmModalBtn.click();
+  
+        this.metadataDownloadBtn.click();
+        const voteMetadata = await this.downloadVoteMetadata();
+        const url = await metadataBucketService.uploadMetadata(
+          voteMetadata.name,
+          voteMetadata.data
+        );  
+        await this.metadataUrlInput.fill(url);
+      }
       await this.confirmModalBtn.click();
       await this.page.getByTestId("go-to-vote-modal-button").click();
-    }
 
-    // const isVoteButtonEnabled = await this.voteBtn.isEnabled();
-    // await this.voteBtn.click()
+    }
+    else {
+      await this.confirmModalBtn.click()
+    }
   }
 
   async getDRepNotVoted(

--- a/tests/govtool-frontend/playwright/lib/pages/governanceActionDetailsPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/governanceActionDetailsPage.ts
@@ -31,6 +31,9 @@ export default class GovernanceActionDetailsPage {
   readonly continueModalBtn = this.page.getByTestId("continue-modal-button");
   readonly confirmModalBtn = this.page.getByTestId("confirm-modal-button");
 
+  readonly downloadAndStoreYourselfOptionBtn = this.page.getByTestId("download-and-store-yourself-option-button")
+  readonly govtoolPinsDatatoIpfsBtn = this.page.getByTestId("govtool-pins-data-to-ipfs-option-button")
+
   readonly voteSuccessModal = this.page.getByTestId("alert-success");
   readonly externalLinkModal = this.page.getByTestId("external-link-modal");
 
@@ -81,10 +84,16 @@ export default class GovernanceActionDetailsPage {
       await this.yesVoteRadio.click();
     }
 
+    await this.voteBtn.click()
+
     if (context) {
-      await this.contextBtn.click();
+      // await this.contextBtn.click();
       await this.contextInput.fill(context);
-      await this.confirmModalBtn.click();
+
+      this.confirmModalBtn.click()
+
+      await this.downloadAndStoreYourselfOptionBtn.click()
+      
       await this.page.getByRole("checkbox").click();
       await this.confirmModalBtn.click();
 
@@ -100,13 +109,8 @@ export default class GovernanceActionDetailsPage {
       await this.page.getByTestId("go-to-vote-modal-button").click();
     }
 
-    const isVoteButtonEnabled = await this.voteBtn.isEnabled();
-
-    await expect(this.voteBtn, {
-      message: !isVoteButtonEnabled && "Vote button is not enabled",
-    }).toBeEnabled({ timeout: 60_000 });
-
-    await this.voteBtn.click();
+    // const isVoteButtonEnabled = await this.voteBtn.isEnabled();
+    // await this.voteBtn.click()
   }
 
   async getDRepNotVoted(

--- a/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
@@ -55,9 +55,9 @@ export default class GovernanceActionsPage {
   async viewFirstProposalByGovernanceAction(
     governanceAction: GovernanceActionType
   ): Promise<GovernanceActionDetailsPage> {
-    const proposalCard = this.page
-      .getByTestId(`govaction-${governanceAction}-card`)
-      .first();
+     const proposalCard = this.page
+          .locator('[data-testid^="govaction-"][data-testid$="-card"]')
+          .first();
 
     const isVisible = await proposalCard.isVisible();
 
@@ -74,6 +74,21 @@ export default class GovernanceActionsPage {
       );
       return null;
     }
+  }
+
+  async getFirstProposal(
+    governanceAction: GovernanceActionType
+  ) {
+    await functionWaitedAssert(
+      async () => {
+        const proposalCard = this.page
+          .locator('[data-testid^="govaction-"][data-testid$="-card"]')
+          .first();
+
+        await expect(proposalCard
+          .locator('[data-testid^="govaction-"][data-testid$="-view-detail"]')
+          .first()).toBeVisible()
+      }, { name: "Retrying to get the first proposal" });
   }
 
   async viewVotedProposal(
@@ -122,7 +137,7 @@ export default class GovernanceActionsPage {
           expect(
             hasFilter,
             hasFilter == false &&
-              `A proposal card does not contain any of the ${filters}`
+            `A proposal card does not contain any of the ${filters}`
           ).toBe(true);
         }
       }

--- a/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/governanceActionsPage.ts
@@ -77,7 +77,6 @@ export default class GovernanceActionsPage {
   }
 
   async getFirstProposal(
-    governanceAction: GovernanceActionType
   ) {
     await functionWaitedAssert(
       async () => {

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -42,18 +42,12 @@ test.describe("Logged in DReps", () => {
       timeout: 60_000,
     });
 
-    await expect(
-      page.getByTestId("dRep-id-display-card-dashboard")
-    ).toContainText(dRep01Wallet.dRepId, { timeout: 60_000 });
-
+    
     const governanceActionsPage = new GovernanceActionsPage(page);
-
+    
     await governanceActionsPage.goto();
-
-    await expect(page.getByText(/info action/i).first()).toBeVisible({
-      timeout: 60_000,
-    });
-
+    
+    await governanceActionsPage.getFirstProposal(GovernanceActionType.InfoAction);
     const governanceActionDetailsPage =
       await governanceActionsPage.viewFirstProposalByGovernanceAction(
         GovernanceActionType.InfoAction

--- a/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/3-drep-registration/dRepRegistration.dRep.spec.ts
@@ -47,7 +47,7 @@ test.describe("Logged in DReps", () => {
     
     await governanceActionsPage.goto();
     
-    await governanceActionsPage.getFirstProposal(GovernanceActionType.InfoAction);
+    await governanceActionsPage.getFirstProposal();
     const governanceActionDetailsPage =
       await governanceActionsPage.viewFirstProposalByGovernanceAction(
         GovernanceActionType.InfoAction

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
@@ -106,9 +106,7 @@ test.describe("Temporary DReps", async () => {
 
   test.beforeEach(async ({ page, browser }) => {
     const wallet = await walletManager.popWallet("registeredDRep");
-
     const tempDRepAuth = await createTempDRepAuth(page, wallet);
-
     dRepPage = await createNewPageWithWallet(browser, {
       storageState: tempDRepAuth,
       wallet,
@@ -116,32 +114,39 @@ test.describe("Temporary DReps", async () => {
     });
   });
 
-  test("4J. Should include metadata anchor in the vote transaction", async ({}, testInfo) => {
+  const verifyVoteWithMetadata = async (testInfo: any, useGovToolIPFS: boolean = false) => {
     test.setTimeout(testInfo.timeout + environments.txTimeOut);
-
+    
     const govActionsPage = new GovernanceActionsPage(dRepPage);
     await govActionsPage.goto();
-
+    
     const govActionDetailsPage = await govActionsPage.viewFirstProposal();
-
-    const fakerContext = faker.lorem.sentence(200)
-    await govActionDetailsPage.vote(fakerContext);
-
-    await dRepPage.reload();1
-    await dRepPage.waitForTimeout(5_000);1
-
+    const fakerContext = faker.lorem.sentence(200);
+    
+    if (useGovToolIPFS) {
+      await govActionDetailsPage.vote(fakerContext, false, true);
+    } else {
+      await govActionDetailsPage.vote(fakerContext);
+    }
+    
+    await dRepPage.reload();
+    await dRepPage.waitForTimeout(5_000);
     await govActionsPage.votedTab.click();
     
-    const votedGovActionDetailsPage =  await govActionsPage.viewFirstVotedProposal();
-
-    await votedGovActionDetailsPage.currentPage.getByTestId("show-more-button").click()
-
-    await votedGovActionDetailsPage.currentPage.waitForTimeout(2000)
-
-    const voteRationaleContext = await votedGovActionDetailsPage.currentPage.getByTestId("vote-rationale-context")
+    const votedGovActionDetailsPage = await govActionsPage.viewFirstVotedProposal();
+    await votedGovActionDetailsPage.currentPage.getByTestId("show-more-button").click();
+    await votedGovActionDetailsPage.currentPage.waitForTimeout(2000);
     
+    const voteRationaleContext = await votedGovActionDetailsPage.currentPage.getByTestId("vote-rationale-context");
     await expect(voteRationaleContext).toContainText(fakerContext);
+  };
 
+  test("4J. Should include metadata anchor in the vote transaction (Download and store yourself)", async ({}, testInfo) => {
+    await verifyVoteWithMetadata(testInfo, false);
+  });
+
+  test("4k. Should include metadata anchor in the vote transaction (GovTool pins data to IPFS)", async ({}, testInfo) => {
+    await verifyVoteWithMetadata(testInfo, true);
   });
 });
 

--- a/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/4-proposal-visibility/proposalVisibility.dRep.spec.ts
@@ -123,15 +123,25 @@ test.describe("Temporary DReps", async () => {
     await govActionsPage.goto();
 
     const govActionDetailsPage = await govActionsPage.viewFirstProposal();
-    await govActionDetailsPage.vote(faker.lorem.sentence(200));
 
-    await dRepPage.waitForTimeout(5_000);
+    const fakerContext = faker.lorem.sentence(200)
+    await govActionDetailsPage.vote(fakerContext);
+
+    await dRepPage.reload();1
+    await dRepPage.waitForTimeout(5_000);1
 
     await govActionsPage.votedTab.click();
-    await govActionsPage.viewFirstVotedProposal();
+    
+    const votedGovActionDetailsPage =  await govActionsPage.viewFirstVotedProposal();
 
-    //  Vote context is not displayed in UI to validate
-    expect(false, "No vote context displayed").toBe(true);
+    await votedGovActionDetailsPage.currentPage.getByTestId("show-more-button").click()
+
+    await votedGovActionDetailsPage.currentPage.waitForTimeout(2000)
+
+    const voteRationaleContext = await votedGovActionDetailsPage.currentPage.getByTestId("vote-rationale-context")
+    
+    await expect(voteRationaleContext).toContainText(fakerContext);
+
   });
 });
 

--- a/tests/govtool-frontend/playwright/tests/dRep.setup.ts
+++ b/tests/govtool-frontend/playwright/tests/dRep.setup.ts
@@ -75,9 +75,6 @@ setup("Register DRep of static wallets", async () => {
 
 setup("Setup temporary DRep wallets", async () => {
 
-  Logger.info("KUBER API KEY")
-  Logger.info(process.env.KUBER_API_KEY)
-
   const totalRequiredBalanceForDRepSetup =
     (DREP_WALLETS_COUNT + REGISTER_DREP_WALLETS_COUNT) *
     (dRepDeposit / 1000000 + 22);

--- a/tests/govtool-frontend/playwright/tests/dRep.setup.ts
+++ b/tests/govtool-frontend/playwright/tests/dRep.setup.ts
@@ -12,9 +12,10 @@ import kuberService from "@services/kuberService";
 import walletManager from "lib/walletManager";
 import { functionWaitedAssert } from "@helpers/waitedLoop";
 import { StaticWallet } from "@types";
+import { Logger } from "@helpers/logger";
 
 const REGISTER_DREP_WALLETS_COUNT = 6;
-const DREP_WALLETS_COUNT = 10;
+const DREP_WALLETS_COUNT = 11;
 
 let dRepDeposit: number;
 
@@ -73,6 +74,10 @@ setup("Register DRep of static wallets", async () => {
 });
 
 setup("Setup temporary DRep wallets", async () => {
+
+  Logger.info("KUBER API KEY")
+  Logger.info(process.env.KUBER_API_KEY)
+
   const totalRequiredBalanceForDRepSetup =
     (DREP_WALLETS_COUNT + REGISTER_DREP_WALLETS_COUNT) *
     (dRepDeposit / 1000000 + 22);


### PR DESCRIPTION
## List of changes

- Fixed broken and outdated tests affected by the new live voting flow changes.
- Updated and restored functionality for the following tests: 5A, 5F, 5E, 5L, 5C, 5D_1, 5D_2.
- Resolved an unrelated failure in test 3A:
     - The GovTools budget popup contained the keyword InfoAction, which was also used in the test to verify if the page had loaded.
     - This caused a false positive/negative match, leading the test to fail. Updated the check to avoid this conflict.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
