### PR TITLE
fix(metadata-validation): complete SSRF protection

### DIFF
--- a/govtool/metadata-validation/package-lock.json
+++ b/govtool/metadata-validation/package-lock.json
@@ -20,6 +20,7 @@
         "blakejs": "^1.2.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "ipaddr.js": "^2.5.0",
         "joi": "18.2.1",
         "jsonld": "^9.0.0",
         "reflect-metadata": "^0.2.0",
@@ -5929,12 +5930,12 @@
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
+      "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10"
       }
     },
     "node_modules/is-arrayish": {
@@ -8147,6 +8148,15 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }

--- a/govtool/metadata-validation/package.json
+++ b/govtool/metadata-validation/package.json
@@ -31,6 +31,7 @@
     "blakejs": "^1.2.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "ipaddr.js": "^2.5.0",
     "joi": "18.2.1",
     "jsonld": "^9.0.0",
     "reflect-metadata": "^0.2.0",

--- a/govtool/metadata-validation/src/app.service.test.ts
+++ b/govtool/metadata-validation/src/app.service.test.ts
@@ -80,6 +80,8 @@ describe('AppService', () => {
       expect.objectContaining({
         httpAgent: expect.any(Object),
         httpsAgent: expect.any(Object),
+        maxRedirects: 0,
+        proxy: false,
       }),
     );
   });
@@ -154,6 +156,40 @@ describe('AppService', () => {
     expect(httpService.get).not.toHaveBeenCalled();
   });
 
+  it.each([
+    'http://[::]/metadata.json',
+    'http://[::1]/metadata.json',
+    'http://[fc00::1]/metadata.json',
+    'http://[fe90::1]/metadata.json',
+    'http://[febf::1]/metadata.json',
+    'http://[ff02::1]/metadata.json',
+    'http://[::ffff:7f00:1]/metadata.json',
+  ])('should block special-use IPv6 URL %s before fetching', async (url) => {
+    const result = await service.validateMetadata({ hash: 'hash', url });
+
+    expect(result).toEqual({
+      status: MetadataValidationStatus.URL_BLOCKED,
+      valid: false,
+      metadata: undefined,
+    });
+    expect(httpService.get).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'http://192.0.2.1/metadata.json',
+    'http://198.51.100.1/metadata.json',
+    'http://203.0.113.1/metadata.json',
+  ])('should block reserved IPv4 URL %s before fetching', async (url) => {
+    const result = await service.validateMetadata({ hash: 'hash', url });
+
+    expect(result).toEqual({
+      status: MetadataValidationStatus.URL_BLOCKED,
+      valid: false,
+      metadata: undefined,
+    });
+    expect(httpService.get).not.toHaveBeenCalled();
+  });
+
   it('should block hostnames that resolve to private addresses', async () => {
     (lookup as jest.Mock).mockResolvedValueOnce([{ address: '10.0.0.5' }]);
 
@@ -214,5 +250,26 @@ describe('AppService', () => {
         });
       }),
     ).rejects.toThrow(MetadataValidationStatus.URL_BLOCKED);
+  });
+
+  it('should preserve URL_BLOCKED from a connection-time lookup', async () => {
+    const blockedError = Object.assign(
+      new Error(MetadataValidationStatus.URL_BLOCKED),
+      { code: MetadataValidationStatus.URL_BLOCKED },
+    );
+    jest
+      .spyOn(httpService, 'get')
+      .mockReturnValueOnce(throwError(() => blockedError));
+
+    const result = await service.validateMetadata({
+      hash: 'hash',
+      url: 'http://example.com',
+    });
+
+    expect(result).toEqual({
+      status: MetadataValidationStatus.URL_BLOCKED,
+      valid: false,
+      metadata: undefined,
+    });
   });
 });

--- a/govtool/metadata-validation/src/app.service.ts
+++ b/govtool/metadata-validation/src/app.service.ts
@@ -3,78 +3,68 @@ import { catchError, finalize, firstValueFrom } from 'rxjs';
 import { HttpService } from '@nestjs/axios';
 import * as blake from 'blakejs';
 import { lookup } from 'node:dns/promises';
-import { isIP, LookupFunction } from 'node:net';
+import { LookupFunction } from 'node:net';
 import { Agent as HttpAgent } from 'node:http';
 import { Agent as HttpsAgent } from 'node:https';
+import * as ipaddr from 'ipaddr.js';
 
 import { ValidateMetadataDTO } from '@dto';
 import { LoggerMessage, MetadataValidationStatus } from '@enums';
 import { validateMetadataStandard, parseMetadata, getStandard } from '@utils';
 import { /* MetadataStandard, */ ValidateMetadataResult } from '@types';
 
+class UrlBlockedError extends Error {
+  readonly code = MetadataValidationStatus.URL_BLOCKED;
+
+  constructor() {
+    super(MetadataValidationStatus.URL_BLOCKED);
+    this.name = 'UrlBlockedError';
+  }
+}
+
 @Injectable()
 export class AppService {
   constructor(private readonly httpService: HttpService) {}
 
   private readonly safeHttpAgent = new HttpAgent({
+    keepAlive: true,
     lookup: this.createSafeLookup(),
   });
 
   private readonly safeHttpsAgent = new HttpsAgent({
+    keepAlive: true,
     lookup: this.createSafeLookup(),
   });
 
-  private isBlockedIPv4(address: string): boolean {
-    const parts = address.split('.').map(Number);
-    const [first, second] = parts;
-
-    return (
-      first === 0 ||
-      first === 10 ||
-      first === 127 ||
-      (first === 100 && second >= 64 && second <= 127) ||
-      (first === 169 && second === 254) ||
-      (first === 172 && second >= 16 && second <= 31) ||
-      (first === 192 && second === 0 && parts[2] === 0) ||
-      (first === 192 && second === 168) ||
-      (first === 198 && (second === 18 || second === 19)) ||
-      first >= 224
-    );
-  }
-
-  private isBlockedIPv6(address: string): boolean {
-    const normalized = address.toLowerCase();
-    const ipv4MappedPrefix = '::ffff:';
-
-    if (normalized.startsWith(ipv4MappedPrefix)) {
-      const mappedAddress = normalized.slice(ipv4MappedPrefix.length);
-      if (isIP(mappedAddress) === 4) {
-        return this.isBlockedIPv4(mappedAddress);
-      }
-    }
-
-    return (
-      normalized === '::' ||
-      normalized === '::1' ||
-      normalized.startsWith('fc') ||
-      normalized.startsWith('fd') ||
-      normalized.startsWith('fe80:') ||
-      normalized.startsWith('::ffff:0:')
-    );
+  private stripIPv6Brackets(hostname: string): string {
+    return hostname.startsWith('[') && hostname.endsWith(']')
+      ? hostname.slice(1, -1)
+      : hostname;
   }
 
   private isBlockedAddress(address: string): boolean {
-    const version = isIP(address);
-
-    if (version === 4) {
-      return this.isBlockedIPv4(address);
+    const normalized = this.stripIPv6Brackets(address);
+    if (!ipaddr.isValid(normalized)) {
+      return false;
     }
 
-    if (version === 6) {
-      return this.isBlockedIPv6(address);
+    return ipaddr.process(normalized).range() !== 'unicast';
+  }
+
+  private isUrlBlockedError(error: unknown): boolean {
+    if (!error || typeof error !== 'object') {
+      return false;
     }
 
-    return false;
+    const candidate = error as {
+      code?: unknown;
+      cause?: { code?: unknown };
+    };
+
+    return (
+      candidate.code === MetadataValidationStatus.URL_BLOCKED ||
+      candidate.cause?.code === MetadataValidationStatus.URL_BLOCKED
+    );
   }
 
   private async assertAllowedMetadataUrl(url: string): Promise<void> {
@@ -90,7 +80,7 @@ export class AppService {
       throw MetadataValidationStatus.URL_BLOCKED;
     }
 
-    const hostname = parsedUrl.hostname.toLowerCase();
+    const hostname = this.stripIPv6Brackets(parsedUrl.hostname.toLowerCase());
     if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
       throw MetadataValidationStatus.URL_BLOCKED;
     }
@@ -119,10 +109,8 @@ export class AppService {
         .then((result) => {
           const addresses = Array.isArray(result) ? result : [result];
 
-          if (
-            addresses.some(({ address }) => this.isBlockedAddress(address))
-          ) {
-            callback(new Error(MetadataValidationStatus.URL_BLOCKED), '', 0);
+          if (addresses.some(({ address }) => this.isBlockedAddress(address))) {
+            callback(new UrlBlockedError(), '', 0);
             return;
           }
 
@@ -155,12 +143,13 @@ export class AppService {
 
     try {
       await this.assertAllowedMetadataUrl(url);
-
       const { data: rawData } = await firstValueFrom(
         this.httpService
           .get(url, {
             httpAgent: this.safeHttpAgent,
             httpsAgent: this.safeHttpsAgent,
+            maxRedirects: 0,
+            proxy: false,
             headers: {
               // Required to not being blocked by APIs that require a User-Agent
               'User-Agent': 'GovTool/Metadata-Validation-Tool',
@@ -175,6 +164,10 @@ export class AppService {
             finalize(() => Logger.log(`Fetching ${url} completed`)),
             catchError((error) => {
               Logger.error(error, JSON.stringify(error));
+              if (this.isUrlBlockedError(error)) {
+                throw MetadataValidationStatus.URL_BLOCKED;
+              }
+
               throw MetadataValidationStatus.URL_NOT_FOUND;
             }),
           ),


### PR DESCRIPTION
## List of changes

- Disable automatic redirects and proxy routing for metadata requests
- Improve IPv4 and IPv6 validation using `ipaddr.js`
- Block IPv4-mapped IPv6 and special-use IP ranges
- Preserve connection-time DNS rebinding protection and `URL_BLOCKED` errors
- Add SSRF regression tests

## Checklist

- [[Related issue #4142](https://github.com/IntersectMBO/govtool/issues/4142)](https://github.com/IntersectMBO/govtool/issues/4142)
- [x] My changes generate no new warnings
- [x] My code follows the [[style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides)](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [[changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [X] I have added tests that prove my fix is effective or that my feature works