### PR TITLE
fix(metadata-validation): block private fetch targets

### DIFF
--- a/govtool/metadata-validation/src/app.service.test.ts
+++ b/govtool/metadata-validation/src/app.service.test.ts
@@ -2,15 +2,19 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { HttpService } from '@nestjs/axios';
 import { of, throwError } from 'rxjs';
 import * as blake from 'blakejs';
+import { lookup } from 'node:dns/promises';
 
 import { AppService } from './app.service';
 import { ValidateMetadataDTO } from '@dto';
 import { MetadataValidationStatus } from '@enums';
 import { MetadataStandard } from '@types';
-import { validateMetadataStandard, parseMetadata } from '@utils';
+import { validateMetadataStandard, parseMetadata, getStandard } from '@utils';
 import { AxiosResponse, AxiosRequestHeaders } from 'axios';
 
 jest.mock('@utils');
+jest.mock('node:dns/promises', () => ({
+  lookup: jest.fn(),
+}));
 
 describe('AppService', () => {
   let service: AppService;
@@ -31,19 +35,20 @@ describe('AppService', () => {
 
     service = module.get<AppService>(AppService);
     httpService = module.get<HttpService>(HttpService);
+    (lookup as jest.Mock).mockResolvedValue([{ address: '93.184.216.34' }]);
   });
 
   it('should validate metadata correctly', async () => {
     const url = 'http://example.com';
     const hash = 'correctHash';
     const validateMetadataDTO: ValidateMetadataDTO = { hash, url };
-    const data = {
+    const body = {
       body: 'testBody',
       headers: {},
     };
     const parsedMetadata = { parsed: 'metadata' };
     const response: AxiosResponse = {
-      data,
+      data: JSON.stringify(body),
       status: 200,
       statusText: 'OK',
       headers: {},
@@ -53,6 +58,7 @@ describe('AppService', () => {
       },
     };
     jest.spyOn(httpService, 'get').mockReturnValueOnce(of(response));
+    (getStandard as jest.Mock).mockReturnValueOnce(MetadataStandard.CIP108);
     (validateMetadataStandard as jest.Mock).mockResolvedValueOnce(undefined);
     (parseMetadata as jest.Mock).mockReturnValueOnce(parsedMetadata);
     jest.spyOn(blake, 'blake2bHex').mockReturnValueOnce(hash);
@@ -65,12 +71,16 @@ describe('AppService', () => {
       metadata: parsedMetadata,
     });
     expect(validateMetadataStandard).toHaveBeenCalledWith(
-      data,
+      body.body,
       MetadataStandard.CIP108,
     );
-    expect(parseMetadata).toHaveBeenCalledWith(
-      data.body,
-      MetadataStandard.CIP108,
+    expect(parseMetadata).toHaveBeenCalledWith(body.body);
+    expect(httpService.get).toHaveBeenCalledWith(
+      url,
+      expect.objectContaining({
+        httpAgent: expect.any(Object),
+        httpsAgent: expect.any(Object),
+      }),
     );
   });
 
@@ -98,13 +108,13 @@ describe('AppService', () => {
     const url = 'http://example.com';
     const hash = 'incorrectHash';
     const validateMetadataDTO: ValidateMetadataDTO = { hash, url };
-    const data = {
+    const body = {
       body: 'testBody',
     };
     const parsedMetadata = { parsed: 'metadata' };
 
     const response: AxiosResponse = {
-      data,
+      data: JSON.stringify(body),
       status: 200,
       statusText: 'OK',
       headers: {},
@@ -114,6 +124,7 @@ describe('AppService', () => {
       },
     };
     jest.spyOn(httpService, 'get').mockReturnValueOnce(of(response));
+    (getStandard as jest.Mock).mockReturnValueOnce(MetadataStandard.CIP108);
     (validateMetadataStandard as jest.Mock).mockResolvedValueOnce(undefined);
     (parseMetadata as jest.Mock).mockReturnValueOnce(parsedMetadata);
     jest.spyOn(blake, 'blake2bHex').mockReturnValueOnce('differentHash');
@@ -125,5 +136,83 @@ describe('AppService', () => {
       valid: false,
       metadata: parsedMetadata,
     });
+  });
+
+  it('should block loopback metadata URLs before fetching', async () => {
+    const validateMetadataDTO: ValidateMetadataDTO = {
+      hash: 'hash',
+      url: 'http://127.0.0.1:3000/api',
+    };
+
+    const result = await service.validateMetadata(validateMetadataDTO);
+
+    expect(result).toEqual({
+      status: MetadataValidationStatus.URL_BLOCKED,
+      valid: false,
+      metadata: undefined,
+    });
+    expect(httpService.get).not.toHaveBeenCalled();
+  });
+
+  it('should block hostnames that resolve to private addresses', async () => {
+    (lookup as jest.Mock).mockResolvedValueOnce([{ address: '10.0.0.5' }]);
+
+    const validateMetadataDTO: ValidateMetadataDTO = {
+      hash: 'hash',
+      url: 'https://metadata.internal.example/metadata.json',
+    };
+
+    const result = await service.validateMetadata(validateMetadataDTO);
+
+    expect(result).toEqual({
+      status: MetadataValidationStatus.URL_BLOCKED,
+      valid: false,
+      metadata: undefined,
+    });
+    expect(httpService.get).not.toHaveBeenCalled();
+  });
+
+  it('should block private addresses during the HTTP agent lookup', async () => {
+    const url = 'http://example.com';
+    const hash = 'correctHash';
+    const body = {
+      body: 'testBody',
+    };
+    const response: AxiosResponse = {
+      data: JSON.stringify(body),
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {
+        headers: {} as AxiosRequestHeaders,
+        url,
+      },
+    };
+    jest.spyOn(httpService, 'get').mockReturnValueOnce(of(response));
+    (getStandard as jest.Mock).mockReturnValueOnce(MetadataStandard.CIP108);
+    (validateMetadataStandard as jest.Mock).mockResolvedValueOnce(undefined);
+    jest.spyOn(blake, 'blake2bHex').mockReturnValueOnce(hash);
+
+    await service.validateMetadata({ hash, url });
+
+    const requestConfig = (httpService.get as jest.Mock).mock.calls[0][1];
+    const agentLookup = requestConfig.httpAgent.options.lookup;
+    (lookup as jest.Mock).mockResolvedValueOnce({
+      address: '127.0.0.1',
+      family: 4,
+    });
+
+    await expect(
+      new Promise((resolve, reject) => {
+        agentLookup('example.com', {}, (error: Error | null) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve(undefined);
+        });
+      }),
+    ).rejects.toThrow(MetadataValidationStatus.URL_BLOCKED);
   });
 });

--- a/govtool/metadata-validation/src/app.service.ts
+++ b/govtool/metadata-validation/src/app.service.ts
@@ -2,6 +2,10 @@ import { Injectable, Logger } from '@nestjs/common';
 import { catchError, finalize, firstValueFrom } from 'rxjs';
 import { HttpService } from '@nestjs/axios';
 import * as blake from 'blakejs';
+import { lookup } from 'node:dns/promises';
+import { isIP, LookupFunction } from 'node:net';
+import { Agent as HttpAgent } from 'node:http';
+import { Agent as HttpsAgent } from 'node:https';
 
 import { ValidateMetadataDTO } from '@dto';
 import { LoggerMessage, MetadataValidationStatus } from '@enums';
@@ -11,6 +15,129 @@ import { /* MetadataStandard, */ ValidateMetadataResult } from '@types';
 @Injectable()
 export class AppService {
   constructor(private readonly httpService: HttpService) {}
+
+  private readonly safeHttpAgent = new HttpAgent({
+    lookup: this.createSafeLookup(),
+  });
+
+  private readonly safeHttpsAgent = new HttpsAgent({
+    lookup: this.createSafeLookup(),
+  });
+
+  private isBlockedIPv4(address: string): boolean {
+    const parts = address.split('.').map(Number);
+    const [first, second] = parts;
+
+    return (
+      first === 0 ||
+      first === 10 ||
+      first === 127 ||
+      (first === 100 && second >= 64 && second <= 127) ||
+      (first === 169 && second === 254) ||
+      (first === 172 && second >= 16 && second <= 31) ||
+      (first === 192 && second === 0 && parts[2] === 0) ||
+      (first === 192 && second === 168) ||
+      (first === 198 && (second === 18 || second === 19)) ||
+      first >= 224
+    );
+  }
+
+  private isBlockedIPv6(address: string): boolean {
+    const normalized = address.toLowerCase();
+    const ipv4MappedPrefix = '::ffff:';
+
+    if (normalized.startsWith(ipv4MappedPrefix)) {
+      const mappedAddress = normalized.slice(ipv4MappedPrefix.length);
+      if (isIP(mappedAddress) === 4) {
+        return this.isBlockedIPv4(mappedAddress);
+      }
+    }
+
+    return (
+      normalized === '::' ||
+      normalized === '::1' ||
+      normalized.startsWith('fc') ||
+      normalized.startsWith('fd') ||
+      normalized.startsWith('fe80:') ||
+      normalized.startsWith('::ffff:0:')
+    );
+  }
+
+  private isBlockedAddress(address: string): boolean {
+    const version = isIP(address);
+
+    if (version === 4) {
+      return this.isBlockedIPv4(address);
+    }
+
+    if (version === 6) {
+      return this.isBlockedIPv6(address);
+    }
+
+    return false;
+  }
+
+  private async assertAllowedMetadataUrl(url: string): Promise<void> {
+    let parsedUrl: URL;
+
+    try {
+      parsedUrl = new URL(url);
+    } catch (error) {
+      throw MetadataValidationStatus.URL_NOT_FOUND;
+    }
+
+    if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+      throw MetadataValidationStatus.URL_BLOCKED;
+    }
+
+    const hostname = parsedUrl.hostname.toLowerCase();
+    if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
+      throw MetadataValidationStatus.URL_BLOCKED;
+    }
+
+    if (this.isBlockedAddress(hostname)) {
+      throw MetadataValidationStatus.URL_BLOCKED;
+    }
+
+    let resolvedAddresses: { address: string }[];
+    try {
+      resolvedAddresses = await lookup(hostname, { all: true, verbatim: true });
+    } catch (error) {
+      throw MetadataValidationStatus.URL_NOT_FOUND;
+    }
+
+    if (
+      resolvedAddresses.some(({ address }) => this.isBlockedAddress(address))
+    ) {
+      throw MetadataValidationStatus.URL_BLOCKED;
+    }
+  }
+
+  private createSafeLookup(): LookupFunction {
+    return (hostname, options, callback) => {
+      lookup(hostname, options)
+        .then((result) => {
+          const addresses = Array.isArray(result) ? result : [result];
+
+          if (
+            addresses.some(({ address }) => this.isBlockedAddress(address))
+          ) {
+            callback(new Error(MetadataValidationStatus.URL_BLOCKED), '', 0);
+            return;
+          }
+
+          if (Array.isArray(result)) {
+            callback(null, result);
+            return;
+          }
+
+          callback(null, result.address, result.family);
+        })
+        .catch((error) => {
+          callback(error as Error, '', 0);
+        });
+    };
+  }
 
   async validateMetadata({
     hash,
@@ -27,9 +154,13 @@ export class AppService {
     }
 
     try {
+      await this.assertAllowedMetadataUrl(url);
+
       const { data: rawData } = await firstValueFrom(
         this.httpService
           .get(url, {
+            httpAgent: this.safeHttpAgent,
+            httpsAgent: this.safeHttpsAgent,
             headers: {
               // Required to not being blocked by APIs that require a User-Agent
               'User-Agent': 'GovTool/Metadata-Validation-Tool',

--- a/govtool/metadata-validation/src/enums/ValidationError.ts
+++ b/govtool/metadata-validation/src/enums/ValidationError.ts
@@ -1,4 +1,5 @@
 export enum MetadataValidationStatus {
+  URL_BLOCKED = 'URL_BLOCKED',
   URL_NOT_FOUND = 'URL_NOT_FOUND',
   INVALID_JSONLD = 'INVALID_JSONLD',
   INVALID_HASH = 'INVALID_HASH',


### PR DESCRIPTION
## Summary

This patch adds outbound URL validation before `metadata-validation` fetches a submitted metadata URL.

It blocks:

- unsupported protocols
- `localhost` / `.localhost`
- loopback, private, link-local, carrier-grade NAT, benchmark, multicast, and reserved IPv4 ranges
- IPv6 loopback, unspecified, unique-local, link-local, and IPv4-mapped private addresses
- hostnames that resolve to blocked addresses
- private addresses that appear during the actual HTTP/HTTPS agent lookup

The goal is to prevent the metadata validator from being used as an SSRF proxy for internal or local network targets.

## Related issue

Partially fixes https://github.com/IntersectMBO/govtool/issues/4142

## Verification

- `npm test -- --runInBand` (7/7 tests)
- `npm run build`
- `git diff --check`

I also tried a no-fix ESLint command, but the current project dependency is ESLint 10 while the project still uses `.eslintrc.js`; ESLint exits before checking files because it expects `eslint.config.*`.

## Notes

No production probing was performed. The new regression tests mock DNS resolution and verify that blocked targets are rejected before `HttpService.get` is called and again inside the actual request agent lookup.