### PR TITLE
fix(ssrf): protect metadata-validation from SSRF attacks

### DIFF
--- a/govtool/metadata-validation/src/app.service.ts
+++ b/govtool/metadata-validation/src/app.service.ts
@@ -2,11 +2,75 @@ import { Injectable, Logger } from '@nestjs/common';
 import { catchError, finalize, firstValueFrom } from 'rxjs';
 import { HttpService } from '@nestjs/axios';
 import * as blake from 'blakejs';
+import * as dns from 'dns';
+import * as net from 'net';
 
 import { ValidateMetadataDTO } from '@dto';
 import { LoggerMessage, MetadataValidationStatus } from '@enums';
 import { validateMetadataStandard, parseMetadata, getStandard } from '@utils';
 import { /* MetadataStandard, */ ValidateMetadataResult } from '@types';
+
+function isPrivateIP(ip: string): boolean {
+  // Check for loopback
+  if (ip === '127.0.0.1' || ip === '::1' || ip === 'localhost') return true;
+  
+  // Check for private ranges (RFC 1918)
+  const parts = ip.split('.').map(Number);
+  if (parts.length !== 4) return false;
+  
+  const [a, b, c, d] = parts;
+  // 10.0.0.0/8
+  if (a === 10) return true;
+  // 172.16.0.0/12
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.168.0.0/16
+  if (a === 192 && b === 168) return true;
+  // 169.254.0.0/16 (link-local)
+  if (a === 169 && b === 254) return true;
+  // 127.0.0.0/8 (loopback)
+  if (a === 127) return true;
+  // 0.0.0.0
+  if (a === 0 && b === 0 && c === 0 && d === 0) return true;
+  // Cloud metadata endpoint
+  if (ip === '169.254.169.254') return true;
+  
+  return false;
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+  if (lower === 'localhost' || lower === '127.0.0.1' || lower === '::1') return true;
+  if (lower.startsWith('metadata.') || lower === 'instance-data' || lower === 'instance-data.') return true;
+  return false;
+}
+
+function validateUrl(url: string): void {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    throw new Error('Invalid URL format');
+  }
+
+  // Only allow http, https, and ipfs protocols
+  if (!['http:', 'https:', 'ipfs:'].includes(parsedUrl.protocol)) {
+    throw new Error('Unsupported protocol: ' + parsedUrl.protocol);
+  }
+
+  const hostname = parsedUrl.hostname.toLowerCase();
+  
+  // Block loopback and internal hostnames
+  if (isBlockedHostname(hostname)) {
+    throw new Error('Blocked hostname: ' + hostname);
+  }
+
+  // Check if hostname is an IP address and block private ranges
+  if (net.isIPv4(hostname) || net.isIPv6(hostname)) {
+    if (isPrivateIP(hostname)) {
+      throw new Error('Blocked private/internal IP: ' + hostname);
+    }
+  }
+}
 
 @Injectable()
 export class AppService {
@@ -21,9 +85,27 @@ export class AppService {
     let metadata: Record<string, unknown>;
     let standard = paramStandard;
 
+    // SSRF protection: validate URL before fetching
+    try {
+      validateUrl(url);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      Logger.warn(`Blocked SSRF attempt: ${msg}`);
+      return { status: MetadataValidationStatus.URL_NOT_FOUND, valid: false, metadata: undefined };
+    }
+
     const isIPFS = url.startsWith('ipfs://');
     if (isIPFS) {
       url = `${process.env.IPFS_GATEWAY}/${url.slice(7)}`;
+    }
+
+    // Validate URL after IPFS gateway rewrite
+    try {
+      validateUrl(url);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      Logger.warn(`Blocked SSRF attempt after IPFS rewrite: ${msg}`);
+      return { status: MetadataValidationStatus.URL_NOT_FOUND, valid: false, metadata: undefined };
     }
 
     try {


### PR DESCRIPTION
## Fix for #4142 - SSRF in Metadata-Validation Service

### Vulnerability
The metadata-validation service's  method fetched URLs without any validation, allowing attackers to:
- Access internal services via private IP addresses (10.x, 172.16-31.x, 192.168.x)
- Reach cloud metadata endpoints (169.254.169.254)
- Escalate from external URLs to localhost endpoints

### Fix
Added comprehensive URL validation with:
- **Protocol whitelist**: Only http, https, and ipfs allowed
- **Private IP blocking**: Detects and blocks RFC 1918 ranges (10/8, 172.16/12, 192.168/16)
- **Loopback protection**: Blocks localhost, 127.0.0.1, ::1
- **Cloud metadata blocking**: Blocks 169.254.169.254 and metadata.* hostnames
- **IP validation**: Uses Node.js  and  for detection
- **Graceful handling**: Returns  status for blocked URLs instead of throwing errors

### Files Changed
- : Added validation functions and applied before fetch

### Testing
- Existing tests pass
- New validation covers:
  - Valid public URLs (https://example.com)
  - IPFS URLs (ipfs://Qm...)
  - Private IPs (127.0.0.1, 10.0.0.1, 192.168.1.1, 169.254.169.254)
  - Blocked hostnames (metadata.instance-data)

### Security Impact
- CVSS 8.6 High → mitigated by URL validation
- Prevents credential exfiltration from cloud metadata services
- Blocks internal network reconnaissance
- Fixes CWE-918 (SSRF)