### PR TITLE
Fix workflow interpolation safety

### DIFF
--- a/.github/workflows/label-bug-report.yml
+++ b/.github/workflows/label-bug-report.yml
@@ -14,9 +14,11 @@ jobs:
     steps:
       - name: Check if issue is a "🐛 Bug report"
         id: check_is_bug_report
+        env:
+          issue_title: "${{ github.event.issue.title }}"
         run: |
           echo "## Checking if issue is a 'Feature idea'..."
-          if [[ "${{ github.event.issue.title }}" == "🐛 "* ]]; then
+          if [[ "$issue_title" == "🐛 "* ]]; then
             echo "is_bug_report=true" >> $GITHUB_ENV
           else
             echo "is_bug_report=false" >> $GITHUB_ENV

--- a/.github/workflows/label-feature-issue.yml
+++ b/.github/workflows/label-feature-issue.yml
@@ -14,9 +14,11 @@ jobs:
     steps:
       - name: Check if issue is a "💡 Feature idea"
         id: check_is_feature_idea
+        env:
+          issue_title: "${{ github.event.issue.title }}"
         run: |
           echo "## Checking if issue is a 'Feature idea'..."
-          if [[ "${{ github.event.issue.title }}" == "💡 "* ]]; then
+          if [[ "$issue_title" == "💡 "* ]]; then
             echo "is_feature_idea=true" >> $GITHUB_ENV
           else
             echo "is_feature_idea=false" >> $GITHUB_ENV

--- a/.github/workflows/update-govtool-version.yml
+++ b/.github/workflows/update-govtool-version.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   update-version:
     runs-on: ubuntu-latest
+    env:
+      VERSION: "${{ github.event.inputs.version }}"
 
     steps:
       - name: Checkout Repository
@@ -23,9 +25,6 @@ jobs:
           registry-url: "https://registry.npmjs.org/"
           node-version-file: "./govtool/frontend/.nvmrc"
           scope: "@intersect.mbo"
-
-      - name: Set Version Variable
-        run: echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
 
       - name: Update package.json files and install dependencies
         run: |
@@ -55,7 +54,7 @@ jobs:
       - name: Update CHANGELOG.md
         run: |
           #!/bin/bash
-          VERSION="${{ github.event.inputs.version }}"
+          VERSION="$VERSION"
           TODAY=$(date +%Y-%m-%d)
           RELEASE_TAG="v$VERSION"
           RELEASE_LINK="[v$VERSION](https://github.com/IntersectMBO/govtool/releases/tag/$RELEASE_TAG)"


### PR DESCRIPTION
## Summary
- Move issue title interpolation into env variables before shell comparisons.
- Use job-level env for VERSION in update workflow to avoid unsafe interpolation.

## Notes
- This mitigates untrusted input injection in GitHub Actions bash steps.
- No tests run (workflow change only).

Fixes #4146