### PR TITLE
temp increase title length limit

### DIFF
--- a/govtool/metadata-validation/src/utils/validateCIP108body.ts
+++ b/govtool/metadata-validation/src/utils/validateCIP108body.ts
@@ -17,7 +17,7 @@ export const validateCIP108body = (body: Record<string, unknown>) => {
   if (!title || !abstract || !motivation || !rationale) {
     throw MetadataValidationStatus.INCORRECT_FORMAT;
   }
-  if (String(title).length > 80 || String(abstract).length > 3000) {
+  if (String(title).length > 84 || String(abstract).length > 3000) {
     throw MetadataValidationStatus.INCORRECT_FORMAT;
   }
 


### PR DESCRIPTION
## List of changes

- Temp increase the gov action metadata title
- To stop error for https://gov.tools/governance_actions/3234567a3f48ace25efc150f1369192615974e232ea06e0251701831d9e4486d#0

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
