### PR TITLE
Fix : Update Random Option to Activity Option in DRep List Related Tests

### DIFF
--- a/tests/govtool-frontend/playwright/lib/helpers/dRep.ts
+++ b/tests/govtool-frontend/playwright/lib/helpers/dRep.ts
@@ -17,8 +17,9 @@ export async function fetchFirstActiveDRepDetails(page: Page) {
   let dRepGivenName: string;
   let dRepId: string;
   let dRepDirectoryPage: DRepDirectoryPage;
+  let routePath = "**/drep/list?page=0&pageSize=5&sort=Activity&**";
   await page.route(
-    "**/drep/list?page=0&pageSize=10&sort=Random&**",
+    routePath,
     async (route) => {
       const response = await route.fetch();
       const json = await response.json();
@@ -40,7 +41,7 @@ export async function fetchFirstActiveDRepDetails(page: Page) {
   );
 
   const responsePromise = page.waitForResponse(
-    "**/drep/list?page=0&pageSize=10&sort=Random&**"
+    routePath
   );
 
   await functionWaitedAssert(

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
@@ -13,7 +13,7 @@ test.beforeEach(async () => {
 });
 
 enum SortOption {
-  Random = "Random",
+  Activity = "Activity",
   RegistrationDate = "RegistrationDate",
   VotingPower = "VotingPower",
   Status = "Status",
@@ -51,7 +51,8 @@ test("2K_2. Should sort DReps", async ({ page }) => {
   );
 });
 
-test("2K_3. Should sort DReps randomly", async ({ page }) => {
+test("2K_3. Should sort DReps randomly (Deprecated)", async ({ page }) => {
+  test.skip()
   const dRepDirectory = new DRepDirectoryPage(page);
   await dRepDirectory.goto();
 
@@ -60,13 +61,13 @@ test("2K_3. Should sort DReps randomly", async ({ page }) => {
   await page.getByTestId(`${SortOption.RegistrationDate}-radio`).click();
 
   const dRepList1: IDRep[] = await dRepDirectory.getDRepsResponseFromApi(
-    SortOption.Random
+    SortOption.Activity
   );
 
   await page.getByTestId(`${SortOption.RegistrationDate}-radio`).click();
 
   const dRepList2: IDRep[] = await dRepDirectory.getDRepsResponseFromApi(
-    SortOption.Random
+    SortOption.Activity
   );
 
   // Extract dRepIds from both lists
@@ -82,11 +83,12 @@ test("2K_3. Should sort DReps randomly", async ({ page }) => {
   expect(isOrderDifferent).toBe(true);
 });
 
-test("2O. Should load more DReps on show more", async ({ page }) => {
+test("2O. Should load more DReps on show more (Deprecated)", async ({ page }) => {
+  test.skip();
   const responsePromise = page.waitForResponse((response) =>
     response
       .url()
-      .includes(`drep/list?page=1&pageSize=10&sort=${SortOption.Random}`)
+      .includes(`drep/list?page=1&pageSize=10&sort=${SortOption.Activity}`)
   );
   const dRepDirectory = new DRepDirectoryPage(page);
   await dRepDirectory.goto();


### PR DESCRIPTION
## List of changes

- Updated Random option to Activity option and tests where it was being used.
- Marked skip to some now deprecated random sort dependent tests.

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
