### PR TITLE
fix drep vote calculation for proposal display tests

### DIFF
--- a/tests/govtool-frontend/playwright/lib/pages/outcomeDetailsPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/outcomeDetailsPage.ts
@@ -94,7 +94,7 @@ export default class OutcomeDetailsPage {
     isLoggedIn = false
   ) {
     await Promise.all(
-      Object.keys(outcomeType).map(async (filterKey) => {
+      Object.entries(outcomeType).map(async ([filterKey, filterValue]) => {
         const outcomePage = new OutComesPage(this.page);
         const {
           govActionDetailsPage,
@@ -106,6 +106,7 @@ export default class OutcomeDetailsPage {
           isLoggedIn
         );
 
+        
         if (!govActionDetailsPage) {
           return;
         }
@@ -119,6 +120,11 @@ export default class OutcomeDetailsPage {
           await govActionDetailsPage.getSposAndDRepAbstainNoConfidence(
             metricsResponse
           );
+
+        const metricsResponseJson = await metricsResponse.json();
+        const totalStakeControlledByNoConfidence = Number(metricsResponseJson.always_no_confidence_voting_power)
+        const dRepYesVotes = filterValue === outcomeType.NoConfidence ? Number(proposalToCheck.yes_votes) + totalStakeControlledByNoConfidence : Number(proposalToCheck.yes_votes);
+        const dRepNoVotes = filterValue != outcomeType.NoConfidence ? Number(proposalToCheck.no_votes) + totalStakeControlledByNoConfidence : Number(proposalToCheck.no_votes) ;
 
         const currentPageUrl = govActionDetailsPage.currentPage.url();
 
@@ -134,7 +140,7 @@ export default class OutcomeDetailsPage {
               message: `DRep "Yes" voting power checked for ${currentPageUrl}`,
             }
           ).toHaveText(
-            `Yes${formatWithThousandSeparator(proposalToCheck.yes_votes, false)}`,
+            `Yes${formatWithThousandSeparator(dRepYesVotes, false)}`,
             {
               timeout: 60_000,
             }
@@ -177,7 +183,7 @@ export default class OutcomeDetailsPage {
               message: `DRep "No" voting power checked for ${currentPageUrl}`,
             }
           ).toHaveText(
-            `No${formatWithThousandSeparator(proposalToCheck.no_votes, false)}`
+            `No${formatWithThousandSeparator(dRepNoVotes, false)}`
           ); //BUG missing testIds
         }
 


### PR DESCRIPTION
## List of changes

- Fixed DRep's Vote calculation logic in Outcome details Page.

Test Cases now Fixed from this change
-  9G_1. Should display correct vote counts on outcome details page in disconnect state
-  9G_2. Should display correct vote counts on outcome details page

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
