### PR TITLE
Increase CIP-108 title length limit to 84

### DIFF
--- a/govtool/metadata-validation/src/utils/validateCIP108body.ts
+++ b/govtool/metadata-validation/src/utils/validateCIP108body.ts
@@ -17,7 +17,7 @@ export const validateCIP108body = (body: Record<string, unknown>) => {
   if (!title || !abstract || !motivation || !rationale) {
     throw MetadataValidationStatus.INCORRECT_FORMAT;
   }
-  if (String(title).length > 80 || String(abstract).length > 3000) {
+  if (String(title).length > 84 || String(abstract).length > 3000) {
     throw MetadataValidationStatus.INCORRECT_FORMAT;
   }
 


### PR DESCRIPTION
## Summary

- increase the CIP-108 title length limit from 80 to 84 characters
- port the exact patch from #4180 to `develop`
- retain the original commit provenance via `cherry-pick -x`

## Why

PR #4180 was merged directly into `main`, while `develop` retained the previous 80-character limit. This keeps both branches aligned without merging unrelated `main` history into `develop`.

## Impact

CIP-108 metadata titles containing 81–84 characters are accepted by the metadata validation service.

## Validation

- `npm run build` — passed
- patch ID matches commit `16282f69293d77ff215f011189d4f148d65934ed`
- one commit, one file, one insertion and one deletion relative to `develop`
- `npm test -- --runInBand` — utility tests pass; two existing `app.service.test.ts` assertions fail identically on untouched `develop`

Original PR: #4180
