### PR TITLE
Fix SQL counting the number of active CC members

### DIFF
--- a/govtool/backend/sql/get-network-metrics.sql
+++ b/govtool/backend/sql/get-network-metrics.sql
@@ -23,20 +23,12 @@ CurrentEpoch AS (
 ),
 CommitteeMembers AS (
     SELECT DISTINCT ON (cm.committee_hash_id)
-        cr.id,
-        block.time,
-        encode(cold_key_hash.raw, 'hex') cold_key,
-        encode(hot_key_hash.raw, 'hex') hot_key
-    FROM committee_registration cr
-    JOIN tx ON tx.id = cr.tx_id
-    JOIN block ON block.id = tx.block_id
-    JOIN committee_hash cold_key_hash ON cr.cold_key_id = cold_key_hash.id
-    JOIN committee_hash hot_key_hash ON cr.hot_key_id = hot_key_hash.id
-    JOIN committee_member cm ON cm.committee_hash_id = cold_key_hash.id OR cm.committee_hash_id = hot_key_hash.id
-    LEFT JOIN committee_de_registration cdr ON cdr.cold_key_id = cold_key_hash.id
+        cm.id,
+        cm.expiration_epoch
+    FROM committee_member cm
     CROSS JOIN CurrentEpoch
     WHERE
-        cdr.id IS NULL AND cm.expiration_epoch > CurrentEpoch.no 
+        cm.expiration_epoch >= CurrentEpoch.no
 ),
 NoOfCommitteeMembers AS (
 	SELECT COUNT(*) total FROM CommitteeMembers


### PR DESCRIPTION
## List of changes

- Fix SQL counting the number of active CC members

## Checklist

- [🐛 Live Voting: Number of CC members displayed inconsistently across governance actions](https://github.com/IntersectMBO/govtool/issues/4059)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
