### PR TITLE
Even more DRep search improvements #4030

### DIFF
--- a/govtool/backend/app/Main.hs
+++ b/govtool/backend/app/Main.hs
@@ -115,6 +115,7 @@ startApp vvaConfig sentryService = do
           $ setOnException (exceptionHandler vvaConfig sentryService) defaultSettings
   cacheEnv <- do
     let newCache = Cache.newCache (Just $ TimeSpec (fromIntegral (cacheDurationSeconds vvaConfig)) 0)
+    let newDRepListCache = Cache.newCache (Just $ TimeSpec (fromIntegral (dRepListCacheDurationSeconds vvaConfig)) 0)
     proposalListCache <- newCache
     getProposalCache <- newCache
     currentEpochCache <- newCache
@@ -123,7 +124,7 @@ startApp vvaConfig sentryService = do
     dRepGetVotesCache <- newCache
     dRepInfoCache <- newCache
     dRepVotingPowerCache <- newCache
-    dRepListCache <- newCache
+    dRepListCache <- newDRepListCache
     networkMetricsCache <- newCache
     networkInfoCache <- newCache
     networkTotalStakeCache <- newCache

--- a/govtool/backend/example-config.json
+++ b/govtool/backend/example-config.json
@@ -10,6 +10,7 @@
   "port" : 9999,
   "host" : "localhost",
   "cachedurationseconds": 20,
+  "dreplistcachedurationseconds": 600,
   "sentrydsn": "https://username:password@senty.host/id",
   "sentryenv": "dev"
 }

--- a/govtool/backend/src/VVA/Config.hs
+++ b/govtool/backend/src/VVA/Config.hs
@@ -68,19 +68,21 @@ instance DefaultConfig DBConfig where
 data VVAConfigInternal
   = VVAConfigInternal
       { -- | db-sync database access.
-        vVAConfigInternalDbsyncconfig         :: DBConfig
+        vVAConfigInternalDbsyncconfig                 :: DBConfig
         -- | Server port.
-      , vVAConfigInternalPort                 :: Int
+      , vVAConfigInternalPort                         :: Int
         -- | Server host.
-      , vVAConfigInternalHost                 :: Text
+      , vVAConfigInternalHost                         :: Text
         -- | Request cache duration
-      , vVaConfigInternalCacheDurationSeconds :: Int
+      , vVaConfigInternalCacheDurationSeconds         :: Int
+        -- | DRep List request cache duration
+      , vVaConfigInternalDRepListCacheDurationSeconds :: Int
         -- | Sentry DSN
-      , vVAConfigInternalSentrydsn            :: String
+      , vVAConfigInternalSentrydsn                    :: String
         -- | Sentry environment
-      , vVAConfigInternalSentryEnv            :: String
+      , vVAConfigInternalSentryEnv                    :: String
         -- | Pinata API JWT
-      , vVAConfigInternalPinataApiJwt         :: Maybe Text
+      , vVAConfigInternalPinataApiJwt                 :: Maybe Text
       }
   deriving (FromConfig, Generic, Show)
 
@@ -92,6 +94,7 @@ instance DefaultConfig VVAConfigInternal where
         vVAConfigInternalPort = 3000,
         vVAConfigInternalHost = "localhost",
         vVaConfigInternalCacheDurationSeconds = 20,
+        vVaConfigInternalDRepListCacheDurationSeconds = 600,
         vVAConfigInternalSentrydsn = "https://username:password@senty.host/id",
         vVAConfigInternalSentryEnv = "development",
         vVAConfigInternalPinataApiJwt = Nothing
@@ -101,19 +104,21 @@ instance DefaultConfig VVAConfigInternal where
 data VVAConfig
   = VVAConfig
       { -- | db-sync database credentials.
-        dbSyncConnectionString :: Text
+        dbSyncConnectionString       :: Text
         -- | Server port.
-      , serverPort             :: Int
+      , serverPort                   :: Int
         -- | Server host.
-      , serverHost             :: Text
+      , serverHost                   :: Text
         -- | Request cache duration
-      , cacheDurationSeconds   :: Int
+      , cacheDurationSeconds         :: Int
+        -- | DRep List request cache duration
+      , dRepListCacheDurationSeconds :: Int
         -- | Sentry DSN
-      , sentryDSN              :: String
+      , sentryDSN                    :: String
         -- | Sentry environment
-      , sentryEnv              :: String
+      , sentryEnv                    :: String
         -- | Pinata API JWT
-      , pinataApiJwt           :: Maybe Text
+      , pinataApiJwt                 :: Maybe Text
       }
   deriving (Generic, Show, ToJSON)
 
@@ -153,6 +158,7 @@ convertConfig VVAConfigInternal {..} =
       serverPort = vVAConfigInternalPort,
       serverHost = vVAConfigInternalHost,
       cacheDurationSeconds = vVaConfigInternalCacheDurationSeconds,
+      dRepListCacheDurationSeconds = vVaConfigInternalDRepListCacheDurationSeconds,
       sentryDSN = vVAConfigInternalSentrydsn,
       sentryEnv = vVAConfigInternalSentryEnv,
       pinataApiJwt = vVAConfigInternalPinataApiJwt

--- a/govtool/frontend/src/components/molecules/PaginationFooter.tsx
+++ b/govtool/frontend/src/components/molecules/PaginationFooter.tsx
@@ -8,7 +8,8 @@ import {
 } from "@mui/material";
 import KeyboardArrowLeft from "@mui/icons-material/KeyboardArrowLeft";
 import KeyboardArrowRight from "@mui/icons-material/KeyboardArrowRight";
-import { FC } from "react";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import { FC, useState } from "react";
 
 type Props = {
   page: number;
@@ -46,6 +47,19 @@ export const PaginationFooter: FC<Props> = ({
     }
   };
 
+  const [open, setOpen] = useState(false);
+
+  const ArrowIcon: React.FC<React.ComponentProps<typeof ArrowDropDownIcon>> = (props,) => (
+    <ArrowDropDownIcon
+      {...props}
+      onMouseDown={(e: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setOpen(true);
+      }}
+    />
+  );
+
   return (
     <Box
       sx={{
@@ -68,15 +82,22 @@ export const PaginationFooter: FC<Props> = ({
           onChange={handlePageSizeChange}
           variant="standard"
           disableUnderline
+          open={open}
+          onOpen={() => setOpen(true)}
+          onClose={() => setOpen(false)}
+          IconComponent={ArrowIcon}
           sx={{
             verticalAlign: "baseline",
             "& .MuiSelect-select": {
               py: 0,
+              pr: "8px !important",
               lineHeight: 1.5,
               display: "inline-flex",
               alignItems: "center",
             },
             "& .MuiSelect-icon": {
+              pointerEvents: "auto",
+              cursor: "pointer",
               top: "calc(50% - 12px)",
             },
           }}


### PR DESCRIPTION
## List of changes

- Add new configuration property in backend "dreplistcachedurationseconds" - set by default to 600 (10 minutes).
- Use new cache duration property value for drepList.
- Change padding-right from 24px to 8px on page size value in pagination.
- Change select arrow icon to be clickable and open select the same way clicking on the page size value does.

## Checklist

- [DRep search improvements #4030](https://github.com/IntersectMBO/govtool/issues/4030)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
