### PR TITLE
Fix/umami analytics header forwarding

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -58,6 +58,8 @@ services:
             UMAMI_URL: ${UMAMI_URL:-}
             UMAMI_WEBSITE_ID: ${UMAMI_WEBSITE_ID:-}
             UMAMI_SSL_VERIFY: ${UMAMI_SSL_VERIFY:-true}
+            TRUSTED_PROXY_CIDRS: ${TRUSTED_PROXY_CIDRS:-}
+            REAL_IP_HEADER: ${REAL_IP_HEADER:-X-Forwarded-For}
             VITE_PDF_API_URL: ${PDF_API_URL:-}
             VITE_OUTCOMES_API_URL: ${OUTCOMES_API_URL:-}
             VITE_IPFS_GATEWAY: ${IPFS_GATEWAY:-https://ipfs.io/ipfs}

--- a/govtool/frontend/docker-entrypoint.sh
+++ b/govtool/frontend/docker-entrypoint.sh
@@ -9,6 +9,31 @@ html_escape() {
   jq -Rnr --arg value "${1:-}" '$value | @html'
 }
 
+TRUSTED_PROXY_CIDRS_VALUE="${TRUSTED_PROXY_CIDRS:-}"
+REAL_IP_HEADER_VALUE="${REAL_IP_HEADER:-X-Forwarded-For}"
+REAL_IP_CONFIG=""
+
+if [ -n "$TRUSTED_PROXY_CIDRS_VALUE" ]; then
+  if ! printf '%s' "$REAL_IP_HEADER_VALUE" | grep -Eq '^[A-Za-z0-9-]+$'; then
+    echo "WARNING: Real IP resolution is disabled because REAL_IP_HEADER contains unsupported characters." >&2
+  else
+    SET_REAL_IP_FROM_DIRECTIVES=""
+    for TRUSTED_PROXY_CIDR in $(printf '%s' "$TRUSTED_PROXY_CIDRS_VALUE" | tr ',' ' '); do
+      if printf '%s' "$TRUSTED_PROXY_CIDR" | grep -Eq '^[0-9A-Fa-f:.]+(/[0-9]{1,3})?$'; then
+        SET_REAL_IP_FROM_DIRECTIVES="${SET_REAL_IP_FROM_DIRECTIVES}  set_real_ip_from ${TRUSTED_PROXY_CIDR};
+"
+      else
+        echo "WARNING: Ignoring TRUSTED_PROXY_CIDRS entry with unsupported characters: ${TRUSTED_PROXY_CIDR}" >&2
+      fi
+    done
+
+    if [ -n "$SET_REAL_IP_FROM_DIRECTIVES" ]; then
+      REAL_IP_CONFIG="${SET_REAL_IP_FROM_DIRECTIVES}  real_ip_header ${REAL_IP_HEADER_VALUE};
+  real_ip_recursive on;"
+    fi
+  fi
+fi
+
 UMAMI_URL_VALUE="${UMAMI_URL:-}"
 UMAMI_WEBSITE_ID_VALUE="${UMAMI_WEBSITE_ID:-}"
 UMAMI_SSL_VERIFY_VALUE="$(printf '%s' "${UMAMI_SSL_VERIFY:-true}" | tr '[:upper:]' '[:lower:]')"
@@ -142,10 +167,16 @@ mv /tmp/index.html /usr/share/nginx/html/index.html
 
 rm -f /usr/share/nginx/html/index.html.br /usr/share/nginx/html/index.html.gz
 
-awk -v umami_upstream="$UMAMI_UPSTREAM_CONFIG" -v umami_proxy="$UMAMI_PROXY_CONFIG" '
+awk -v umami_upstream="$UMAMI_UPSTREAM_CONFIG" -v umami_proxy="$UMAMI_PROXY_CONFIG" -v real_ip="$REAL_IP_CONFIG" '
   /# UMAMI_UPSTREAM_CONFIG/ {
     if (umami_upstream != "") {
       print umami_upstream
+    }
+    next
+  }
+  /# REAL_IP_CONFIG/ {
+    if (real_ip != "") {
+      print real_ip
     }
     next
   }

--- a/govtool/frontend/docker-entrypoint.sh
+++ b/govtool/frontend/docker-entrypoint.sh
@@ -13,6 +13,17 @@ TRUSTED_PROXY_CIDRS_VALUE="${TRUSTED_PROXY_CIDRS:-}"
 REAL_IP_HEADER_VALUE="${REAL_IP_HEADER:-X-Forwarded-For}"
 REAL_IP_CONFIG=""
 
+# Real IP resolution applies only to the Umami proxy location, so
+# $remote_addr stays the direct peer everywhere else. Unset means trust
+# the private ranges reverse proxies normally connect from; internet
+# clients cannot spoof these as a source address. Set
+# TRUSTED_PROXY_CIDRS=none to disable real IP resolution entirely.
+if [ -z "$TRUSTED_PROXY_CIDRS_VALUE" ]; then
+  TRUSTED_PROXY_CIDRS_VALUE="10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 fc00::/7"
+elif [ "$(printf '%s' "$TRUSTED_PROXY_CIDRS_VALUE" | tr '[:upper:]' '[:lower:]')" = "none" ]; then
+  TRUSTED_PROXY_CIDRS_VALUE=""
+fi
+
 if [ -n "$TRUSTED_PROXY_CIDRS_VALUE" ]; then
   if ! printf '%s' "$REAL_IP_HEADER_VALUE" | grep -Eq '^[A-Za-z0-9-]+$'; then
     echo "WARNING: Real IP resolution is disabled because REAL_IP_HEADER contains unsupported characters." >&2
@@ -20,7 +31,7 @@ if [ -n "$TRUSTED_PROXY_CIDRS_VALUE" ]; then
     SET_REAL_IP_FROM_DIRECTIVES=""
     for TRUSTED_PROXY_CIDR in $(printf '%s' "$TRUSTED_PROXY_CIDRS_VALUE" | tr ',' ' '); do
       if printf '%s' "$TRUSTED_PROXY_CIDR" | grep -Eq '^[0-9A-Fa-f:.]+(/[0-9]{1,3})?$'; then
-        SET_REAL_IP_FROM_DIRECTIVES="${SET_REAL_IP_FROM_DIRECTIVES}  set_real_ip_from ${TRUSTED_PROXY_CIDR};
+        SET_REAL_IP_FROM_DIRECTIVES="${SET_REAL_IP_FROM_DIRECTIVES}    set_real_ip_from ${TRUSTED_PROXY_CIDR};
 "
       else
         echo "WARNING: Ignoring TRUSTED_PROXY_CIDRS entry with unsupported characters: ${TRUSTED_PROXY_CIDR}" >&2
@@ -28,8 +39,8 @@ if [ -n "$TRUSTED_PROXY_CIDRS_VALUE" ]; then
     done
 
     if [ -n "$SET_REAL_IP_FROM_DIRECTIVES" ]; then
-      REAL_IP_CONFIG="${SET_REAL_IP_FROM_DIRECTIVES}  real_ip_header ${REAL_IP_HEADER_VALUE};
-  real_ip_recursive on;"
+      REAL_IP_CONFIG="${SET_REAL_IP_FROM_DIRECTIVES}    real_ip_header ${REAL_IP_HEADER_VALUE};
+    real_ip_recursive on;"
     fi
   fi
 fi
@@ -124,6 +135,7 @@ upstream umami_backend {
       esac
 
       UMAMI_PROXY_CONFIG="  location /x/ {
+${REAL_IP_CONFIG}
     proxy_pass ${UMAMI_SCHEME}://umami_backend${UMAMI_BASE_PATH}/;
     proxy_set_header Host ${UMAMI_AUTHORITY};
     proxy_set_header X-Real-IP \$remote_addr;
@@ -167,16 +179,10 @@ mv /tmp/index.html /usr/share/nginx/html/index.html
 
 rm -f /usr/share/nginx/html/index.html.br /usr/share/nginx/html/index.html.gz
 
-awk -v umami_upstream="$UMAMI_UPSTREAM_CONFIG" -v umami_proxy="$UMAMI_PROXY_CONFIG" -v real_ip="$REAL_IP_CONFIG" '
+awk -v umami_upstream="$UMAMI_UPSTREAM_CONFIG" -v umami_proxy="$UMAMI_PROXY_CONFIG" '
   /# UMAMI_UPSTREAM_CONFIG/ {
     if (umami_upstream != "") {
       print umami_upstream
-    }
-    next
-  }
-  /# REAL_IP_CONFIG/ {
-    if (real_ip != "") {
-      print real_ip
     }
     next
   }

--- a/govtool/frontend/nginx.conf
+++ b/govtool/frontend/nginx.conf
@@ -2,6 +2,7 @@
 
 server {
   listen 80;
+  # REAL_IP_CONFIG
   root /usr/share/nginx/html;
   error_page 503 @maintenance;
 

--- a/govtool/frontend/nginx.conf
+++ b/govtool/frontend/nginx.conf
@@ -1,8 +1,13 @@
 # UMAMI_UPSTREAM_CONFIG
 
+log_format proxied_combined '$remote_addr - $remote_user [$time_local] '
+                            '"$request" $status $body_bytes_sent '
+                            '"$http_referer" "$http_user_agent" '
+                            'xff="$http_x_forwarded_for"';
+
 server {
   listen 80;
-  # REAL_IP_CONFIG
+  access_log /var/log/nginx/access.log proxied_combined;
   root /usr/share/nginx/html;
   error_page 503 @maintenance;
 


### PR DESCRIPTION
## List of changes

- Improve handling of forwarded IP headers
- Log now show forward chain in addition to the client-ip

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
